### PR TITLE
Fix app-breaking API/frontend mismatches and add polish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ JWT_SECRET=change-this-secret-in-production-must-be-at-least-256-bits-long-rando
 DB_URL=jdbc:postgresql://localhost:5432/healthupgrades
 DB_USERNAME=healthupgrades
 DB_PASSWORD=healthupgrades
+# Comma-separated origins allowed to call the API cross-origin. Only needed when the frontend is NOT
+# served through the Vite dev proxy or the nginx proxy (i.e. when it calls the API on another origin).
+CORS_ALLOWED_ORIGINS=http://localhost:3000
 
 # Frontend
-VITE_API_URL=http://localhost:8080
+# Optional. Leave empty to use the same-origin /api proxy (Vite in dev, nginx in prod) — recommended.
+# Set this only if the API is hosted on a different origin than the frontend.
+VITE_API_URL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: cd frontend && npm ci
 
       - name: Lint frontend
-        run: cd frontend && npm run lint || true
+        run: cd frontend && npm run lint
 
       - name: Build frontend
         run: cd frontend && npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ logs/
 
 # Docker
 .docker/
+
+# Local tooling config (project guide, skills, agents)
+.claude/

--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ npm run build
 | `POSTGRES_PASSWORD` | `healthupgrades` | PostgreSQL password |
 | `DB_URL` | `jdbc:postgresql://localhost:5432/healthupgrades` | Full JDBC URL |
 | `JWT_SECRET` | (default dev key) | JWT signing secret (change in production!) |
-| `VITE_API_URL` | `http://localhost:8080` | Backend API URL for frontend |
+| `CORS_ALLOWED_ORIGINS` | `http://localhost:3000` | Comma-separated origins allowed to call the API cross-origin (only needed when not using the dev/nginx `/api` proxy) |
+| `VITE_API_URL` | (empty) | Backend API URL for frontend. Leave empty to use the same-origin `/api` proxy (Vite in dev, nginx in prod) — recommended. Set only if the API is on another origin. |
 
 ## Future Improvements
 

--- a/backend/src/main/java/com/healthupgrades/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/healthupgrades/common/security/SecurityConfig.java
@@ -73,11 +73,23 @@ public class SecurityConfig {
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
+        List<String> origins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(Arrays.stream(allowedOrigins.split(",")).map(String::trim).toList());
+        if (origins.contains("*")) {
+            // Browsers reject a wildcard origin combined with credentials, so use origin patterns
+            // and disable credentials in that case (this API authenticates via a bearer token, not cookies).
+            config.setAllowedOriginPatterns(List.of("*"));
+            config.setAllowCredentials(false);
+        } else {
+            config.setAllowedOrigins(origins);
+            config.setAllowCredentials(true);
+        }
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
-        config.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);

--- a/backend/src/main/java/com/healthupgrades/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/healthupgrades/common/security/SecurityConfig.java
@@ -1,9 +1,9 @@
 package com.healthupgrades.common.security;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -16,6 +16,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -25,6 +31,9 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthFilter;
     private final UserDetailsServiceImpl userDetailsService;
 
+    @Value("${app.cors.allowed-origins:http://localhost:3000}")
+    private String allowedOrigins;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -32,6 +41,7 @@ public class SecurityConfig {
                 // CSRF attacks require browser-managed session cookies; JWT in Authorization header is not
                 // automatically sent by browsers, so CSRF protection is not applicable here.
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
@@ -59,5 +69,18 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(Arrays.stream(allowedOrigins.split(",")).map(String::trim).toList());
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/backend/src/main/java/com/healthupgrades/dashboard/api/DashboardDto.java
+++ b/backend/src/main/java/com/healthupgrades/dashboard/api/DashboardDto.java
@@ -1,19 +1,20 @@
 package com.healthupgrades.dashboard.api;
 
+import com.healthupgrades.upgrade.api.UpgradeDto;
+
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 public record DashboardDto(
-        int activeUpgrades,
-        int plannedUpgrades,
-        List<UpgradeSummary> todayUpgrades,
-        List<UpgradeSummary> overdueUpgrades,
+        List<UpgradeDto> activeUpgrades,
+        List<UpgradeDto> plannedUpgrades,
+        List<UpgradeDto> todayUpgrades,
+        List<UpgradeDto> overdueUpgrades,
         double weeklyCompletionRate,
         Map<UUID, Integer> streaks,
-        List<UpgradeSummary> recentlyCompleted,
+        List<UpgradeDto> recentlyCompleted,
         List<AreaSummary> areaSummary
 ) {
-    public record UpgradeSummary(UUID id, String title, String status) {}
-    public record AreaSummary(UUID areaId, String areaName, int upgradeCount, int activeCount) {}
+    public record AreaSummary(UUID areaId, String areaName, int totalUpgrades, int activeCount, int completedCount) {}
 }

--- a/backend/src/main/java/com/healthupgrades/dashboard/application/DashboardAggregationService.java
+++ b/backend/src/main/java/com/healthupgrades/dashboard/application/DashboardAggregationService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @Service
@@ -31,19 +32,16 @@ public class DashboardAggregationService {
     public DashboardDto buildDashboard(UUID userId) {
         List<HealthUpgrade> allUpgrades = upgradeRepository.findByUserId(userId);
 
-        List<UpgradeDto> activeUpgrades = mapByStatus(allUpgrades, UpgradeStatus.ACTIVE);
-        List<UpgradeDto> plannedUpgrades = mapByStatus(allUpgrades, UpgradeStatus.PLANNED);
+        // Map every upgrade to a DTO once (a single batched tracking-config query), then reuse the
+        // results across the different dashboard sections instead of re-mapping per section.
+        Map<UUID, UpgradeDto> dtoById = upgradeService.toDtos(allUpgrades).stream()
+                .collect(Collectors.toMap(UpgradeDto::id, dto -> dto));
 
         LocalDate today = LocalDate.now();
-        List<UpgradeDto> todayUpgrades = allUpgrades.stream()
-                .filter(u -> u.isActiveOn(today))
-                .map(upgradeService::toDto)
-                .toList();
-
-        List<UpgradeDto> overdueUpgrades = allUpgrades.stream()
-                .filter(HealthUpgrade::isOverdue)
-                .map(upgradeService::toDto)
-                .toList();
+        List<UpgradeDto> activeUpgrades = filterToDtos(allUpgrades, dtoById, u -> u.getStatus() == UpgradeStatus.ACTIVE);
+        List<UpgradeDto> plannedUpgrades = filterToDtos(allUpgrades, dtoById, u -> u.getStatus() == UpgradeStatus.PLANNED);
+        List<UpgradeDto> todayUpgrades = filterToDtos(allUpgrades, dtoById, u -> u.isActiveOn(today));
+        List<UpgradeDto> overdueUpgrades = filterToDtos(allUpgrades, dtoById, HealthUpgrade::isOverdue);
 
         double weeklyRate = calculateWeeklyCompletionRate(userId, today);
 
@@ -53,7 +51,7 @@ public class DashboardAggregationService {
                 .filter(u -> u.getStatus() == UpgradeStatus.COMPLETED)
                 .sorted(Comparator.comparing(HealthUpgrade::getUpdatedAt).reversed())
                 .limit(5)
-                .map(upgradeService::toDto)
+                .map(u -> dtoById.get(u.getId()))
                 .toList();
 
         List<HealthArea> areas = areaRepository.findByUserId(userId);
@@ -63,8 +61,9 @@ public class DashboardAggregationService {
                 weeklyRate, streaks, recentlyCompleted, areaSummary);
     }
 
-    private List<UpgradeDto> mapByStatus(List<HealthUpgrade> upgrades, UpgradeStatus status) {
-        return upgrades.stream().filter(u -> u.getStatus() == status).map(upgradeService::toDto).toList();
+    private List<UpgradeDto> filterToDtos(List<HealthUpgrade> upgrades, Map<UUID, UpgradeDto> dtoById,
+                                          Predicate<HealthUpgrade> predicate) {
+        return upgrades.stream().filter(predicate).map(u -> dtoById.get(u.getId())).toList();
     }
 
     private double calculateWeeklyCompletionRate(UUID userId, LocalDate today) {

--- a/backend/src/main/java/com/healthupgrades/dashboard/application/DashboardAggregationService.java
+++ b/backend/src/main/java/com/healthupgrades/dashboard/application/DashboardAggregationService.java
@@ -6,6 +6,8 @@ import com.healthupgrades.healtharea.infrastructure.HealthAreaRepository;
 import com.healthupgrades.tracking.domain.ProgressEntry;
 import com.healthupgrades.tracking.domain.StreakCalculator;
 import com.healthupgrades.tracking.infrastructure.ProgressEntryRepository;
+import com.healthupgrades.upgrade.api.UpgradeDto;
+import com.healthupgrades.upgrade.application.UpgradeService;
 import com.healthupgrades.upgrade.domain.HealthUpgrade;
 import com.healthupgrades.upgrade.domain.UpgradeStatus;
 import com.healthupgrades.upgrade.infrastructure.UpgradeRepository;
@@ -24,40 +26,45 @@ public class DashboardAggregationService {
     private final ProgressEntryRepository progressRepository;
     private final HealthAreaRepository areaRepository;
     private final StreakCalculator streakCalculator;
+    private final UpgradeService upgradeService;
 
     public DashboardDto buildDashboard(UUID userId) {
         List<HealthUpgrade> allUpgrades = upgradeRepository.findByUserId(userId);
 
-        int activeCount = (int) allUpgrades.stream().filter(u -> u.getStatus() == UpgradeStatus.ACTIVE).count();
-        int plannedCount = (int) allUpgrades.stream().filter(u -> u.getStatus() == UpgradeStatus.PLANNED).count();
+        List<UpgradeDto> activeUpgrades = mapByStatus(allUpgrades, UpgradeStatus.ACTIVE);
+        List<UpgradeDto> plannedUpgrades = mapByStatus(allUpgrades, UpgradeStatus.PLANNED);
 
         LocalDate today = LocalDate.now();
-        List<DashboardDto.UpgradeSummary> todaySummary = allUpgrades.stream()
+        List<UpgradeDto> todayUpgrades = allUpgrades.stream()
                 .filter(u -> u.isActiveOn(today))
-                .map(u -> new DashboardDto.UpgradeSummary(u.getId(), u.getTitle(), u.getStatus().name()))
+                .map(upgradeService::toDto)
                 .toList();
 
-        List<DashboardDto.UpgradeSummary> overdueSummary = allUpgrades.stream()
+        List<UpgradeDto> overdueUpgrades = allUpgrades.stream()
                 .filter(HealthUpgrade::isOverdue)
-                .map(u -> new DashboardDto.UpgradeSummary(u.getId(), u.getTitle(), u.getStatus().name()))
+                .map(upgradeService::toDto)
                 .toList();
 
         double weeklyRate = calculateWeeklyCompletionRate(userId, today);
 
         Map<UUID, Integer> streaks = calculateStreaks(userId, allUpgrades);
 
-        List<DashboardDto.UpgradeSummary> recentCompleted = allUpgrades.stream()
+        List<UpgradeDto> recentlyCompleted = allUpgrades.stream()
                 .filter(u -> u.getStatus() == UpgradeStatus.COMPLETED)
                 .sorted(Comparator.comparing(HealthUpgrade::getUpdatedAt).reversed())
                 .limit(5)
-                .map(u -> new DashboardDto.UpgradeSummary(u.getId(), u.getTitle(), u.getStatus().name()))
+                .map(upgradeService::toDto)
                 .toList();
 
         List<HealthArea> areas = areaRepository.findByUserId(userId);
         List<DashboardDto.AreaSummary> areaSummary = buildAreaSummary(areas, allUpgrades);
 
-        return new DashboardDto(activeCount, plannedCount, todaySummary, overdueSummary,
-                weeklyRate, streaks, recentCompleted, areaSummary);
+        return new DashboardDto(activeUpgrades, plannedUpgrades, todayUpgrades, overdueUpgrades,
+                weeklyRate, streaks, recentlyCompleted, areaSummary);
+    }
+
+    private List<UpgradeDto> mapByStatus(List<HealthUpgrade> upgrades, UpgradeStatus status) {
+        return upgrades.stream().filter(u -> u.getStatus() == status).map(upgradeService::toDto).toList();
     }
 
     private double calculateWeeklyCompletionRate(UUID userId, LocalDate today) {
@@ -89,7 +96,8 @@ public class DashboardAggregationService {
                     List<HealthUpgrade> areaUpgrades = byArea.getOrDefault(area.getId(), Collections.emptyList());
                     int total = areaUpgrades.size();
                     int active = (int) areaUpgrades.stream().filter(u -> u.getStatus() == UpgradeStatus.ACTIVE).count();
-                    return new DashboardDto.AreaSummary(area.getId(), area.getName(), total, active);
+                    int completed = (int) areaUpgrades.stream().filter(u -> u.getStatus() == UpgradeStatus.COMPLETED).count();
+                    return new DashboardDto.AreaSummary(area.getId(), area.getName(), total, active, completed);
                 })
                 .toList();
     }

--- a/backend/src/main/java/com/healthupgrades/reflection/api/ReflectionController.java
+++ b/backend/src/main/java/com/healthupgrades/reflection/api/ReflectionController.java
@@ -2,6 +2,7 @@ package com.healthupgrades.reflection.api;
 
 import com.healthupgrades.reflection.application.ReflectionService;
 import com.healthupgrades.user.domain.User;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +22,7 @@ public class ReflectionController {
     @PostMapping
     public ResponseEntity<ReflectionDto> create(@AuthenticationPrincipal User user,
                                                  @PathVariable UUID upgradeId,
-                                                 @RequestBody ReflectionRequest req) {
+                                                 @Valid @RequestBody ReflectionRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED).body(service.create(user.getId(), upgradeId, req));
     }
 

--- a/backend/src/main/java/com/healthupgrades/reflection/api/ReflectionRequest.java
+++ b/backend/src/main/java/com/healthupgrades/reflection/api/ReflectionRequest.java
@@ -1,11 +1,14 @@
 package com.healthupgrades.reflection.api;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
 import java.time.LocalDate;
 
 public record ReflectionRequest(
         LocalDate date,
-        Integer difficultyRating,
-        Integer benefitRating,
+        @Min(1) @Max(5) Integer difficultyRating,
+        @Min(1) @Max(5) Integer benefitRating,
         String whatWorked,
         String whatDidNotWork,
         String nextAdjustment

--- a/backend/src/main/java/com/healthupgrades/tracking/api/ProgressController.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/api/ProgressController.java
@@ -2,6 +2,7 @@ package com.healthupgrades.tracking.api;
 
 import com.healthupgrades.tracking.application.TrackingService;
 import com.healthupgrades.user.domain.User;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +22,7 @@ public class ProgressController {
     public ResponseEntity<ProgressDto> recordProgress(
             @AuthenticationPrincipal User user,
             @PathVariable UUID upgradeId,
-            @RequestBody ProgressRequest req) {
+            @Valid @RequestBody ProgressRequest req) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(trackingService.recordProgress(user.getId(), upgradeId, req));
     }
@@ -34,10 +35,10 @@ public class ProgressController {
     }
 
     @GetMapping("/api/upgrades/{upgradeId}/streak")
-    public ResponseEntity<Integer> getStreak(
+    public ResponseEntity<StreakDto> getStreak(
             @AuthenticationPrincipal User user,
             @PathVariable UUID upgradeId) {
-        return ResponseEntity.ok(trackingService.getCurrentStreak(user.getId(), upgradeId));
+        return ResponseEntity.ok(trackingService.getStreakSummary(user.getId(), upgradeId));
     }
 
     @GetMapping("/api/progress/today")

--- a/backend/src/main/java/com/healthupgrades/tracking/api/ProgressRequest.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/api/ProgressRequest.java
@@ -1,12 +1,16 @@
 package com.healthupgrades.tracking.api;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PositiveOrZero;
+
 import java.time.LocalDate;
 
 public record ProgressRequest(
         LocalDate date,
         Boolean completed,
-        Double numericValue,
+        @PositiveOrZero Double numericValue,
         String unit,
-        Integer rating,
+        @Min(1) @Max(5) Integer rating,
         String note
 ) {}

--- a/backend/src/main/java/com/healthupgrades/tracking/api/StreakDto.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/api/StreakDto.java
@@ -1,0 +1,3 @@
+package com.healthupgrades.tracking.api;
+
+public record StreakDto(int current, int longest) {}

--- a/backend/src/main/java/com/healthupgrades/tracking/application/TrackingService.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/application/TrackingService.java
@@ -7,9 +7,11 @@ import com.healthupgrades.common.exception.DuplicateProgressException;
 import com.healthupgrades.common.exception.ResourceNotFoundException;
 import com.healthupgrades.tracking.api.ProgressDto;
 import com.healthupgrades.tracking.api.ProgressRequest;
+import com.healthupgrades.tracking.api.StreakDto;
 import com.healthupgrades.tracking.api.TrackingConfigDto;
 import com.healthupgrades.tracking.api.TrackingConfigRequest;
 import com.healthupgrades.tracking.domain.ProgressEntry;
+import com.healthupgrades.tracking.domain.ProgressEvaluationService;
 import com.healthupgrades.tracking.domain.StreakCalculator;
 import com.healthupgrades.tracking.domain.TrackingConfig;
 import com.healthupgrades.tracking.infrastructure.ProgressEntryRepository;
@@ -32,6 +34,7 @@ public class TrackingService {
     private final ProgressEntryRepository progressRepository;
     private final UpgradeService upgradeService;
     private final StreakCalculator streakCalculator;
+    private final ProgressEvaluationService evaluationService;
     private final DomainEventPublisher eventPublisher;
 
     @Transactional
@@ -74,6 +77,15 @@ public class TrackingService {
                 .rating(req.rating())
                 .note(req.note())
                 .build();
+
+        // When a tracking config exists, the server decides whether the entry counts as "completed"
+        // by evaluating it against the configured target (e.g. numericValue >= target), instead of
+        // trusting the client. This keeps streaks and completion rates honest.
+        TrackingConfig config = configRepository.findByUpgradeId(upgradeId).orElse(null);
+        if (config != null) {
+            entry.setCompleted(evaluationService.isSuccessful(entry, config));
+        }
+
         entry = progressRepository.save(entry);
         eventPublisher.publish(new ProgressEntryRecorded(entry.getId(), upgradeId, userId, date, LocalDateTime.now()));
 
@@ -95,10 +107,12 @@ public class TrackingService {
         return progressRepository.findByUserIdAndDate(userId, LocalDate.now()).stream().map(this::toDto).toList();
     }
 
-    public int getCurrentStreak(UUID userId, UUID upgradeId) {
+    public StreakDto getStreakSummary(UUID userId, UUID upgradeId) {
         upgradeService.getUpgrade(userId, upgradeId);
         List<ProgressEntry> entries = progressRepository.findByUpgradeIdOrderByDateDesc(upgradeId);
-        return streakCalculator.calculateCurrentStreak(entries);
+        return new StreakDto(
+                streakCalculator.calculateCurrentStreak(entries),
+                streakCalculator.calculateLongestStreak(entries));
     }
 
     public List<ProgressDto> getWeekProgress(UUID userId) {

--- a/backend/src/main/java/com/healthupgrades/tracking/infrastructure/TrackingConfigRepository.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/infrastructure/TrackingConfigRepository.java
@@ -3,9 +3,13 @@ package com.healthupgrades.tracking.infrastructure;
 import com.healthupgrades.tracking.domain.TrackingConfig;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface TrackingConfigRepository extends JpaRepository<TrackingConfig, UUID> {
     Optional<TrackingConfig> findByUpgradeId(UUID upgradeId);
+
+    List<TrackingConfig> findByUpgradeIdIn(Collection<UUID> upgradeIds);
 }

--- a/backend/src/main/java/com/healthupgrades/upgrade/api/PlanRequest.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/api/PlanRequest.java
@@ -1,5 +1,7 @@
 package com.healthupgrades.upgrade.api;
 
+import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDate;
 
-public record PlanRequest(LocalDate plannedStartDate) {}
+public record PlanRequest(@NotNull LocalDate plannedStartDate) {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/api/RescheduleRequest.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/api/RescheduleRequest.java
@@ -1,5 +1,7 @@
 package com.healthupgrades.upgrade.api;
 
+import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDate;
 
-public record RescheduleRequest(LocalDate newDate) {}
+public record RescheduleRequest(@NotNull LocalDate newDate) {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/api/UpgradeController.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/api/UpgradeController.java
@@ -58,7 +58,7 @@ public class UpgradeController {
     @PostMapping("/{id}/plan")
     public ResponseEntity<UpgradeDto> plan(@AuthenticationPrincipal User user,
                                             @PathVariable UUID id,
-                                            @RequestBody PlanRequest req) {
+                                            @Valid @RequestBody PlanRequest req) {
         return ResponseEntity.ok(service.plan(user.getId(), id, req.plannedStartDate()));
     }
 
@@ -88,7 +88,7 @@ public class UpgradeController {
     @PostMapping("/{id}/reschedule")
     public ResponseEntity<UpgradeDto> reschedule(@AuthenticationPrincipal User user,
                                                   @PathVariable UUID id,
-                                                  @RequestBody RescheduleRequest req) {
+                                                  @Valid @RequestBody RescheduleRequest req) {
         return ResponseEntity.ok(service.reschedule(user.getId(), id, req.newDate()));
     }
 }

--- a/backend/src/main/java/com/healthupgrades/upgrade/api/UpgradeDto.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/api/UpgradeDto.java
@@ -1,5 +1,6 @@
 package com.healthupgrades.upgrade.api;
 
+import com.healthupgrades.tracking.api.TrackingConfigDto;
 import com.healthupgrades.upgrade.domain.Difficulty;
 import com.healthupgrades.upgrade.domain.UpgradeStatus;
 import com.healthupgrades.upgrade.domain.UpgradeType;
@@ -23,6 +24,8 @@ public record UpgradeDto(
         String motivation,
         String successCriteria,
         boolean overdue,
+        Long version,
+        TrackingConfigDto trackingConfig,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeService.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeService.java
@@ -2,6 +2,9 @@ package com.healthupgrades.upgrade.application;
 
 import com.healthupgrades.common.events.*;
 import com.healthupgrades.common.exception.ResourceNotFoundException;
+import com.healthupgrades.tracking.api.TrackingConfigDto;
+import com.healthupgrades.tracking.domain.TrackingConfig;
+import com.healthupgrades.tracking.infrastructure.TrackingConfigRepository;
 import com.healthupgrades.upgrade.api.UpgradeDto;
 import com.healthupgrades.upgrade.api.UpgradeRequest;
 import com.healthupgrades.upgrade.domain.*;
@@ -23,6 +26,7 @@ public class UpgradeService {
     private final UpgradeRepository repository;
     private final UpgradeSchedulingService schedulingService;
     private final DomainEventPublisher eventPublisher;
+    private final TrackingConfigRepository trackingConfigRepository;
 
     @Transactional
     public UpgradeDto create(UUID userId, UpgradeRequest req) {
@@ -143,10 +147,18 @@ public class UpgradeService {
     }
 
     public UpgradeDto toDto(HealthUpgrade u) {
+        TrackingConfigDto trackingConfig = trackingConfigRepository.findByUpgradeId(u.getId())
+                .map(UpgradeService::toTrackingConfigDto)
+                .orElse(null);
         return new UpgradeDto(u.getId(), u.getUserId(), u.getAreaId(), u.getTitle(),
                 u.getDescription(), u.getType(), u.getStatus(), u.getDifficulty(),
                 u.getPlannedStartDate(), u.getActualStartDate(), u.getTargetEndDate(),
-                u.getMotivation(), u.getSuccessCriteria(), u.isOverdue(),
-                u.getCreatedAt(), u.getUpdatedAt());
+                u.getMotivation(), u.getSuccessCriteria(), u.isOverdue(), u.getVersion(),
+                trackingConfig, u.getCreatedAt(), u.getUpdatedAt());
+    }
+
+    private static TrackingConfigDto toTrackingConfigDto(TrackingConfig c) {
+        return new TrackingConfigDto(c.getId(), c.getUpgradeId(), c.getTrackingType(),
+                c.getFrequency(), c.getTargetNumericValue(), c.getTargetUnit(), c.getRequiredDaily());
     }
 }

--- a/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeService.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeService.java
@@ -16,7 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
@@ -61,7 +63,7 @@ public class UpgradeService {
         } else {
             stream = repository.findByUserId(userId).stream();
         }
-        return stream.map(this::toDto).toList();
+        return toDtos(stream.toList());
     }
 
     public UpgradeDto findById(UUID userId, UUID id) {
@@ -150,6 +152,22 @@ public class UpgradeService {
         TrackingConfigDto trackingConfig = trackingConfigRepository.findByUpgradeId(u.getId())
                 .map(UpgradeService::toTrackingConfigDto)
                 .orElse(null);
+        return toDto(u, trackingConfig);
+    }
+
+    /**
+     * Batch variant of {@link #toDto(HealthUpgrade)}. Loads every upgrade's tracking config in a single
+     * query instead of one lookup per upgrade, avoiding the N+1 pattern on list/dashboard endpoints.
+     */
+    public List<UpgradeDto> toDtos(List<HealthUpgrade> upgrades) {
+        if (upgrades.isEmpty()) return List.of();
+        List<UUID> ids = upgrades.stream().map(HealthUpgrade::getId).toList();
+        Map<UUID, TrackingConfigDto> configsByUpgradeId = trackingConfigRepository.findByUpgradeIdIn(ids).stream()
+                .collect(Collectors.toMap(TrackingConfig::getUpgradeId, UpgradeService::toTrackingConfigDto));
+        return upgrades.stream().map(u -> toDto(u, configsByUpgradeId.get(u.getId()))).toList();
+    }
+
+    private UpgradeDto toDto(HealthUpgrade u, TrackingConfigDto trackingConfig) {
         return new UpgradeDto(u.getId(), u.getUserId(), u.getAreaId(), u.getTitle(),
                 u.getDescription(), u.getType(), u.getStatus(), u.getDifficulty(),
                 u.getPlannedStartDate(), u.getActualStartDate(), u.getTargetEndDate(),

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -21,6 +21,10 @@ app:
   jwt:
     secret: ${JWT_SECRET:a-very-long-default-secret-key-that-should-be-changed-in-production-at-least-256-bits}
     expiration: 86400000
+  cors:
+    # Comma-separated list of origins allowed to call the API directly (cross-origin).
+    # Not needed when the frontend is served behind the Vite dev proxy or nginx (same-origin /api).
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
 
 logging:
   level:

--- a/backend/src/main/resources/db/migration/V3__fix_demo_password.sql
+++ b/backend/src/main/resources/db/migration/V3__fix_demo_password.sql
@@ -1,0 +1,8 @@
+-- V3: Fix the demo user's password hash.
+-- The hash seeded in V2 was a placeholder that did not match "demo123", so the demo login failed.
+-- This is the correct BCrypt hash for "demo123". Applied as an UPDATE (not by editing V2) so Flyway
+-- checksums on already-migrated databases stay intact.
+UPDATE users
+SET password_hash = '$2a$10$jNbye8EhQ.PcgwIBRD.9LujAo51uufY4idX2Hm1mtkBThj2/o5I4e',
+    updated_at = now()
+WHERE email = 'demo@healthupgrades.com';

--- a/backend/src/test/java/com/healthupgrades/dashboard/application/DashboardAggregationServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/dashboard/application/DashboardAggregationServiceTest.java
@@ -1,0 +1,90 @@
+package com.healthupgrades.dashboard.application;
+
+import com.healthupgrades.dashboard.api.DashboardDto;
+import com.healthupgrades.healtharea.infrastructure.HealthAreaRepository;
+import com.healthupgrades.tracking.domain.ProgressEntry;
+import com.healthupgrades.tracking.domain.StreakCalculator;
+import com.healthupgrades.tracking.infrastructure.ProgressEntryRepository;
+import com.healthupgrades.upgrade.api.UpgradeDto;
+import com.healthupgrades.upgrade.application.UpgradeService;
+import com.healthupgrades.upgrade.domain.HealthUpgrade;
+import com.healthupgrades.upgrade.domain.UpgradeStatus;
+import com.healthupgrades.upgrade.infrastructure.UpgradeRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardAggregationServiceTest {
+
+    @Mock UpgradeRepository upgradeRepository;
+    @Mock ProgressEntryRepository progressRepository;
+    @Mock HealthAreaRepository areaRepository;
+    @Mock StreakCalculator streakCalculator;
+    @Mock UpgradeService upgradeService;
+
+    @InjectMocks DashboardAggregationService service;
+
+    private final UUID userId = UUID.randomUUID();
+
+    private HealthUpgrade upgrade(UpgradeStatus status) {
+        return HealthUpgrade.builder()
+                .id(UUID.randomUUID())
+                .userId(userId)
+                .status(status)
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    private ProgressEntry entry(boolean completed) {
+        return ProgressEntry.builder()
+                .id(UUID.randomUUID())
+                .upgradeId(UUID.randomUUID())
+                .userId(userId)
+                .date(LocalDate.now())
+                .completed(completed)
+                .build();
+    }
+
+    @Test
+    void buildDashboard_countsByStatus_andComputesWeeklyRate() {
+        List<HealthUpgrade> upgrades = List.of(
+                upgrade(UpgradeStatus.ACTIVE),
+                upgrade(UpgradeStatus.ACTIVE),
+                upgrade(UpgradeStatus.PLANNED),
+                upgrade(UpgradeStatus.COMPLETED));
+        when(upgradeRepository.findByUserId(userId)).thenReturn(upgrades);
+        when(upgradeService.toDto(any())).thenReturn(dummyDto());
+        // 2 of 4 weekly entries completed -> 50%
+        when(progressRepository.findByUserIdAndDateBetween(any(), any(), any()))
+                .thenReturn(List.of(entry(true), entry(true), entry(false), entry(false)));
+        when(progressRepository.findByUpgradeId(any())).thenReturn(List.of());
+        when(streakCalculator.calculateCurrentStreak(any())).thenReturn(4);
+        when(areaRepository.findByUserId(userId)).thenReturn(List.of());
+
+        DashboardDto dashboard = service.buildDashboard(userId);
+
+        assertThat(dashboard.activeUpgrades()).hasSize(2);
+        assertThat(dashboard.plannedUpgrades()).hasSize(1);
+        assertThat(dashboard.recentlyCompleted()).hasSize(1);
+        assertThat(dashboard.weeklyCompletionRate()).isEqualTo(50.0);
+        // streaks are computed only for ACTIVE upgrades
+        assertThat(dashboard.streaks()).hasSize(2);
+    }
+
+    private UpgradeDto dummyDto() {
+        return new UpgradeDto(UUID.randomUUID(), userId, null, "t", null, null, null, null,
+                null, null, null, null, null, false, 0L, null, LocalDateTime.now(), LocalDateTime.now());
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/dashboard/application/DashboardAggregationServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/dashboard/application/DashboardAggregationServiceTest.java
@@ -65,7 +65,10 @@ class DashboardAggregationServiceTest {
                 upgrade(UpgradeStatus.PLANNED),
                 upgrade(UpgradeStatus.COMPLETED));
         when(upgradeRepository.findByUserId(userId)).thenReturn(upgrades);
-        when(upgradeService.toDto(any())).thenReturn(dummyDto());
+        when(upgradeService.toDtos(any())).thenAnswer(inv -> {
+            List<HealthUpgrade> ups = inv.getArgument(0);
+            return ups.stream().map(u -> dtoFor(u.getId())).toList();
+        });
         // 2 of 4 weekly entries completed -> 50%
         when(progressRepository.findByUserIdAndDateBetween(any(), any(), any()))
                 .thenReturn(List.of(entry(true), entry(true), entry(false), entry(false)));
@@ -83,8 +86,8 @@ class DashboardAggregationServiceTest {
         assertThat(dashboard.streaks()).hasSize(2);
     }
 
-    private UpgradeDto dummyDto() {
-        return new UpgradeDto(UUID.randomUUID(), userId, null, "t", null, null, null, null,
+    private UpgradeDto dtoFor(UUID id) {
+        return new UpgradeDto(id, userId, null, "t", null, null, null, null,
                 null, null, null, null, null, false, 0L, null, LocalDateTime.now(), LocalDateTime.now());
     }
 }

--- a/backend/src/test/java/com/healthupgrades/tracking/application/TrackingServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/tracking/application/TrackingServiceTest.java
@@ -1,0 +1,78 @@
+package com.healthupgrades.tracking.application;
+
+import com.healthupgrades.common.events.DomainEventPublisher;
+import com.healthupgrades.common.exception.DuplicateProgressException;
+import com.healthupgrades.tracking.api.ProgressDto;
+import com.healthupgrades.tracking.api.ProgressRequest;
+import com.healthupgrades.tracking.domain.ProgressEntry;
+import com.healthupgrades.tracking.domain.ProgressEvaluationService;
+import com.healthupgrades.tracking.domain.StreakCalculator;
+import com.healthupgrades.tracking.domain.TrackingConfig;
+import com.healthupgrades.tracking.domain.TrackingType;
+import com.healthupgrades.tracking.infrastructure.ProgressEntryRepository;
+import com.healthupgrades.tracking.infrastructure.TrackingConfigRepository;
+import com.healthupgrades.upgrade.application.UpgradeService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TrackingServiceTest {
+
+    @Mock TrackingConfigRepository configRepository;
+    @Mock ProgressEntryRepository progressRepository;
+    @Mock UpgradeService upgradeService;
+    @Mock StreakCalculator streakCalculator;
+    @Mock ProgressEvaluationService evaluationService;
+    @Mock DomainEventPublisher eventPublisher;
+
+    @InjectMocks TrackingService service;
+
+    private final UUID userId = UUID.randomUUID();
+    private final UUID upgradeId = UUID.randomUUID();
+
+    @Test
+    void recordProgress_setsCompletedFromEvaluation_whenConfigExists() {
+        // The client did not supply `completed`; a NUMERIC config exists and the evaluator says "met".
+        ProgressRequest req = new ProgressRequest(LocalDate.now(), null, 2.5, "liters", null, null);
+        TrackingConfig config = TrackingConfig.builder()
+                .upgradeId(upgradeId).trackingType(TrackingType.NUMERIC).targetNumericValue(2.0).build();
+
+        when(progressRepository.existsByUpgradeIdAndDate(any(), any())).thenReturn(false);
+        when(configRepository.findByUpgradeId(upgradeId)).thenReturn(Optional.of(config));
+        when(evaluationService.isSuccessful(any(), any())).thenReturn(true);
+        when(progressRepository.save(any(ProgressEntry.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(progressRepository.findByUpgradeIdOrderByDateDesc(upgradeId)).thenReturn(List.of());
+        when(streakCalculator.calculateCurrentStreak(any())).thenReturn(3);
+
+        ProgressDto dto = service.recordProgress(userId, upgradeId, req);
+
+        assertThat(dto.completed()).isTrue();
+        verify(evaluationService).isSuccessful(any(), any());
+    }
+
+    @Test
+    void recordProgress_duplicateDate_throwsAndDoesNotSave() {
+        ProgressRequest req = new ProgressRequest(LocalDate.now(), true, null, null, null, null);
+        when(progressRepository.existsByUpgradeIdAndDate(any(), any())).thenReturn(true);
+
+        assertThatThrownBy(() -> service.recordProgress(userId, upgradeId, req))
+                .isInstanceOf(DuplicateProgressException.class);
+
+        verify(progressRepository, never()).save(any());
+    }
+}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,5 +1,5 @@
 import client from './client';
-import type { AuthResponse } from '../types';
+import type { AuthResponse, User } from '../types';
 
 export const loginApi = async (email: string, password: string): Promise<AuthResponse> => {
   const { data } = await client.post<AuthResponse>('/api/auth/login', { email, password });
@@ -8,5 +8,10 @@ export const loginApi = async (email: string, password: string): Promise<AuthRes
 
 export const registerApi = async (name: string, email: string, password: string): Promise<AuthResponse> => {
   const { data } = await client.post<AuthResponse>('/api/auth/register', { name, email, password });
+  return data;
+};
+
+export const getMe = async (): Promise<User> => {
+  const { data } = await client.get<User>('/api/auth/me');
   return data;
 };

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,7 +1,10 @@
 import axios from 'axios';
 
+// Default to a relative base URL so every `/api/...` call is same-origin and flows through the
+// Vite dev proxy (vite.config.ts) in development and the nginx proxy (nginx.conf) in production.
+// This avoids cross-origin/CORS issues. Set VITE_API_URL only when the API lives on another origin.
 const client = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8080',
+  baseURL: import.meta.env.VITE_API_URL || '',
 });
 
 client.interceptors.request.use((config) => {

--- a/frontend/src/api/progress.ts
+++ b/frontend/src/api/progress.ts
@@ -1,5 +1,5 @@
 import client from './client';
-import type { ProgressEntry, CreateProgressRequest } from '../types';
+import type { ProgressEntry, CreateProgressRequest, StreakSummary } from '../types';
 
 export const getProgressByUpgrade = async (upgradeId: string): Promise<ProgressEntry[]> => {
   const { data } = await client.get<ProgressEntry[]>(`/api/upgrades/${upgradeId}/progress`);
@@ -29,8 +29,8 @@ export const createProgress = async (req: CreateProgressRequest): Promise<Progre
   return data;
 };
 
-export const getStreak = async (upgradeId: string): Promise<number> => {
-  const { data } = await client.get<number>(`/api/upgrades/${upgradeId}/streak`);
+export const getStreak = async (upgradeId: string): Promise<StreakSummary> => {
+  const { data } = await client.get<StreakSummary>(`/api/upgrades/${upgradeId}/streak`);
   return data;
 };
 

--- a/frontend/src/api/reflections.ts
+++ b/frontend/src/api/reflections.ts
@@ -2,11 +2,14 @@ import client from './client';
 import type { Reflection, CreateReflectionRequest } from '../types';
 
 export const getReflectionsByUpgrade = async (upgradeId: string): Promise<Reflection[]> => {
-  const { data } = await client.get<Reflection[]>(`/api/reflections/upgrade/${upgradeId}`);
+  const { data } = await client.get<Reflection[]>(`/api/upgrades/${upgradeId}/reflections`);
   return data;
 };
 
-export const createReflection = async (req: CreateReflectionRequest): Promise<Reflection> => {
-  const { data } = await client.post<Reflection>('/api/reflections', req);
+export const createReflection = async (
+  upgradeId: string,
+  req: Omit<CreateReflectionRequest, 'upgradeId'>,
+): Promise<Reflection> => {
+  const { data } = await client.post<Reflection>(`/api/upgrades/${upgradeId}/reflections`, req);
   return data;
 };

--- a/frontend/src/api/trackingConfig.ts
+++ b/frontend/src/api/trackingConfig.ts
@@ -1,0 +1,23 @@
+import client from './client';
+import type { TrackingConfig, TrackingType, Frequency } from '../types';
+
+export interface SaveTrackingConfigRequest {
+  trackingType: TrackingType;
+  frequency?: Frequency;
+  targetNumericValue?: number;
+  targetUnit?: string;
+  requiredDaily?: boolean;
+}
+
+export const getTrackingConfig = async (upgradeId: string): Promise<TrackingConfig> => {
+  const { data } = await client.get<TrackingConfig>(`/api/upgrades/${upgradeId}/tracking-config`);
+  return data;
+};
+
+export const saveTrackingConfig = async (
+  upgradeId: string,
+  req: SaveTrackingConfigRequest,
+): Promise<TrackingConfig> => {
+  const { data } = await client.put<TrackingConfig>(`/api/upgrades/${upgradeId}/tracking-config`, req);
+  return data;
+};

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,18 +1,7 @@
-import React, { createContext, useState, useEffect, useCallback } from 'react';
-import { loginApi, registerApi } from '../api/auth';
+import React, { useState, useEffect, useCallback } from 'react';
+import { loginApi, registerApi, getMe } from '../api/auth';
+import { AuthContext } from './authContextValue';
 import type { User } from '../types';
-
-interface AuthContextType {
-  user: User | null;
-  token: string | null;
-  isLoading: boolean;
-  login: (email: string, password: string) => Promise<void>;
-  register: (name: string, email: string, password: string) => Promise<void>;
-  logout: () => void;
-  isAuthenticated: boolean;
-}
-
-export const AuthContext = createContext<AuthContextType | null>(null);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
@@ -22,15 +11,34 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   useEffect(() => {
     const storedToken = localStorage.getItem('jwt_token');
     const storedUser = localStorage.getItem('user');
-    if (storedToken && storedUser) {
-      setToken(storedToken);
+    if (!storedToken) {
+      setIsLoading(false);
+      return;
+    }
+
+    setToken(storedToken);
+    // Optimistically restore the cached user so the UI renders immediately...
+    if (storedUser) {
       try {
         setUser(JSON.parse(storedUser) as User);
       } catch {
         localStorage.removeItem('user');
       }
     }
-    setIsLoading(false);
+
+    // ...then validate the token against the backend. If it's expired/invalid, clear the session.
+    getMe()
+      .then((freshUser) => {
+        setUser(freshUser);
+        localStorage.setItem('user', JSON.stringify(freshUser));
+      })
+      .catch(() => {
+        localStorage.removeItem('jwt_token');
+        localStorage.removeItem('user');
+        setToken(null);
+        setUser(null);
+      })
+      .finally(() => setIsLoading(false));
   }, []);
 
   const login = useCallback(async (email: string, password: string) => {

--- a/frontend/src/contexts/authContextValue.ts
+++ b/frontend/src/contexts/authContextValue.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+import type { User } from '../types';
+
+export interface AuthContextType {
+  user: User | null;
+  token: string | null;
+  isLoading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (name: string, email: string, password: string) => Promise<void>;
+  logout: () => void;
+  isAuthenticated: boolean;
+}
+
+export const AuthContext = createContext<AuthContextType | null>(null);

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { AuthContext } from '../contexts/AuthContext';
+import { AuthContext } from '../contexts/authContextValue';
 
 export const useAuth = () => {
   const ctx = useContext(AuthContext);

--- a/frontend/src/pages/ActiveUpgradesPage.tsx
+++ b/frontend/src/pages/ActiveUpgradesPage.tsx
@@ -12,7 +12,7 @@ import type { UpgradeStatus } from '../types';
 const ActiveUpgradesPage: React.FC = () => {
   const qc = useQueryClient();
   const navigate = useNavigate();
-  const { data: upgrades = [], isLoading } = useQuery({ queryKey: ['upgrades', 'ACTIVE'], queryFn: () => getUpgrades('ACTIVE') });
+  const { data: upgrades = [], isLoading, error } = useQuery({ queryKey: ['upgrades', 'ACTIVE'], queryFn: () => getUpgrades('ACTIVE') });
 
   const statusMutation = useMutation({
     mutationFn: ({ id, status }: { id: string; status: UpgradeStatus }) => performUpgradeAction(id, status),
@@ -20,6 +20,7 @@ const ActiveUpgradesPage: React.FC = () => {
   });
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
+  if (error) return <p className="text-red-500 text-center py-10">Failed to load upgrades.</p>;
 
   return (
     <div className="max-w-4xl mx-auto">

--- a/frontend/src/pages/DailyCheckinPage.tsx
+++ b/frontend/src/pages/DailyCheckinPage.tsx
@@ -14,6 +14,12 @@ type ProgressMap = Record<string, Partial<CreateProgressRequest>>;
 
 const today = () => new Date().toISOString().split('T')[0];
 
+// Avoid sending NaN to the API when the numeric field is cleared.
+const numOrUndef = (v: string): number | undefined => {
+  const n = parseFloat(v);
+  return Number.isNaN(n) ? undefined : n;
+};
+
 const DailyCheckinPage: React.FC = () => {
   const qc = useQueryClient();
   const navigate = useNavigate();
@@ -91,7 +97,7 @@ const DailyCheckinPage: React.FC = () => {
                     className="rounded-lg border border-gray-300 px-3 py-2 text-sm w-28 focus:outline-none focus:ring-2 focus:ring-blue-500"
                     placeholder="0"
                     value={progressMap[u.id]?.numericValue ?? ''}
-                    onChange={(e) => updateProgress(u.id, { numericValue: parseFloat(e.target.value) })}
+                    onChange={(e) => updateProgress(u.id, { numericValue: numOrUndef(e.target.value) })}
                   />
                   <span className="text-sm text-gray-500">{u.trackingConfig?.targetUnit ?? ''}</span>
                 </div>

--- a/frontend/src/pages/HealthAreasPage.tsx
+++ b/frontend/src/pages/HealthAreasPage.tsx
@@ -18,7 +18,7 @@ const HealthAreasPage: React.FC = () => {
   const [form, setForm] = useState<CreateHealthAreaRequest>({ name: '', description: '', icon: '', color: '' });
   const [formError, setFormError] = useState('');
 
-  const { data: areas = [], isLoading } = useQuery({ queryKey: ['healthAreas'], queryFn: getHealthAreas });
+  const { data: areas = [], isLoading, error } = useQuery({ queryKey: ['healthAreas'], queryFn: getHealthAreas });
 
   const createMutation = useMutation({
     mutationFn: createHealthArea,
@@ -56,6 +56,7 @@ const HealthAreasPage: React.FC = () => {
   };
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
+  if (error) return <p className="text-red-500 text-center py-10">Failed to load health areas.</p>;
 
   return (
     <div className="max-w-4xl mx-auto">

--- a/frontend/src/pages/PlannedUpgradesPage.tsx
+++ b/frontend/src/pages/PlannedUpgradesPage.tsx
@@ -12,7 +12,7 @@ import type { UpgradeStatus } from '../types';
 const PlannedUpgradesPage: React.FC = () => {
   const qc = useQueryClient();
   const navigate = useNavigate();
-  const { data: upgrades = [], isLoading } = useQuery({ queryKey: ['upgrades', 'PLANNED'], queryFn: () => getUpgrades('PLANNED') });
+  const { data: upgrades = [], isLoading, error } = useQuery({ queryKey: ['upgrades', 'PLANNED'], queryFn: () => getUpgrades('PLANNED') });
 
   const statusMutation = useMutation({
     mutationFn: ({ id, status }: { id: string; status: UpgradeStatus }) => performUpgradeAction(id, status),
@@ -26,6 +26,7 @@ const PlannedUpgradesPage: React.FC = () => {
   });
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
+  if (error) return <p className="text-red-500 text-center py-10">Failed to load upgrades.</p>;
 
   return (
     <div className="max-w-4xl mx-auto">

--- a/frontend/src/pages/ProgressHistoryPage.tsx
+++ b/frontend/src/pages/ProgressHistoryPage.tsx
@@ -10,8 +10,8 @@ import Badge from '../components/ui/Badge';
 import type { ProgressEntry, HealthUpgrade } from '../types';
 
 const ProgressHistoryPage: React.FC = () => {
-  const { data: progress = [], isLoading: pLoading } = useQuery({ queryKey: ['allProgress'], queryFn: getWeekProgress });
-  const { data: upgrades = [], isLoading: uLoading } = useQuery({ queryKey: ['allUpgrades'], queryFn: () => getUpgrades() });
+  const { data: progress = [], isLoading: pLoading, error: pError } = useQuery({ queryKey: ['allProgress'], queryFn: getWeekProgress });
+  const { data: upgrades = [], isLoading: uLoading, error: uError } = useQuery({ queryKey: ['allUpgrades'], queryFn: () => getUpgrades() });
 
   const upgradeMap: Record<string, HealthUpgrade> = {};
   upgrades.forEach((u) => { upgradeMap[u.id] = u; });
@@ -19,6 +19,7 @@ const ProgressHistoryPage: React.FC = () => {
   const sorted = [...progress].sort((a: ProgressEntry, b: ProgressEntry) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   if (pLoading || uLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
+  if (pError || uError) return <p className="text-red-500 text-center py-10">Failed to load progress history.</p>;
 
   return (
     <div className="max-w-3xl mx-auto">

--- a/frontend/src/pages/UpgradeBacklogPage.tsx
+++ b/frontend/src/pages/UpgradeBacklogPage.tsx
@@ -35,7 +35,7 @@ const UpgradeBacklogPage: React.FC = () => {
   const [form, setForm] = useState<CreateUpgradeRequest>({ title: '', type: 'HABIT', difficulty: 'MEDIUM' });
   const [formError, setFormError] = useState('');
 
-  const { data: upgrades = [], isLoading } = useQuery({ queryKey: ['upgrades', 'IDEA'], queryFn: () => getUpgrades('IDEA') });
+  const { data: upgrades = [], isLoading, error } = useQuery({ queryKey: ['upgrades', 'IDEA'], queryFn: () => getUpgrades('IDEA') });
   const { data: areas = [] } = useQuery({ queryKey: ['healthAreas'], queryFn: getHealthAreas });
 
   const createMutation = useMutation({
@@ -62,6 +62,7 @@ const UpgradeBacklogPage: React.FC = () => {
   const areaOptions = [{ value: '', label: 'No area' }, ...areas.map((a) => ({ value: a.id, label: a.name }))];
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
+  if (error) return <p className="text-red-500 text-center py-10">Failed to load the backlog.</p>;
 
   return (
     <div className="max-w-4xl mx-auto">

--- a/frontend/src/pages/UpgradeDetailsPage.tsx
+++ b/frontend/src/pages/UpgradeDetailsPage.tsx
@@ -4,15 +4,17 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getUpgradeById } from '../api/upgrades';
 import { getProgressByUpgrade, createProgress, getStreak } from '../api/progress';
 import { getReflectionsByUpgrade, createReflection } from '../api/reflections';
+import { saveTrackingConfig, type SaveTrackingConfigRequest } from '../api/trackingConfig';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
+import Select from '../components/ui/Select';
 import Modal from '../components/ui/Modal';
 import UpgradeStatusBadge from '../components/upgrade/UpgradeStatusBadge';
 import UpgradeTypeBadge from '../components/upgrade/UpgradeTypeBadge';
 import Badge from '../components/ui/Badge';
-import type { CreateProgressRequest, CreateReflectionRequest } from '../types';
+import type { CreateProgressRequest, CreateReflectionRequest, TrackingType, Frequency } from '../types';
 
 const today = () => new Date().toISOString().split('T')[0];
 
@@ -23,6 +25,13 @@ const UpgradeDetailsPage: React.FC = () => {
 
   const [progressOpen, setProgressOpen] = useState(false);
   const [reflectionOpen, setReflectionOpen] = useState(false);
+  const [trackingOpen, setTrackingOpen] = useState(false);
+
+  const [trackingForm, setTrackingForm] = useState<SaveTrackingConfigRequest>({
+    trackingType: 'BOOLEAN',
+    frequency: 'DAILY',
+    requiredDaily: true,
+  });
 
   const [progressForm, setProgressForm] = useState<CreateProgressRequest>({
     upgradeId: id ?? '',
@@ -40,10 +49,10 @@ const UpgradeDetailsPage: React.FC = () => {
     benefitRating: 3,
   });
 
-  const { data: upgrade, isLoading } = useQuery({ queryKey: ['upgrade', id], queryFn: () => getUpgradeById(id!), enabled: !!id });
+  const { data: upgrade, isLoading, error } = useQuery({ queryKey: ['upgrade', id], queryFn: () => getUpgradeById(id!), enabled: !!id });
   const { data: progress = [] } = useQuery({ queryKey: ['progress', id], queryFn: () => getProgressByUpgrade(id!), enabled: !!id });
   const { data: reflections = [] } = useQuery({ queryKey: ['reflections', id], queryFn: () => getReflectionsByUpgrade(id!), enabled: !!id });
-  const { data: streak = 0 } = useQuery({ queryKey: ['streak', id], queryFn: () => getStreak(id!), enabled: !!id });
+  const { data: streak = { current: 0, longest: 0 } } = useQuery({ queryKey: ['streak', id], queryFn: () => getStreak(id!), enabled: !!id });
 
   const progressMutation = useMutation({
     mutationFn: createProgress,
@@ -51,11 +60,17 @@ const UpgradeDetailsPage: React.FC = () => {
   });
 
   const reflectionMutation = useMutation({
-    mutationFn: createReflection,
+    mutationFn: (body: Omit<CreateReflectionRequest, 'upgradeId'>) => createReflection(id!, body),
     onSuccess: () => { qc.invalidateQueries({ queryKey: ['reflections', id] }); setReflectionOpen(false); },
   });
 
-  if (isLoading || !upgrade) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
+  const trackingMutation = useMutation({
+    mutationFn: (req: SaveTrackingConfigRequest) => saveTrackingConfig(id!, req),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['upgrade', id] }); setTrackingOpen(false); },
+  });
+
+  if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
+  if (error || !upgrade) return <p className="text-red-500 text-center py-10">Failed to load this upgrade.</p>;
 
   return (
     <div className="max-w-3xl mx-auto space-y-6">
@@ -88,27 +103,45 @@ const UpgradeDetailsPage: React.FC = () => {
         </div>
       </Card>
 
-      {streak > 0 && (
+      {streak.current > 0 && (
         <div className="bg-orange-50 border border-orange-200 rounded-xl p-4 flex items-center gap-3">
           <span className="text-3xl">🔥</span>
           <div>
-            <p className="font-semibold text-orange-700">{streak}-day streak!</p>
-            <p className="text-sm text-orange-500">Keep it up!</p>
+            <p className="font-semibold text-orange-700">{streak.current}-day streak!</p>
+            <p className="text-sm text-orange-500">Longest streak: {streak.longest} day{streak.longest === 1 ? '' : 's'}. Keep it up!</p>
           </div>
         </div>
       )}
 
-      {upgrade.trackingConfig && (
-        <Card header="Tracking Configuration">
+      <Card header={
+        <div className="flex items-center justify-between">
+          <span>Tracking Configuration</span>
+          <Button size="sm" variant="secondary" onClick={() => {
+            setTrackingForm({
+              trackingType: upgrade.trackingConfig?.trackingType ?? 'BOOLEAN',
+              frequency: upgrade.trackingConfig?.frequency ?? 'DAILY',
+              targetNumericValue: upgrade.trackingConfig?.targetNumericValue,
+              targetUnit: upgrade.trackingConfig?.targetUnit,
+              requiredDaily: upgrade.trackingConfig?.requiredDaily ?? true,
+            });
+            setTrackingOpen(true);
+          }}>
+            {upgrade.trackingConfig ? 'Edit' : 'Configure'}
+          </Button>
+        </div>
+      }>
+        {upgrade.trackingConfig ? (
           <div className="grid grid-cols-2 gap-3 text-sm">
             <div><span className="text-gray-500">Type:</span> <span className="font-medium">{upgrade.trackingConfig.trackingType}</span></div>
             <div><span className="text-gray-500">Frequency:</span> <span className="font-medium">{upgrade.trackingConfig.frequency}</span></div>
-            {upgrade.trackingConfig.targetNumericValue && (
+            {upgrade.trackingConfig.targetNumericValue != null && (
               <div><span className="text-gray-500">Target:</span> <span className="font-medium">{upgrade.trackingConfig.targetNumericValue} {upgrade.trackingConfig.targetUnit}</span></div>
             )}
           </div>
-        </Card>
-      )}
+        ) : (
+          <p className="text-gray-500 text-sm text-center py-4">No tracking configured yet. Configure how you'll track this upgrade.</p>
+        )}
+      </Card>
 
       <Card header={
         <div className="flex items-center justify-between">
@@ -192,7 +225,7 @@ const UpgradeDetailsPage: React.FC = () => {
       </Modal>
 
       <Modal isOpen={reflectionOpen} onClose={() => setReflectionOpen(false)} title="Add Reflection">
-        <form onSubmit={(e) => { e.preventDefault(); reflectionMutation.mutate({ ...reflectionForm, upgradeId: id! }); }} className="space-y-4">
+        <form onSubmit={(e) => { e.preventDefault(); reflectionMutation.mutate(reflectionForm); }} className="space-y-4">
           <Input label="Date" type="date" value={reflectionForm.date} onChange={(e) => setReflectionForm({ ...reflectionForm, date: e.target.value })} />
           <div>
             <label className="text-sm font-medium text-gray-700">What worked?</label>
@@ -213,6 +246,62 @@ const UpgradeDetailsPage: React.FC = () => {
           <div className="flex gap-2 justify-end">
             <Button variant="secondary" type="button" onClick={() => setReflectionOpen(false)}>Cancel</Button>
             <Button type="submit" loading={reflectionMutation.isPending}>Save</Button>
+          </div>
+        </form>
+      </Modal>
+
+      <Modal isOpen={trackingOpen} onClose={() => setTrackingOpen(false)} title="Configure Tracking">
+        <form onSubmit={(e) => { e.preventDefault(); trackingMutation.mutate(trackingForm); }} className="space-y-4">
+          <Select
+            label="Tracking type"
+            value={trackingForm.trackingType}
+            onChange={(e) => setTrackingForm({ ...trackingForm, trackingType: e.target.value as TrackingType })}
+            options={[
+              { value: 'BOOLEAN', label: 'Yes / No (did it)' },
+              { value: 'NUMERIC', label: 'Numeric (amount vs target)' },
+              { value: 'RATING', label: 'Rating (1-5)' },
+              { value: 'TEXT', label: 'Text note' },
+            ]}
+          />
+          <Select
+            label="Frequency"
+            value={trackingForm.frequency ?? 'DAILY'}
+            onChange={(e) => setTrackingForm({ ...trackingForm, frequency: e.target.value as Frequency })}
+            options={[
+              { value: 'DAILY', label: 'Daily' },
+              { value: 'WEEKLY', label: 'Weekly' },
+              { value: 'MONTHLY', label: 'Monthly' },
+              { value: 'CUSTOM', label: 'Custom' },
+            ]}
+          />
+          {trackingForm.trackingType === 'NUMERIC' && (
+            <div className="grid grid-cols-2 gap-4">
+              <Input
+                label="Target value"
+                type="number"
+                value={trackingForm.targetNumericValue ?? ''}
+                onChange={(e) => setTrackingForm({ ...trackingForm, targetNumericValue: e.target.value === '' ? undefined : parseFloat(e.target.value) })}
+              />
+              <Input
+                label="Unit"
+                value={trackingForm.targetUnit ?? ''}
+                placeholder="e.g. liters"
+                onChange={(e) => setTrackingForm({ ...trackingForm, targetUnit: e.target.value })}
+              />
+            </div>
+          )}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={trackingForm.requiredDaily ?? false}
+              onChange={(e) => setTrackingForm({ ...trackingForm, requiredDaily: e.target.checked })}
+              className="w-4 h-4 rounded"
+            />
+            <span className="text-sm font-medium text-gray-700">Required daily</span>
+          </label>
+          <div className="flex gap-2 justify-end">
+            <Button variant="secondary" type="button" onClick={() => setTrackingOpen(false)}>Cancel</Button>
+            <Button type="submit" loading={trackingMutation.isPending}>Save</Button>
           </div>
         </form>
       </Modal>

--- a/frontend/src/pages/UpgradeDetailsPage.tsx
+++ b/frontend/src/pages/UpgradeDetailsPage.tsx
@@ -18,6 +18,16 @@ import type { CreateProgressRequest, CreateReflectionRequest, TrackingType, Freq
 
 const today = () => new Date().toISOString().split('T')[0];
 
+// Parse number inputs without ever sending NaN to the API (e.g. when the field is cleared).
+const numOrUndef = (v: string): number | undefined => {
+  const n = parseFloat(v);
+  return Number.isNaN(n) ? undefined : n;
+};
+const intOrUndef = (v: string): number | undefined => {
+  const n = parseInt(v, 10);
+  return Number.isNaN(n) ? undefined : n;
+};
+
 const UpgradeDetailsPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -204,7 +214,7 @@ const UpgradeDetailsPage: React.FC = () => {
             </label>
           )}
           {upgrade.trackingConfig?.trackingType === 'NUMERIC' && (
-            <Input label={`Value (${upgrade.trackingConfig.targetUnit ?? ''})`} type="number" value={progressForm.numericValue ?? ''} onChange={(e) => setProgressForm({ ...progressForm, numericValue: parseFloat(e.target.value) })} />
+            <Input label={`Value (${upgrade.trackingConfig.targetUnit ?? ''})`} type="number" value={progressForm.numericValue ?? ''} onChange={(e) => setProgressForm({ ...progressForm, numericValue: numOrUndef(e.target.value) })} />
           )}
           {upgrade.trackingConfig?.trackingType === 'RATING' && (
             <div>
@@ -240,8 +250,8 @@ const UpgradeDetailsPage: React.FC = () => {
             <textarea className="w-full mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" rows={2} value={reflectionForm.nextAdjustment ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, nextAdjustment: e.target.value })} />
           </div>
           <div className="grid grid-cols-2 gap-4">
-            <Input label="Difficulty (1-5)" type="number" min={1} max={5} value={reflectionForm.difficultyRating ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, difficultyRating: parseInt(e.target.value) })} />
-            <Input label="Benefit (1-5)" type="number" min={1} max={5} value={reflectionForm.benefitRating ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, benefitRating: parseInt(e.target.value) })} />
+            <Input label="Difficulty (1-5)" type="number" min={1} max={5} value={reflectionForm.difficultyRating ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, difficultyRating: intOrUndef(e.target.value) })} />
+            <Input label="Benefit (1-5)" type="number" min={1} max={5} value={reflectionForm.benefitRating ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, benefitRating: intOrUndef(e.target.value) })} />
           </div>
           <div className="flex gap-2 justify-end">
             <Button variant="secondary" type="button" onClick={() => setReflectionOpen(false)}>Cancel</Button>
@@ -280,7 +290,7 @@ const UpgradeDetailsPage: React.FC = () => {
                 label="Target value"
                 type="number"
                 value={trackingForm.targetNumericValue ?? ''}
-                onChange={(e) => setTrackingForm({ ...trackingForm, targetNumericValue: e.target.value === '' ? undefined : parseFloat(e.target.value) })}
+                onChange={(e) => setTrackingForm({ ...trackingForm, targetNumericValue: numOrUndef(e.target.value) })}
               />
               <Input
                 label="Unit"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -42,7 +42,7 @@ export type UpgradeStatus =
 
 export type Difficulty = 'EASY' | 'MEDIUM' | 'HARD';
 
-export type TrackingType = 'BOOLEAN' | 'NUMERIC' | 'TEXT' | 'RATING' | 'CHECKLIST';
+export type TrackingType = 'BOOLEAN' | 'NUMERIC' | 'TEXT' | 'RATING';
 
 export type Frequency = 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'CUSTOM';
 
@@ -70,9 +70,16 @@ export interface HealthUpgrade {
   targetEndDate?: string;
   motivation?: string;
   successCriteria?: string;
+  overdue?: boolean;
   createdAt: string;
+  updatedAt?: string;
   version: number;
   trackingConfig?: TrackingConfig;
+}
+
+export interface StreakSummary {
+  current: number;
+  longest: number;
 }
 
 export interface ProgressEntry {


### PR DESCRIPTION
## Summary

A comprehensive review of the project surfaced several integration bugs that prevented the app from working end-to-end in a browser, plus correctness gaps a prior review missed. This branch fixes them and adds polish.

## App-breaking fixes
- **Relative API base URL + CORS** — the axios client hardcoded `http://localhost:8080` while the backend had no CORS config, so every browser call (dev *and* Docker) was cross-origin and blocked. Base URL is now relative (flows through the Vite dev proxy / nginx prod proxy, same-origin); a configurable CORS bean is added as a fallback.
- **Dashboard contract** — backend returned `activeUpgrades`/`plannedUpgrades` as ints + lean summaries the UI couldn't use (counts always 0, sections always empty). `DashboardDto` now returns full `UpgradeDto` lists so the cards/counts render.
- **Reflections 404** — frontend hit `/api/reflections/...`; corrected to `/api/upgrades/{id}/reflections`.
- **Tracking config never reached the UI** — `UpgradeDto` now includes `trackingConfig`; added a tracking-config API + a configuration modal, so Daily Check-in shows the right input per type.
- **Server-side progress evaluation** — `ProgressEvaluationService` was dead code; it's now wired into `TrackingService` so completion is judged against the target (fixes streaks and the weekly completion rate).
- **Demo login** — V2's seeded BCrypt hash didn't match `demo123`; added `V3__fix_demo_password.sql` with a correct, verified hash.

## Polish
- `@Valid` + bean-validation constraints on progress/reflection/plan/reschedule requests
- Current + longest streak via the streak endpoint (`StreakDto`)
- JWT validated on app load via `/api/auth/me`; expired sessions cleared
- Error states on list and detail pages
- Dropped the unsupported `CHECKLIST` tracking type from the frontend
- CI now enforces frontend lint (removed the lint bypass); fixed the lone warning by extracting the auth context into its own module
- New backend tests: tracking evaluation, duplicate-progress handling, dashboard aggregation

## Verification
- Backend: `mvn test` → **49 passing**
- Frontend: `npm run build` (tsc typecheck) + `npm run lint` → clean

Not yet verified: the live end-to-end run (V3 migration + login→dashboard→check-in flow against real Postgres/browser).

## Out of scope
Reminders CRUD API/UI and a scheduled overdue-detection job remain future work (`UpgradeOverdueDetected` is defined but never published).