### PR TITLE
Real-time + scheduled notifications over WebSocket

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -44,6 +44,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
 
         <!-- JWT -->
         <dependency>

--- a/backend/src/main/java/com/healthupgrades/HealthUpgradesApplication.java
+++ b/backend/src/main/java/com/healthupgrades/HealthUpgradesApplication.java
@@ -2,12 +2,21 @@ package com.healthupgrades;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.time.Clock;
 
 @SpringBootApplication
 @EnableScheduling
 public class HealthUpgradesApplication {
     public static void main(String[] args) {
         SpringApplication.run(HealthUpgradesApplication.class, args);
+    }
+
+    /** Injectable clock so time-based logic (schedulers) is timezone-explicit and testable. */
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
     }
 }

--- a/backend/src/main/java/com/healthupgrades/HealthUpgradesApplication.java
+++ b/backend/src/main/java/com/healthupgrades/HealthUpgradesApplication.java
@@ -2,8 +2,10 @@ package com.healthupgrades;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class HealthUpgradesApplication {
     public static void main(String[] args) {
         SpringApplication.run(HealthUpgradesApplication.class, args);

--- a/backend/src/main/java/com/healthupgrades/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/healthupgrades/common/security/SecurityConfig.java
@@ -46,6 +46,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
+                        // The WebSocket handshake is open; the STOMP CONNECT frame is authenticated by
+                        // JwtChannelInterceptor (the JWT travels in the STOMP headers, not the handshake).
+                        .requestMatchers("/ws/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .authenticationProvider(authenticationProvider())

--- a/backend/src/main/java/com/healthupgrades/common/websocket/JwtChannelInterceptor.java
+++ b/backend/src/main/java/com/healthupgrades/common/websocket/JwtChannelInterceptor.java
@@ -1,0 +1,47 @@
+package com.healthupgrades.common.websocket;
+
+import com.healthupgrades.auth.infrastructure.UserRepository;
+import com.healthupgrades.common.security.JwtTokenProvider;
+import com.healthupgrades.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Authenticates STOMP connections. On the CONNECT frame it validates the JWT supplied in the
+ * "Authorization: Bearer ..." header and attaches a {@link StompPrincipal} (named by userId) to the
+ * session, so subsequent per-user messaging is routed correctly. An invalid/missing token rejects the
+ * connection.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtTokenProvider tokenProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String authHeader = accessor.getFirstNativeHeader("Authorization");
+            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+                throw new IllegalArgumentException("Missing or malformed Authorization header on STOMP CONNECT");
+            }
+            String token = authHeader.substring(7);
+            if (!tokenProvider.validateToken(token)) {
+                throw new IllegalArgumentException("Invalid JWT on STOMP CONNECT");
+            }
+            String email = tokenProvider.extractEmail(token);
+            User user = userRepository.findByEmail(email)
+                    .orElseThrow(() -> new IllegalArgumentException("Unknown user on STOMP CONNECT"));
+            accessor.setUser(new StompPrincipal(user.getId().toString()));
+        }
+        return message;
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/common/websocket/StompPrincipal.java
+++ b/backend/src/main/java/com/healthupgrades/common/websocket/StompPrincipal.java
@@ -1,0 +1,15 @@
+package com.healthupgrades.common.websocket;
+
+import java.security.Principal;
+
+/**
+ * STOMP session principal whose name is the user's id (as a string). Using the userId as the principal
+ * name lets {@code SimpMessagingTemplate.convertAndSendToUser(userId, ...)} route messages without an
+ * email lookup, and lets the client subscribe to {@code /user/queue/...} without knowing its own name.
+ */
+public record StompPrincipal(String name) implements Principal {
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/common/websocket/WebSocketConfig.java
+++ b/backend/src/main/java/com/healthupgrades/common/websocket/WebSocketConfig.java
@@ -1,0 +1,41 @@
+package com.healthupgrades.common.websocket;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtChannelInterceptor jwtChannelInterceptor;
+
+    @Value("${app.cors.allowed-origins:http://localhost:3000}")
+    private String allowedOrigins;
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // Native WebSocket (no SockJS). Same-origin requests via the Vite/nginx proxy need no CORS,
+        // but allowedOriginPatterns lets a different-origin frontend connect when configured.
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns(allowedOrigins.split(","));
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/queue", "/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+        registry.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(jwtChannelInterceptor);
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/common/websocket/WebSocketConfig.java
+++ b/backend/src/main/java/com/healthupgrades/common/websocket/WebSocketConfig.java
@@ -9,6 +9,8 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import java.util.Arrays;
+
 @Configuration
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
@@ -23,8 +25,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // Native WebSocket (no SockJS). Same-origin requests via the Vite/nginx proxy need no CORS,
         // but allowedOriginPatterns lets a different-origin frontend connect when configured.
-        registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns(allowedOrigins.split(","));
+        String[] origins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toArray(String[]::new);
+        registry.addEndpoint("/ws").setAllowedOriginPatterns(origins);
     }
 
     @Override

--- a/backend/src/main/java/com/healthupgrades/notification/api/NotificationController.java
+++ b/backend/src/main/java/com/healthupgrades/notification/api/NotificationController.java
@@ -1,0 +1,41 @@
+package com.healthupgrades.notification.api;
+
+import com.healthupgrades.notification.application.NotificationService;
+import com.healthupgrades.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService service;
+
+    @GetMapping
+    public ResponseEntity<List<NotificationDto>> list(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(service.listRecent(user.getId()));
+    }
+
+    @GetMapping("/unread-count")
+    public ResponseEntity<Map<String, Long>> unreadCount(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(Map.of("count", service.unreadCount(user.getId())));
+    }
+
+    @PostMapping("/{id}/read")
+    public ResponseEntity<NotificationDto> markRead(@AuthenticationPrincipal User user, @PathVariable UUID id) {
+        return ResponseEntity.ok(service.markRead(user.getId(), id));
+    }
+
+    @PostMapping("/read-all")
+    public ResponseEntity<Void> markAllRead(@AuthenticationPrincipal User user) {
+        service.markAllRead(user.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/notification/api/NotificationDto.java
+++ b/backend/src/main/java/com/healthupgrades/notification/api/NotificationDto.java
@@ -1,0 +1,18 @@
+package com.healthupgrades.notification.api;
+
+import com.healthupgrades.notification.domain.NotificationCategory;
+import com.healthupgrades.notification.domain.NotificationType;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record NotificationDto(
+        UUID id,
+        NotificationType type,
+        NotificationCategory category,
+        String title,
+        String message,
+        UUID relatedUpgradeId,
+        boolean read,
+        LocalDateTime createdAt
+) {}

--- a/backend/src/main/java/com/healthupgrades/notification/application/NotificationEventListener.java
+++ b/backend/src/main/java/com/healthupgrades/notification/application/NotificationEventListener.java
@@ -1,0 +1,86 @@
+package com.healthupgrades.notification.application;
+
+import com.healthupgrades.common.events.*;
+import com.healthupgrades.notification.domain.NotificationCategory;
+import com.healthupgrades.notification.domain.NotificationType;
+import com.healthupgrades.upgrade.domain.HealthUpgrade;
+import com.healthupgrades.upgrade.infrastructure.UpgradeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.UUID;
+
+/**
+ * Turns domain events into user notifications. Uses {@code AFTER_COMMIT} so a notification is only
+ * created once the originating action's transaction has actually committed (no notifications on
+ * rollback). Scheduled/delayed notifications (overdue, check-in, reminders) are produced directly by
+ * {@code NotificationScheduler}, not here. Per-progress entries are intentionally not notified (too
+ * frequent) — streak milestones cover that.
+ */
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final NotificationService notificationService;
+    private final UpgradeRepository upgradeRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onCreated(HealthUpgradeCreated e) {
+        notificationService.create(e.userId(), NotificationType.UPGRADE_CREATED, NotificationCategory.INFO,
+                "New upgrade idea", "\"" + e.title() + "\" was added to your backlog.", e.upgradeId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPlanned(HealthUpgradePlanned e) {
+        notificationService.create(e.userId(), NotificationType.UPGRADE_PLANNED, NotificationCategory.INFO,
+                "Upgrade planned", "\"" + title(e.upgradeId(), e.userId()) + "\" is planned to start "
+                        + e.plannedStartDate() + ".", e.upgradeId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onActivated(HealthUpgradeActivated e) {
+        notificationService.create(e.userId(), NotificationType.UPGRADE_ACTIVATED, NotificationCategory.SUCCESS,
+                "Upgrade activated 💪", "You activated \"" + title(e.upgradeId(), e.userId()) + "\". Let's go!",
+                e.upgradeId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPaused(HealthUpgradePaused e) {
+        notificationService.create(e.userId(), NotificationType.UPGRADE_PAUSED, NotificationCategory.INFO,
+                "Upgrade paused", "\"" + title(e.upgradeId(), e.userId()) + "\" is paused.", e.upgradeId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onCompleted(HealthUpgradeCompleted e) {
+        notificationService.create(e.userId(), NotificationType.UPGRADE_COMPLETED, NotificationCategory.SUCCESS,
+                "Upgrade completed 🎉", "Congrats! You completed \"" + title(e.upgradeId(), e.userId()) + "\".",
+                e.upgradeId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onAbandoned(HealthUpgradeAbandoned e) {
+        notificationService.create(e.userId(), NotificationType.UPGRADE_ABANDONED, NotificationCategory.INFO,
+                "Upgrade abandoned", "\"" + title(e.upgradeId(), e.userId()) + "\" was abandoned.", e.upgradeId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onStreak(StreakAchieved e) {
+        notificationService.create(e.userId(), NotificationType.STREAK_ACHIEVED, NotificationCategory.SUCCESS,
+                "🔥 " + e.streakDays() + "-day streak!",
+                "\"" + title(e.upgradeId(), e.userId()) + "\" — keep the momentum going.", e.upgradeId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onReflection(ReflectionAdded e) {
+        notificationService.create(e.userId(), NotificationType.REFLECTION_ADDED, NotificationCategory.INFO,
+                "Reflection added", "You reflected on \"" + title(e.upgradeId(), e.userId()) + "\".", e.upgradeId());
+    }
+
+    private String title(UUID upgradeId, UUID userId) {
+        return upgradeRepository.findByIdAndUserId(upgradeId, userId)
+                .map(HealthUpgrade::getTitle)
+                .orElse("your upgrade");
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/healthupgrades/notification/application/NotificationService.java
@@ -1,0 +1,76 @@
+package com.healthupgrades.notification.application;
+
+import com.healthupgrades.common.exception.ResourceNotFoundException;
+import com.healthupgrades.notification.api.NotificationDto;
+import com.healthupgrades.notification.domain.Notification;
+import com.healthupgrades.notification.domain.NotificationCategory;
+import com.healthupgrades.notification.domain.NotificationType;
+import com.healthupgrades.notification.infrastructure.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    /** STOMP user-destination the frontend subscribes to (resolved per-connection via the principal). */
+    public static final String USER_QUEUE = "/queue/notifications";
+
+    private final NotificationRepository repository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * Persist a notification for a user, then push it in real time to any connected session. Offline
+     * users pick it up via {@link #listRecent} on their next load. This is the single entry point used
+     * by both the event listener and the scheduler.
+     */
+    @Transactional
+    public NotificationDto create(UUID userId, NotificationType type, NotificationCategory category,
+                                  String title, String message, UUID relatedUpgradeId) {
+        Notification notification = repository.save(Notification.builder()
+                .userId(userId)
+                .type(type)
+                .category(category)
+                .title(title)
+                .message(message)
+                .relatedUpgradeId(relatedUpgradeId)
+                .read(false)
+                .build());
+
+        NotificationDto dto = toDto(notification);
+        // Routed to the session(s) whose STOMP principal name == userId (see JwtChannelInterceptor).
+        messagingTemplate.convertAndSendToUser(userId.toString(), USER_QUEUE, dto);
+        return dto;
+    }
+
+    public List<NotificationDto> listRecent(UUID userId) {
+        return repository.findTop50ByUserIdOrderByCreatedAtDesc(userId).stream().map(this::toDto).toList();
+    }
+
+    public long unreadCount(UUID userId) {
+        return repository.countByUserIdAndReadFalse(userId);
+    }
+
+    @Transactional
+    public NotificationDto markRead(UUID userId, UUID id) {
+        Notification notification = repository.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Notification not found: " + id));
+        notification.setRead(true);
+        return toDto(repository.save(notification));
+    }
+
+    @Transactional
+    public void markAllRead(UUID userId) {
+        repository.markAllReadForUser(userId);
+    }
+
+    private NotificationDto toDto(Notification n) {
+        return new NotificationDto(n.getId(), n.getType(), n.getCategory(), n.getTitle(), n.getMessage(),
+                n.getRelatedUpgradeId(), n.isRead(), n.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/healthupgrades/notification/application/NotificationService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 import java.util.UUID;
@@ -43,9 +45,27 @@ public class NotificationService {
                 .build());
 
         NotificationDto dto = toDto(notification);
-        // Routed to the session(s) whose STOMP principal name == userId (see JwtChannelInterceptor).
-        messagingTemplate.convertAndSendToUser(userId.toString(), USER_QUEUE, dto);
+        pushAfterCommit(userId, dto);
         return dto;
+    }
+
+    /**
+     * Push only after the surrounding transaction commits, so a client never receives a real-time
+     * notification for a row that then rolls back. When there is no active transaction (defensive),
+     * push immediately.
+     */
+    private void pushAfterCommit(UUID userId, NotificationDto dto) {
+        // Routed to the session(s) whose STOMP principal name == userId (see JwtChannelInterceptor).
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    messagingTemplate.convertAndSendToUser(userId.toString(), USER_QUEUE, dto);
+                }
+            });
+        } else {
+            messagingTemplate.convertAndSendToUser(userId.toString(), USER_QUEUE, dto);
+        }
     }
 
     public List<NotificationDto> listRecent(UUID userId) {

--- a/backend/src/main/java/com/healthupgrades/notification/domain/Notification.java
+++ b/backend/src/main/java/com/healthupgrades/notification/domain/Notification.java
@@ -1,0 +1,52 @@
+package com.healthupgrades.notification.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationCategory category;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String message;
+
+    private UUID relatedUpgradeId;
+
+    // Mapped to the column "is_read" because "read" is a reserved word in several SQL dialects.
+    @Column(name = "is_read", nullable = false)
+    private boolean read;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/notification/domain/NotificationCategory.java
+++ b/backend/src/main/java/com/healthupgrades/notification/domain/NotificationCategory.java
@@ -1,0 +1,9 @@
+package com.healthupgrades.notification.domain;
+
+/** Drives the icon/colour the frontend shows for a notification. */
+public enum NotificationCategory {
+    INFO,
+    SUCCESS,
+    WARNING,
+    REMINDER
+}

--- a/backend/src/main/java/com/healthupgrades/notification/domain/NotificationType.java
+++ b/backend/src/main/java/com/healthupgrades/notification/domain/NotificationType.java
@@ -1,0 +1,15 @@
+package com.healthupgrades.notification.domain;
+
+public enum NotificationType {
+    UPGRADE_CREATED,
+    UPGRADE_PLANNED,
+    UPGRADE_ACTIVATED,
+    UPGRADE_PAUSED,
+    UPGRADE_COMPLETED,
+    UPGRADE_ABANDONED,
+    STREAK_ACHIEVED,
+    UPGRADE_OVERDUE,
+    REFLECTION_ADDED,
+    REMINDER,
+    CHECKIN_REMINDER
+}

--- a/backend/src/main/java/com/healthupgrades/notification/infrastructure/NotificationRepository.java
+++ b/backend/src/main/java/com/healthupgrades/notification/infrastructure/NotificationRepository.java
@@ -1,0 +1,32 @@
+package com.healthupgrades.notification.infrastructure;
+
+import com.healthupgrades.notification.domain.Notification;
+import com.healthupgrades.notification.domain.NotificationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+
+    List<Notification> findTop50ByUserIdOrderByCreatedAtDesc(UUID userId);
+
+    long countByUserIdAndReadFalse(UUID userId);
+
+    Optional<Notification> findByIdAndUserId(UUID id, UUID userId);
+
+    // Dedup guard for system-generated notifications (e.g. only one "overdue" per upgrade).
+    boolean existsByUserIdAndRelatedUpgradeIdAndType(UUID userId, UUID relatedUpgradeId, NotificationType type);
+
+    // Dedup guard for the once-per-day check-in nudge.
+    boolean existsByUserIdAndTypeAndCreatedAtAfter(UUID userId, NotificationType type, LocalDateTime after);
+
+    @Modifying
+    @Query("update Notification n set n.read = true where n.userId = :userId and n.read = false")
+    void markAllReadForUser(@Param("userId") UUID userId);
+}

--- a/backend/src/main/java/com/healthupgrades/notification/scheduling/NotificationScheduler.java
+++ b/backend/src/main/java/com/healthupgrades/notification/scheduling/NotificationScheduler.java
@@ -1,0 +1,100 @@
+package com.healthupgrades.notification.scheduling;
+
+import com.healthupgrades.notification.application.NotificationService;
+import com.healthupgrades.notification.domain.NotificationCategory;
+import com.healthupgrades.notification.domain.NotificationType;
+import com.healthupgrades.notification.infrastructure.NotificationRepository;
+import com.healthupgrades.reminder.domain.Reminder;
+import com.healthupgrades.reminder.infrastructure.ReminderRepository;
+import com.healthupgrades.tracking.infrastructure.ProgressEntryRepository;
+import com.healthupgrades.upgrade.domain.HealthUpgrade;
+import com.healthupgrades.upgrade.domain.UpgradeStatus;
+import com.healthupgrades.upgrade.infrastructure.UpgradeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Produces the delayed/scheduled notifications. These call {@link NotificationService} directly (rather
+ * than going through domain events) because schedulers run outside a service transaction. Crons are
+ * configured under {@code app.notifications.schedules.*}.
+ */
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final UpgradeRepository upgradeRepository;
+    private final ProgressEntryRepository progressRepository;
+    private final ReminderRepository reminderRepository;
+    private final NotificationRepository notificationRepository;
+    private final NotificationService notificationService;
+
+    /** Alerts the owner once when an active upgrade passes its target date. */
+    @Scheduled(cron = "${app.notifications.schedules.overdue}")
+    public void notifyOverdue() {
+        for (HealthUpgrade u : upgradeRepository.findByStatus(UpgradeStatus.ACTIVE)) {
+            if (u.isOverdue() && !notificationRepository.existsByUserIdAndRelatedUpgradeIdAndType(
+                    u.getUserId(), u.getId(), NotificationType.UPGRADE_OVERDUE)) {
+                notificationService.create(u.getUserId(), NotificationType.UPGRADE_OVERDUE,
+                        NotificationCategory.WARNING, "Upgrade overdue ⏰",
+                        "\"" + u.getTitle() + "\" is past its target date.", u.getId());
+            }
+        }
+    }
+
+    /** Nudges users with active upgrades who haven't logged any progress today (once per day). */
+    @Scheduled(cron = "${app.notifications.schedules.daily-checkin}")
+    public void notifyDailyCheckin() {
+        LocalDate today = LocalDate.now();
+        Map<UUID, List<HealthUpgrade>> activeByUser = upgradeRepository.findByStatus(UpgradeStatus.ACTIVE).stream()
+                .collect(Collectors.groupingBy(HealthUpgrade::getUserId));
+
+        activeByUser.forEach((userId, upgrades) -> {
+            boolean alreadyNudged = notificationRepository.existsByUserIdAndTypeAndCreatedAtAfter(
+                    userId, NotificationType.CHECKIN_REMINDER, today.atStartOfDay());
+            boolean loggedToday = !progressRepository.findByUserIdAndDate(userId, today).isEmpty();
+            if (!alreadyNudged && !loggedToday) {
+                notificationService.create(userId, NotificationType.CHECKIN_REMINDER, NotificationCategory.REMINDER,
+                        "Daily check-in ⏳",
+                        "You have " + upgrades.size() + " active upgrade" + (upgrades.size() == 1 ? "" : "s")
+                                + " to track today.", null);
+            }
+        });
+    }
+
+    /** Dispatches user-configured per-upgrade reminders whose time/day matches now (runs every minute). */
+    @Scheduled(cron = "${app.notifications.schedules.reminders}")
+    public void dispatchReminders() {
+        LocalTime now = LocalTime.now();
+        String todayShort = LocalDate.now().getDayOfWeek().name().substring(0, 3); // e.g. MONDAY -> MON
+
+        for (Reminder reminder : reminderRepository.findByEnabledTrue()) {
+            LocalTime time = reminder.getReminderTime();
+            if (time == null || time.getHour() != now.getHour() || time.getMinute() != now.getMinute()) {
+                continue;
+            }
+            if (!dayMatches(reminder.getDaysOfWeek(), todayShort)) {
+                continue;
+            }
+            upgradeRepository.findById(reminder.getUpgradeId()).ifPresent(u ->
+                    notificationService.create(u.getUserId(), NotificationType.REMINDER, NotificationCategory.REMINDER,
+                            "Reminder ⏰", "Time for \"" + u.getTitle() + "\".", u.getId()));
+        }
+    }
+
+    /** A blank/empty day list means "every day"; otherwise the CSV must contain today (e.g. MON,WED,FRI). */
+    private boolean dayMatches(String daysOfWeek, String todayShort) {
+        if (daysOfWeek == null || daysOfWeek.isBlank()) return true;
+        return Arrays.stream(daysOfWeek.split(","))
+                .map(s -> s.trim().toUpperCase())
+                .anyMatch(todayShort::equals);
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/notification/scheduling/NotificationScheduler.java
+++ b/backend/src/main/java/com/healthupgrades/notification/scheduling/NotificationScheduler.java
@@ -14,12 +14,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -36,6 +38,7 @@ public class NotificationScheduler {
     private final ReminderRepository reminderRepository;
     private final NotificationRepository notificationRepository;
     private final NotificationService notificationService;
+    private final Clock clock;
 
     /** Alerts the owner once when an active upgrade passes its target date. */
     @Scheduled(cron = "${app.notifications.schedules.overdue}")
@@ -53,7 +56,7 @@ public class NotificationScheduler {
     /** Nudges users with active upgrades who haven't logged any progress today (once per day). */
     @Scheduled(cron = "${app.notifications.schedules.daily-checkin}")
     public void notifyDailyCheckin() {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(clock);
         Map<UUID, List<HealthUpgrade>> activeByUser = upgradeRepository.findByStatus(UpgradeStatus.ACTIVE).stream()
                 .collect(Collectors.groupingBy(HealthUpgrade::getUserId));
 
@@ -73,21 +76,31 @@ public class NotificationScheduler {
     /** Dispatches user-configured per-upgrade reminders whose time/day matches now (runs every minute). */
     @Scheduled(cron = "${app.notifications.schedules.reminders}")
     public void dispatchReminders() {
-        LocalTime now = LocalTime.now();
-        String todayShort = LocalDate.now().getDayOfWeek().name().substring(0, 3); // e.g. MONDAY -> MON
+        LocalTime now = LocalTime.now(clock);
+        String todayShort = LocalDate.now(clock).getDayOfWeek().name().substring(0, 3); // e.g. MONDAY -> MON
 
-        for (Reminder reminder : reminderRepository.findByEnabledTrue()) {
-            LocalTime time = reminder.getReminderTime();
-            if (time == null || time.getHour() != now.getHour() || time.getMinute() != now.getMinute()) {
-                continue;
+        List<Reminder> due = reminderRepository.findByEnabledTrue().stream()
+                .filter(r -> isDueNow(r.getReminderTime(), now))
+                .filter(r -> dayMatches(r.getDaysOfWeek(), todayShort))
+                .toList();
+        if (due.isEmpty()) return;
+
+        // Bulk-load the related upgrades in one query instead of one lookup per reminder.
+        List<UUID> upgradeIds = due.stream().map(Reminder::getUpgradeId).distinct().toList();
+        Map<UUID, HealthUpgrade> upgrades = upgradeRepository.findAllById(upgradeIds).stream()
+                .collect(Collectors.toMap(HealthUpgrade::getId, Function.identity()));
+
+        for (Reminder reminder : due) {
+            HealthUpgrade u = upgrades.get(reminder.getUpgradeId());
+            if (u != null) {
+                notificationService.create(u.getUserId(), NotificationType.REMINDER, NotificationCategory.REMINDER,
+                        "Reminder ⏰", "Time for \"" + u.getTitle() + "\".", u.getId());
             }
-            if (!dayMatches(reminder.getDaysOfWeek(), todayShort)) {
-                continue;
-            }
-            upgradeRepository.findById(reminder.getUpgradeId()).ifPresent(u ->
-                    notificationService.create(u.getUserId(), NotificationType.REMINDER, NotificationCategory.REMINDER,
-                            "Reminder ⏰", "Time for \"" + u.getTitle() + "\".", u.getId()));
         }
+    }
+
+    private boolean isDueNow(LocalTime time, LocalTime now) {
+        return time != null && time.getHour() == now.getHour() && time.getMinute() == now.getMinute();
     }
 
     /** A blank/empty day list means "every day"; otherwise the CSV must contain today (e.g. MON,WED,FRI). */

--- a/backend/src/main/java/com/healthupgrades/reminder/api/ReminderController.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/api/ReminderController.java
@@ -1,0 +1,46 @@
+package com.healthupgrades.reminder.api;
+
+import com.healthupgrades.reminder.application.ReminderService;
+import com.healthupgrades.user.domain.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+public class ReminderController {
+
+    private final ReminderService service;
+
+    @GetMapping("/api/upgrades/{upgradeId}/reminders")
+    public ResponseEntity<List<ReminderDto>> list(@AuthenticationPrincipal User user,
+                                                   @PathVariable UUID upgradeId) {
+        return ResponseEntity.ok(service.getForUpgrade(user.getId(), upgradeId));
+    }
+
+    @PostMapping("/api/upgrades/{upgradeId}/reminders")
+    public ResponseEntity<ReminderDto> create(@AuthenticationPrincipal User user,
+                                              @PathVariable UUID upgradeId,
+                                              @Valid @RequestBody ReminderRequest req) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.create(user.getId(), upgradeId, req));
+    }
+
+    @PutMapping("/api/reminders/{id}")
+    public ResponseEntity<ReminderDto> update(@AuthenticationPrincipal User user,
+                                              @PathVariable UUID id,
+                                              @Valid @RequestBody ReminderRequest req) {
+        return ResponseEntity.ok(service.update(user.getId(), id, req));
+    }
+
+    @DeleteMapping("/api/reminders/{id}")
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal User user, @PathVariable UUID id) {
+        service.delete(user.getId(), id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/reminder/api/ReminderDto.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/api/ReminderDto.java
@@ -1,0 +1,13 @@
+package com.healthupgrades.reminder.api;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
+public record ReminderDto(
+        UUID id,
+        UUID upgradeId,
+        LocalTime reminderTime,
+        List<String> daysOfWeek,
+        boolean enabled
+) {}

--- a/backend/src/main/java/com/healthupgrades/reminder/api/ReminderRequest.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/api/ReminderRequest.java
@@ -1,0 +1,12 @@
+package com.healthupgrades.reminder.api;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalTime;
+import java.util.List;
+
+public record ReminderRequest(
+        @NotNull LocalTime reminderTime,
+        List<String> daysOfWeek,   // e.g. ["MON","WED","FRI"]; empty/null means every day
+        Boolean enabled
+) {}

--- a/backend/src/main/java/com/healthupgrades/reminder/application/ReminderService.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/application/ReminderService.java
@@ -1,0 +1,77 @@
+package com.healthupgrades.reminder.application;
+
+import com.healthupgrades.common.exception.ResourceNotFoundException;
+import com.healthupgrades.reminder.api.ReminderDto;
+import com.healthupgrades.reminder.api.ReminderRequest;
+import com.healthupgrades.reminder.domain.Reminder;
+import com.healthupgrades.reminder.infrastructure.ReminderRepository;
+import com.healthupgrades.upgrade.application.UpgradeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ReminderService {
+
+    private final ReminderRepository repository;
+    private final UpgradeService upgradeService;
+
+    @Transactional
+    public ReminderDto create(UUID userId, UUID upgradeId, ReminderRequest req) {
+        upgradeService.getUpgrade(userId, upgradeId); // ownership check (throws if not owned)
+        Reminder reminder = Reminder.builder()
+                .upgradeId(upgradeId)
+                .reminderTime(req.reminderTime())
+                .daysOfWeek(toCsv(req.daysOfWeek()))
+                .enabled(req.enabled() == null || req.enabled())
+                .build();
+        return toDto(repository.save(reminder));
+    }
+
+    public List<ReminderDto> getForUpgrade(UUID userId, UUID upgradeId) {
+        upgradeService.getUpgrade(userId, upgradeId);
+        return repository.findByUpgradeId(upgradeId).stream().map(this::toDto).toList();
+    }
+
+    @Transactional
+    public ReminderDto update(UUID userId, UUID reminderId, ReminderRequest req) {
+        Reminder reminder = getOwnedReminder(userId, reminderId);
+        reminder.setReminderTime(req.reminderTime());
+        reminder.setDaysOfWeek(toCsv(req.daysOfWeek()));
+        if (req.enabled() != null) reminder.setEnabled(req.enabled());
+        return toDto(repository.save(reminder));
+    }
+
+    @Transactional
+    public void delete(UUID userId, UUID reminderId) {
+        Reminder reminder = getOwnedReminder(userId, reminderId);
+        repository.delete(reminder);
+    }
+
+    private Reminder getOwnedReminder(UUID userId, UUID reminderId) {
+        Reminder reminder = repository.findById(reminderId)
+                .orElseThrow(() -> new ResourceNotFoundException("Reminder not found: " + reminderId));
+        upgradeService.getUpgrade(userId, reminder.getUpgradeId()); // ownership via parent upgrade
+        return reminder;
+    }
+
+    private String toCsv(List<String> days) {
+        if (days == null || days.isEmpty()) return null;
+        return String.join(",", days.stream().map(d -> d.trim().toUpperCase()).toList());
+    }
+
+    private List<String> fromCsv(String csv) {
+        if (csv == null || csv.isBlank()) return List.of();
+        return Arrays.stream(csv.split(",")).map(String::trim).filter(s -> !s.isEmpty()).toList();
+    }
+
+    private ReminderDto toDto(Reminder r) {
+        return new ReminderDto(r.getId(), r.getUpgradeId(), r.getReminderTime(),
+                fromCsv(r.getDaysOfWeek()), Boolean.TRUE.equals(r.getEnabled()));
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/reminder/infrastructure/ReminderRepository.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/infrastructure/ReminderRepository.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 
 public interface ReminderRepository extends JpaRepository<Reminder, UUID> {
     List<Reminder> findByUpgradeId(UUID upgradeId);
+    List<Reminder> findByEnabledTrue();
 }

--- a/backend/src/main/java/com/healthupgrades/upgrade/infrastructure/UpgradeRepository.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/infrastructure/UpgradeRepository.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 public interface UpgradeRepository extends JpaRepository<HealthUpgrade, UUID> {
     List<HealthUpgrade> findByUserId(UUID userId);
     Optional<HealthUpgrade> findByIdAndUserId(UUID id, UUID userId);
+    List<HealthUpgrade> findByStatus(UpgradeStatus status);
     List<HealthUpgrade> findByUserIdAndStatus(UUID userId, UpgradeStatus status);
     List<HealthUpgrade> findByUserIdAndType(UUID userId, UpgradeType type);
     List<HealthUpgrade> findByUserIdAndAreaId(UUID userId, UUID areaId);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -24,7 +24,14 @@ app:
   cors:
     # Comma-separated list of origins allowed to call the API directly (cross-origin).
     # Not needed when the frontend is served behind the Vite dev proxy or nginx (same-origin /api).
+    # Also used as the allowed origins for the WebSocket (/ws) handshake.
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+  notifications:
+    schedules:
+      # Cron expressions for the delayed-notification jobs (server timezone).
+      overdue: ${NOTIFY_OVERDUE_CRON:0 0 8 * * *}        # daily at 08:00 — overdue-upgrade alerts
+      daily-checkin: ${NOTIFY_CHECKIN_CRON:0 0 18 * * *} # daily at 18:00 — check-in nudge
+      reminders: ${NOTIFY_REMINDERS_CRON:0 * * * * *}    # every minute — user reminder dispatch
 
 logging:
   level:

--- a/backend/src/main/resources/db/migration/V4__notifications.sql
+++ b/backend/src/main/resources/db/migration/V4__notifications.sql
@@ -1,0 +1,17 @@
+-- V4: Notifications table backing the in-app notification center + real-time push.
+
+CREATE TABLE notifications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    type VARCHAR(50) NOT NULL,
+    category VARCHAR(20) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    message TEXT,
+    related_upgrade_id UUID REFERENCES health_upgrades(id) ON DELETE SET NULL,
+    is_read BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_notifications_user_id ON notifications(user_id);
+CREATE INDEX idx_notifications_user_unread ON notifications(user_id, is_read);
+CREATE INDEX idx_notifications_user_created ON notifications(user_id, created_at);

--- a/backend/src/test/java/com/healthupgrades/notification/application/NotificationEventListenerTest.java
+++ b/backend/src/test/java/com/healthupgrades/notification/application/NotificationEventListenerTest.java
@@ -1,0 +1,54 @@
+package com.healthupgrades.notification.application;
+
+import com.healthupgrades.common.events.HealthUpgradeCompleted;
+import com.healthupgrades.common.events.HealthUpgradeCreated;
+import com.healthupgrades.notification.domain.NotificationCategory;
+import com.healthupgrades.notification.domain.NotificationType;
+import com.healthupgrades.upgrade.domain.HealthUpgrade;
+import com.healthupgrades.upgrade.infrastructure.UpgradeRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationEventListenerTest {
+
+    @Mock NotificationService notificationService;
+    @Mock UpgradeRepository upgradeRepository;
+
+    @InjectMocks NotificationEventListener listener;
+
+    private final UUID userId = UUID.randomUUID();
+    private final UUID upgradeId = UUID.randomUUID();
+
+    @Test
+    void completed_createsSuccessNotificationWithLookedUpTitle() {
+        when(upgradeRepository.findByIdAndUserId(upgradeId, userId))
+                .thenReturn(Optional.of(HealthUpgrade.builder().id(upgradeId).userId(userId).title("Drink water").build()));
+
+        listener.onCompleted(new HealthUpgradeCompleted(upgradeId, userId, LocalDateTime.now()));
+
+        verify(notificationService).create(eq(userId), eq(NotificationType.UPGRADE_COMPLETED),
+                eq(NotificationCategory.SUCCESS), any(), contains("Drink water"), eq(upgradeId));
+    }
+
+    @Test
+    void created_usesEventTitle_noLookup() {
+        listener.onCreated(new HealthUpgradeCreated(upgradeId, userId, "Walk daily", LocalDateTime.now()));
+
+        verify(notificationService).create(eq(userId), eq(NotificationType.UPGRADE_CREATED),
+                eq(NotificationCategory.INFO), any(), contains("Walk daily"), eq(upgradeId));
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/notification/application/NotificationServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/notification/application/NotificationServiceTest.java
@@ -1,0 +1,73 @@
+package com.healthupgrades.notification.application;
+
+import com.healthupgrades.notification.api.NotificationDto;
+import com.healthupgrades.notification.domain.Notification;
+import com.healthupgrades.notification.domain.NotificationCategory;
+import com.healthupgrades.notification.domain.NotificationType;
+import com.healthupgrades.notification.infrastructure.NotificationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock NotificationRepository repository;
+    @Mock SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks NotificationService service;
+
+    private final UUID userId = UUID.randomUUID();
+    private final UUID upgradeId = UUID.randomUUID();
+
+    @Test
+    void create_persistsAndPushesToUser() {
+        when(repository.save(any(Notification.class))).thenAnswer(inv -> {
+            Notification n = inv.getArgument(0);
+            n.setId(UUID.randomUUID());
+            return n;
+        });
+
+        NotificationDto dto = service.create(userId, NotificationType.UPGRADE_COMPLETED,
+                NotificationCategory.SUCCESS, "Upgrade completed 🎉", "Congrats!", upgradeId);
+
+        assertThat(dto.type()).isEqualTo(NotificationType.UPGRADE_COMPLETED);
+        assertThat(dto.read()).isFalse();
+        assertThat(dto.relatedUpgradeId()).isEqualTo(upgradeId);
+        verify(repository).save(any(Notification.class));
+        // pushed to the userId-named STOMP user destination
+        verify(messagingTemplate).convertAndSendToUser(eq(userId.toString()),
+                eq(NotificationService.USER_QUEUE), any(NotificationDto.class));
+    }
+
+    @Test
+    void markRead_flipsFlag() {
+        Notification n = Notification.builder().id(UUID.randomUUID()).userId(userId)
+                .type(NotificationType.REMINDER).category(NotificationCategory.REMINDER)
+                .title("Reminder").read(false).build();
+        when(repository.findByIdAndUserId(n.getId(), userId)).thenReturn(Optional.of(n));
+        when(repository.save(any(Notification.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        NotificationDto dto = service.markRead(userId, n.getId());
+
+        assertThat(dto.read()).isTrue();
+    }
+
+    @Test
+    void unreadCount_delegatesToRepository() {
+        when(repository.countByUserIdAndReadFalse(userId)).thenReturn(4L);
+        assertThat(service.unreadCount(userId)).isEqualTo(4L);
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/notification/scheduling/NotificationSchedulerTest.java
+++ b/backend/src/test/java/com/healthupgrades/notification/scheduling/NotificationSchedulerTest.java
@@ -1,0 +1,81 @@
+package com.healthupgrades.notification.scheduling;
+
+import com.healthupgrades.notification.domain.NotificationType;
+import com.healthupgrades.notification.infrastructure.NotificationRepository;
+import com.healthupgrades.reminder.domain.Reminder;
+import com.healthupgrades.reminder.infrastructure.ReminderRepository;
+import com.healthupgrades.tracking.infrastructure.ProgressEntryRepository;
+import com.healthupgrades.upgrade.domain.HealthUpgrade;
+import com.healthupgrades.upgrade.domain.UpgradeStatus;
+import com.healthupgrades.upgrade.infrastructure.UpgradeRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationSchedulerTest {
+
+    @Mock UpgradeRepository upgradeRepository;
+    @Mock ProgressEntryRepository progressRepository;
+    @Mock ReminderRepository reminderRepository;
+    @Mock NotificationRepository notificationRepository;
+    @Mock com.healthupgrades.notification.application.NotificationService notificationService;
+
+    @InjectMocks NotificationScheduler scheduler;
+
+    private final UUID userId = UUID.randomUUID();
+    private final UUID upgradeId = UUID.randomUUID();
+
+    @Test
+    void notifyOverdue_notifiesOncePerOverdueUpgrade() {
+        HealthUpgrade overdue = HealthUpgrade.builder().id(upgradeId).userId(userId).title("Sleep early")
+                .status(UpgradeStatus.ACTIVE).targetEndDate(LocalDate.now().minusDays(1)).build();
+        HealthUpgrade notOverdue = HealthUpgrade.builder().id(UUID.randomUUID()).userId(userId).title("Walk")
+                .status(UpgradeStatus.ACTIVE).build(); // no target date -> not overdue
+        when(upgradeRepository.findByStatus(UpgradeStatus.ACTIVE)).thenReturn(List.of(overdue, notOverdue));
+        when(notificationRepository.existsByUserIdAndRelatedUpgradeIdAndType(any(), any(), any())).thenReturn(false);
+
+        scheduler.notifyOverdue();
+
+        verify(notificationService).create(eq(userId), eq(NotificationType.UPGRADE_OVERDUE), any(), any(), any(), eq(upgradeId));
+    }
+
+    @Test
+    void notifyOverdue_skipsWhenAlreadyNotified() {
+        HealthUpgrade overdue = HealthUpgrade.builder().id(upgradeId).userId(userId).title("Sleep early")
+                .status(UpgradeStatus.ACTIVE).targetEndDate(LocalDate.now().minusDays(1)).build();
+        when(upgradeRepository.findByStatus(UpgradeStatus.ACTIVE)).thenReturn(List.of(overdue));
+        when(notificationRepository.existsByUserIdAndRelatedUpgradeIdAndType(any(), any(), any())).thenReturn(true);
+
+        scheduler.notifyOverdue();
+
+        verify(notificationService, never()).create(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void dispatchReminders_dueNow_notifiesOwner() {
+        Reminder reminder = Reminder.builder().id(UUID.randomUUID()).upgradeId(upgradeId)
+                .reminderTime(LocalTime.now()).daysOfWeek(null).enabled(true).build();
+        when(reminderRepository.findByEnabledTrue()).thenReturn(List.of(reminder));
+        when(upgradeRepository.findById(upgradeId)).thenReturn(Optional.of(
+                HealthUpgrade.builder().id(upgradeId).userId(userId).title("Meditate").build()));
+
+        scheduler.dispatchReminders();
+
+        verify(notificationService).create(eq(userId), eq(NotificationType.REMINDER), any(), any(), any(), eq(upgradeId));
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/notification/scheduling/NotificationSchedulerTest.java
+++ b/backend/src/test/java/com/healthupgrades/notification/scheduling/NotificationSchedulerTest.java
@@ -8,16 +8,18 @@ import com.healthupgrades.tracking.infrastructure.ProgressEntryRepository;
 import com.healthupgrades.upgrade.domain.HealthUpgrade;
 import com.healthupgrades.upgrade.domain.UpgradeStatus;
 import com.healthupgrades.upgrade.infrastructure.UpgradeRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -35,10 +37,18 @@ class NotificationSchedulerTest {
     @Mock NotificationRepository notificationRepository;
     @Mock com.healthupgrades.notification.application.NotificationService notificationService;
 
-    @InjectMocks NotificationScheduler scheduler;
+    // Fixed clock -> deterministic time-based scheduling (09:00 UTC).
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-06-24T09:00:00Z"), ZoneOffset.UTC);
+    private NotificationScheduler scheduler;
 
     private final UUID userId = UUID.randomUUID();
     private final UUID upgradeId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new NotificationScheduler(upgradeRepository, progressRepository, reminderRepository,
+                notificationRepository, notificationService, fixedClock);
+    }
 
     @Test
     void notifyOverdue_notifiesOncePerOverdueUpgrade() {
@@ -68,14 +78,26 @@ class NotificationSchedulerTest {
 
     @Test
     void dispatchReminders_dueNow_notifiesOwner() {
+        // Reminder time matches the fixed clock (09:00); no day filter -> due now.
         Reminder reminder = Reminder.builder().id(UUID.randomUUID()).upgradeId(upgradeId)
-                .reminderTime(LocalTime.now()).daysOfWeek(null).enabled(true).build();
+                .reminderTime(LocalTime.of(9, 0)).daysOfWeek(null).enabled(true).build();
         when(reminderRepository.findByEnabledTrue()).thenReturn(List.of(reminder));
-        when(upgradeRepository.findById(upgradeId)).thenReturn(Optional.of(
+        when(upgradeRepository.findAllById(List.of(upgradeId))).thenReturn(List.of(
                 HealthUpgrade.builder().id(upgradeId).userId(userId).title("Meditate").build()));
 
         scheduler.dispatchReminders();
 
         verify(notificationService).create(eq(userId), eq(NotificationType.REMINDER), any(), any(), any(), eq(upgradeId));
+    }
+
+    @Test
+    void dispatchReminders_notDue_doesNothing() {
+        Reminder reminder = Reminder.builder().id(UUID.randomUUID()).upgradeId(upgradeId)
+                .reminderTime(LocalTime.of(7, 30)).daysOfWeek(null).enabled(true).build();
+        when(reminderRepository.findByEnabledTrue()).thenReturn(List.of(reminder));
+
+        scheduler.dispatchReminders();
+
+        verify(notificationService, never()).create(any(), any(), any(), any(), any(), any());
     }
 }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,13 +1,30 @@
 server {
     listen 80;
+
     location / {
         root /usr/share/nginx/html;
         index index.html;
         try_files $uri $uri/ /index.html;
     }
+
     location /api {
         proxy_pass http://backend:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # WebSocket endpoint for real-time notifications — must upgrade the connection.
+    location /ws {
+        proxy_pass http://backend:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 3600s;
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "health-upgrades-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@stomp/stompjs": "^7.0.0",
         "@tanstack/react-query": "^5.17.0",
         "axios": "^1.6.0",
         "react": "^18.2.0",
@@ -1377,6 +1378,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
+      "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.100.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0",
     "@tanstack/react-query": "^5.17.0",
+    "@stomp/stompjs": "^7.0.0",
     "axios": "^1.6.0"
   },
   "devDependencies": {

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -1,0 +1,21 @@
+import client from './client';
+import type { AppNotification } from '../types';
+
+export const getNotifications = async (): Promise<AppNotification[]> => {
+  const { data } = await client.get<AppNotification[]>('/api/notifications');
+  return data;
+};
+
+export const getUnreadCount = async (): Promise<number> => {
+  const { data } = await client.get<{ count: number }>('/api/notifications/unread-count');
+  return data.count;
+};
+
+export const markNotificationRead = async (id: string): Promise<AppNotification> => {
+  const { data } = await client.post<AppNotification>(`/api/notifications/${id}/read`);
+  return data;
+};
+
+export const markAllNotificationsRead = async (): Promise<void> => {
+  await client.post('/api/notifications/read-all');
+};

--- a/frontend/src/api/reminders.ts
+++ b/frontend/src/api/reminders.ts
@@ -1,0 +1,21 @@
+import client from './client';
+import type { Reminder, CreateReminderRequest } from '../types';
+
+export const getReminders = async (upgradeId: string): Promise<Reminder[]> => {
+  const { data } = await client.get<Reminder[]>(`/api/upgrades/${upgradeId}/reminders`);
+  return data;
+};
+
+export const createReminder = async (upgradeId: string, req: CreateReminderRequest): Promise<Reminder> => {
+  const { data } = await client.post<Reminder>(`/api/upgrades/${upgradeId}/reminders`, req);
+  return data;
+};
+
+export const updateReminder = async (id: string, req: CreateReminderRequest): Promise<Reminder> => {
+  const { data } = await client.put<Reminder>(`/api/reminders/${id}`, req);
+  return data;
+};
+
+export const deleteReminder = async (id: string): Promise<void> => {
+  await client.delete(`/api/reminders/${id}`);
+};

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
 import Button from '../ui/Button';
+import NotificationBell from '../notifications/NotificationBell';
 
 const Navbar: React.FC = () => {
   const { user, logout } = useAuth();
@@ -12,7 +13,8 @@ const Navbar: React.FC = () => {
         <span className="text-2xl">💪</span>
         <span className="font-bold text-gray-900 text-lg">HealthUpgrades</span>
       </Link>
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-3">
+        <NotificationBell />
         {user && (
           <span className="text-sm text-gray-600 hidden sm:block">
             Hi, <span className="font-medium">{user.name}</span>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -15,6 +15,7 @@ const navItems: NavItem[] = [
   { to: '/upgrades/active', label: 'Active', icon: '🔥' },
   { to: '/daily-checkin', label: 'Daily Check-in', icon: '✅' },
   { to: '/progress-history', label: 'Progress History', icon: '📈' },
+  { to: '/notifications', label: 'Notifications', icon: '🔔' },
 ];
 
 const Sidebar: React.FC = () => (

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useNotifications } from '../../hooks/useNotifications';
+import NotificationDropdown from './NotificationDropdown';
+
+const NotificationBell: React.FC = () => {
+  const { unreadCount } = useNotifications();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="relative w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors"
+        aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
+      >
+        <span className="text-xl">🔔</span>
+        {unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center rounded-full bg-red-500 text-white text-[10px] font-bold">
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+      {open && <NotificationDropdown onClose={() => setOpen(false)} />}
+    </div>
+  );
+};
+
+export default NotificationBell;

--- a/frontend/src/components/notifications/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useNotifications } from '../../hooks/useNotifications';
+import NotificationItem from './NotificationItem';
+import type { AppNotification } from '../../types';
+
+interface Props {
+  onClose: () => void;
+}
+
+const NotificationDropdown: React.FC<Props> = ({ onClose }) => {
+  const { notifications, unreadCount, markRead, markAllRead, desktopPermission, requestDesktopPermission } =
+    useNotifications();
+  const navigate = useNavigate();
+  const recent = notifications.slice(0, 8);
+
+  const select = (n: AppNotification) => {
+    if (!n.read) markRead(n.id);
+    onClose();
+    if (n.relatedUpgradeId) navigate(`/upgrades/${n.relatedUpgradeId}`);
+  };
+
+  return (
+    <div className="absolute right-0 mt-2 w-80 max-w-[calc(100vw-2rem)] bg-white rounded-xl border border-gray-200 shadow-xl z-50 overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+        <span className="font-semibold text-gray-800 text-sm">
+          Notifications{unreadCount > 0 && <span className="text-blue-600"> ({unreadCount})</span>}
+        </span>
+        {unreadCount > 0 && (
+          <button onClick={markAllRead} className="text-xs text-blue-600 hover:underline">
+            Mark all read
+          </button>
+        )}
+      </div>
+
+      {desktopPermission === 'default' && (
+        <button
+          onClick={requestDesktopPermission}
+          className="w-full text-left px-4 py-2 text-xs text-blue-700 bg-blue-50 hover:bg-blue-100 border-b border-gray-100"
+        >
+          🔔 Enable desktop notifications
+        </button>
+      )}
+
+      <div className="max-h-96 overflow-y-auto divide-y divide-gray-100">
+        {recent.length === 0 ? (
+          <p className="text-sm text-gray-500 text-center py-8">No notifications yet.</p>
+        ) : (
+          recent.map((n) => <NotificationItem key={n.id} notification={n} onSelect={select} />)
+        )}
+      </div>
+
+      <button
+        onClick={() => { onClose(); navigate('/notifications'); }}
+        className="w-full text-center px-4 py-2.5 text-sm font-medium text-blue-600 hover:bg-gray-50 border-t border-gray-100"
+      >
+        View all notifications
+      </button>
+    </div>
+  );
+};
+
+export default NotificationDropdown;

--- a/frontend/src/components/notifications/NotificationItem.tsx
+++ b/frontend/src/components/notifications/NotificationItem.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { AppNotification } from '../../types';
+import { categoryMeta, relativeTime } from './notificationMeta';
+
+interface Props {
+  notification: AppNotification;
+  onSelect: (notification: AppNotification) => void;
+}
+
+const NotificationItem: React.FC<Props> = ({ notification, onSelect }) => {
+  const meta = categoryMeta[notification.category];
+  return (
+    <button
+      onClick={() => onSelect(notification)}
+      className={`w-full text-left flex gap-3 p-3 transition-colors hover:bg-gray-50 ${notification.read ? '' : 'bg-blue-50/50'}`}
+    >
+      <span className="text-lg leading-none mt-0.5">{meta.icon}</span>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-medium text-gray-900 truncate">{notification.title}</p>
+          {!notification.read && <span className="w-2 h-2 rounded-full bg-blue-500 shrink-0" aria-label="unread" />}
+        </div>
+        {notification.message && <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">{notification.message}</p>}
+        <p className="text-[11px] text-gray-400 mt-1">{relativeTime(notification.createdAt)}</p>
+      </div>
+    </button>
+  );
+};
+
+export default NotificationItem;

--- a/frontend/src/components/notifications/ToastContainer.tsx
+++ b/frontend/src/components/notifications/ToastContainer.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { AppNotification } from '../../types';
+import { categoryMeta } from './notificationMeta';
+
+export interface ToastData extends Pick<AppNotification, 'category' | 'title' | 'message' | 'relatedUpgradeId'> {
+  id: string;
+}
+
+interface Props {
+  toasts: ToastData[];
+  onDismiss: (id: string) => void;
+}
+
+/** Transient real-time toasts, stacked top-right above everything. */
+const ToastContainer: React.FC<Props> = ({ toasts, onDismiss }) => {
+  const navigate = useNavigate();
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed top-4 right-4 z-[60] flex flex-col gap-2 w-80 max-w-[calc(100vw-2rem)]">
+      {toasts.map((t) => {
+        const meta = categoryMeta[t.category];
+        return (
+          <div
+            key={t.id}
+            role="status"
+            className={`${meta.bg} ${meta.ring} border rounded-xl shadow-lg p-3 flex items-start gap-3 cursor-pointer animate-[fadeIn_0.2s_ease-out]`}
+            onClick={() => {
+              if (t.relatedUpgradeId) navigate(`/upgrades/${t.relatedUpgradeId}`);
+              onDismiss(t.id);
+            }}
+          >
+            <span className="text-lg leading-none mt-0.5">{meta.icon}</span>
+            <div className="flex-1 min-w-0">
+              <p className={`text-sm font-semibold ${meta.text} truncate`}>{t.title}</p>
+              {t.message && <p className="text-xs text-gray-600 mt-0.5 line-clamp-2">{t.message}</p>}
+            </div>
+            <button
+              onClick={(e) => { e.stopPropagation(); onDismiss(t.id); }}
+              className="text-gray-400 hover:text-gray-600 text-lg leading-none"
+              aria-label="Dismiss"
+            >
+              &times;
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ToastContainer;

--- a/frontend/src/components/notifications/ToastContainer.tsx
+++ b/frontend/src/components/notifications/ToastContainer.tsx
@@ -22,24 +22,33 @@ const ToastContainer: React.FC<Props> = ({ toasts, onDismiss }) => {
       {toasts.map((t) => {
         const meta = categoryMeta[t.category];
         return (
+          // The card is a non-interactive live region; the interactive parts are real buttons so the
+          // toast is keyboard- and screen-reader-accessible.
           <div
             key={t.id}
             role="status"
-            className={`${meta.bg} ${meta.ring} border rounded-xl shadow-lg p-3 flex items-start gap-3 cursor-pointer animate-[fadeIn_0.2s_ease-out]`}
-            onClick={() => {
-              if (t.relatedUpgradeId) navigate(`/upgrades/${t.relatedUpgradeId}`);
-              onDismiss(t.id);
-            }}
+            aria-live="polite"
+            className={`${meta.bg} ${meta.ring} border rounded-xl shadow-lg p-3 flex items-start gap-2 animate-[fadeIn_0.2s_ease-out]`}
           >
-            <span className="text-lg leading-none mt-0.5">{meta.icon}</span>
-            <div className="flex-1 min-w-0">
-              <p className={`text-sm font-semibold ${meta.text} truncate`}>{t.title}</p>
-              {t.message && <p className="text-xs text-gray-600 mt-0.5 line-clamp-2">{t.message}</p>}
-            </div>
             <button
-              onClick={(e) => { e.stopPropagation(); onDismiss(t.id); }}
-              className="text-gray-400 hover:text-gray-600 text-lg leading-none"
-              aria-label="Dismiss"
+              type="button"
+              onClick={() => {
+                if (t.relatedUpgradeId) navigate(`/upgrades/${t.relatedUpgradeId}`);
+                onDismiss(t.id);
+              }}
+              className="flex items-start gap-3 flex-1 min-w-0 text-left"
+            >
+              <span className="text-lg leading-none mt-0.5">{meta.icon}</span>
+              <span className="flex-1 min-w-0">
+                <span className={`block text-sm font-semibold ${meta.text} truncate`}>{t.title}</span>
+                {t.message && <span className="block text-xs text-gray-600 mt-0.5 line-clamp-2">{t.message}</span>}
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={() => onDismiss(t.id)}
+              className="text-gray-400 hover:text-gray-600 text-lg leading-none shrink-0"
+              aria-label="Dismiss notification"
             >
               &times;
             </button>

--- a/frontend/src/components/notifications/notificationMeta.ts
+++ b/frontend/src/components/notifications/notificationMeta.ts
@@ -1,0 +1,23 @@
+import type { NotificationCategory } from '../../types';
+
+/** Icon + Tailwind classes per notification category, shared by the toast, dropdown and list. */
+export const categoryMeta: Record<NotificationCategory, { icon: string; bg: string; ring: string; text: string }> = {
+  INFO: { icon: 'ℹ️', bg: 'bg-blue-50', ring: 'border-blue-200', text: 'text-blue-700' },
+  SUCCESS: { icon: '✅', bg: 'bg-green-50', ring: 'border-green-200', text: 'text-green-700' },
+  WARNING: { icon: '⚠️', bg: 'bg-red-50', ring: 'border-red-200', text: 'text-red-700' },
+  REMINDER: { icon: '⏰', bg: 'bg-orange-50', ring: 'border-orange-200', text: 'text-orange-700' },
+};
+
+/** "5m ago" style relative time for an ISO timestamp. */
+export const relativeTime = (iso: string): string => {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const sec = Math.round(diffMs / 1000);
+  if (sec < 60) return 'just now';
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.round(hr / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+};

--- a/frontend/src/contexts/NotificationProvider.tsx
+++ b/frontend/src/contexts/NotificationProvider.tsx
@@ -1,0 +1,125 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Client } from '@stomp/stompjs';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '../hooks/useAuth';
+import { getNotifications, markNotificationRead, markAllNotificationsRead } from '../api/notifications';
+import { NotificationContext } from './notificationContextValue';
+import ToastContainer, { type ToastData } from '../components/notifications/ToastContainer';
+import type { AppNotification } from '../types';
+
+const NOTIF_KEY = ['notifications'];
+
+/** Build the WebSocket URL. Same-origin /ws (via the Vite/nginx proxy) by default; derived from
+ * VITE_API_URL when the API is on another origin. */
+function buildWsUrl(): string {
+  const apiUrl = import.meta.env.VITE_API_URL;
+  if (apiUrl && /^https?:\/\//.test(apiUrl)) {
+    return apiUrl.replace(/^http/, 'ws').replace(/\/$/, '') + '/ws';
+  }
+  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${proto}//${window.location.host}/ws`;
+}
+
+export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { token, isAuthenticated } = useAuth();
+  const queryClient = useQueryClient();
+  const [connected, setConnected] = useState(false);
+  const [toasts, setToasts] = useState<ToastData[]>([]);
+  const [desktopPermission, setDesktopPermission] = useState<NotificationPermission>(
+    typeof Notification !== 'undefined' ? Notification.permission : 'denied',
+  );
+  const clientRef = useRef<Client | null>(null);
+
+  const { data: notifications = [] } = useQuery({
+    queryKey: NOTIF_KEY,
+    queryFn: getNotifications,
+    enabled: isAuthenticated,
+  });
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const pushToast = useCallback((n: AppNotification) => {
+    setToasts((prev) =>
+      [{ id: n.id, category: n.category, title: n.title, message: n.message, relatedUpgradeId: n.relatedUpgradeId }, ...prev].slice(0, 4),
+    );
+    window.setTimeout(() => dismissToast(n.id), 6000);
+  }, [dismissToast]);
+
+  const handleIncoming = useCallback((n: AppNotification) => {
+    // Prepend to the cached list (de-duped) so the bell/badge/list update live.
+    queryClient.setQueryData<AppNotification[]>(NOTIF_KEY, (old = []) =>
+      old.some((x) => x.id === n.id) ? old : [n, ...old],
+    );
+    pushToast(n);
+    // OS/desktop notification only when the tab is backgrounded and permission was granted.
+    if (typeof Notification !== 'undefined' && Notification.permission === 'granted' && document.hidden) {
+      const desktop = new Notification(n.title, { body: n.message ?? '' });
+      desktop.onclick = () => {
+        window.focus();
+        if (n.relatedUpgradeId) window.location.assign(`/upgrades/${n.relatedUpgradeId}`);
+        desktop.close();
+      };
+    }
+  }, [queryClient, pushToast]);
+
+  // STOMP connection lifecycle — connect while authenticated, disconnect on logout/unmount.
+  useEffect(() => {
+    if (!isAuthenticated || !token) return;
+
+    const client = new Client({
+      brokerURL: buildWsUrl(),
+      connectHeaders: { Authorization: `Bearer ${token}` },
+      reconnectDelay: 5000,
+      onConnect: () => {
+        setConnected(true);
+        client.subscribe('/user/queue/notifications', (message) => {
+          try {
+            handleIncoming(JSON.parse(message.body) as AppNotification);
+          } catch {
+            /* ignore malformed frames */
+          }
+        });
+      },
+      onWebSocketClose: () => setConnected(false),
+      onStompError: () => setConnected(false),
+    });
+    client.activate();
+    clientRef.current = client;
+
+    return () => {
+      client.deactivate();
+      clientRef.current = null;
+      setConnected(false);
+    };
+  }, [isAuthenticated, token, handleIncoming]);
+
+  const markRead = useCallback((id: string) => {
+    queryClient.setQueryData<AppNotification[]>(NOTIF_KEY, (old = []) =>
+      old.map((n) => (n.id === id ? { ...n, read: true } : n)),
+    );
+    markNotificationRead(id).catch(() => queryClient.invalidateQueries({ queryKey: NOTIF_KEY }));
+  }, [queryClient]);
+
+  const markAllRead = useCallback(() => {
+    queryClient.setQueryData<AppNotification[]>(NOTIF_KEY, (old = []) => old.map((n) => ({ ...n, read: true })));
+    markAllNotificationsRead().catch(() => queryClient.invalidateQueries({ queryKey: NOTIF_KEY }));
+  }, [queryClient]);
+
+  const requestDesktopPermission = useCallback(() => {
+    if (typeof Notification === 'undefined') return;
+    Notification.requestPermission().then(setDesktopPermission);
+  }, []);
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  return (
+    <NotificationContext.Provider
+      value={{ notifications, unreadCount, connected, desktopPermission, markRead, markAllRead, requestDesktopPermission }}
+    >
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </NotificationContext.Provider>
+  );
+};

--- a/frontend/src/contexts/notificationContextValue.ts
+++ b/frontend/src/contexts/notificationContextValue.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+import type { AppNotification } from '../types';
+
+export interface NotificationContextType {
+  notifications: AppNotification[];
+  unreadCount: number;
+  connected: boolean;
+  desktopPermission: NotificationPermission;
+  markRead: (id: string) => void;
+  markAllRead: () => void;
+  requestDesktopPermission: () => void;
+}
+
+export const NotificationContext = createContext<NotificationContextType | null>(null);

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { NotificationContext } from '../contexts/notificationContextValue';
+
+export const useNotifications = () => {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) throw new Error('useNotifications must be used within NotificationProvider');
+  return ctx;
+};

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useNotifications } from '../hooks/useNotifications';
+import PageHeader from '../components/ui/PageHeader';
+import Button from '../components/ui/Button';
+import EmptyState from '../components/ui/EmptyState';
+import NotificationItem from '../components/notifications/NotificationItem';
+import type { AppNotification } from '../types';
+
+const NotificationsPage: React.FC = () => {
+  const { notifications, unreadCount, markRead, markAllRead, desktopPermission, requestDesktopPermission } =
+    useNotifications();
+  const navigate = useNavigate();
+  const [filter, setFilter] = useState<'all' | 'unread'>('all');
+
+  const shown = filter === 'unread' ? notifications.filter((n) => !n.read) : notifications;
+
+  const select = (n: AppNotification) => {
+    if (!n.read) markRead(n.id);
+    if (n.relatedUpgradeId) navigate(`/upgrades/${n.relatedUpgradeId}`);
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <PageHeader
+        title="Notifications"
+        subtitle={unreadCount > 0 ? `${unreadCount} unread` : 'You are all caught up'}
+        action={
+          <div className="flex gap-2">
+            {desktopPermission === 'default' && (
+              <Button variant="secondary" size="sm" onClick={requestDesktopPermission}>Enable desktop alerts</Button>
+            )}
+            {unreadCount > 0 && <Button size="sm" onClick={markAllRead}>Mark all read</Button>}
+          </div>
+        }
+      />
+
+      <div className="flex gap-2 mb-4">
+        {(['all', 'unread'] as const).map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={`px-3 py-1.5 rounded-lg text-sm font-medium capitalize transition-colors ${
+              filter === f ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            {f}{f === 'unread' && unreadCount > 0 ? ` (${unreadCount})` : ''}
+          </button>
+        ))}
+      </div>
+
+      {shown.length === 0 ? (
+        <EmptyState
+          icon="🔔"
+          title={filter === 'unread' ? 'No unread notifications' : 'No notifications yet'}
+          description="Updates about your upgrades, streaks, reminders and overdue items will show up here."
+        />
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-100">
+          {shown.map((n) => (
+            <NotificationItem key={n.id} notification={n} onSelect={select} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NotificationsPage;

--- a/frontend/src/pages/UpgradeDetailsPage.tsx
+++ b/frontend/src/pages/UpgradeDetailsPage.tsx
@@ -5,6 +5,7 @@ import { getUpgradeById } from '../api/upgrades';
 import { getProgressByUpgrade, createProgress, getStreak } from '../api/progress';
 import { getReflectionsByUpgrade, createReflection } from '../api/reflections';
 import { saveTrackingConfig, type SaveTrackingConfigRequest } from '../api/trackingConfig';
+import { getReminders, createReminder, deleteReminder } from '../api/reminders';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
@@ -17,6 +18,7 @@ import Badge from '../components/ui/Badge';
 import type { CreateProgressRequest, CreateReflectionRequest, TrackingType, Frequency } from '../types';
 
 const today = () => new Date().toISOString().split('T')[0];
+const DAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
 
 // Parse number inputs without ever sending NaN to the API (e.g. when the field is cleared).
 const numOrUndef = (v: string): number | undefined => {
@@ -59,10 +61,25 @@ const UpgradeDetailsPage: React.FC = () => {
     benefitRating: 3,
   });
 
+  const [reminderTime, setReminderTime] = useState('09:00');
+  const [reminderDays, setReminderDays] = useState<string[]>([]);
+  const toggleDay = (d: string) =>
+    setReminderDays((prev) => (prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d]));
+
   const { data: upgrade, isLoading, error } = useQuery({ queryKey: ['upgrade', id], queryFn: () => getUpgradeById(id!), enabled: !!id });
   const { data: progress = [] } = useQuery({ queryKey: ['progress', id], queryFn: () => getProgressByUpgrade(id!), enabled: !!id });
   const { data: reflections = [] } = useQuery({ queryKey: ['reflections', id], queryFn: () => getReflectionsByUpgrade(id!), enabled: !!id });
   const { data: streak = { current: 0, longest: 0 } } = useQuery({ queryKey: ['streak', id], queryFn: () => getStreak(id!), enabled: !!id });
+  const { data: reminders = [] } = useQuery({ queryKey: ['reminders', id], queryFn: () => getReminders(id!), enabled: !!id });
+
+  const createReminderMut = useMutation({
+    mutationFn: () => createReminder(id!, { reminderTime, daysOfWeek: reminderDays, enabled: true }),
+    onSuccess: () => { qc.invalidateQueries({ queryKey: ['reminders', id] }); setReminderDays([]); },
+  });
+  const deleteReminderMut = useMutation({
+    mutationFn: (reminderId: string) => deleteReminder(reminderId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['reminders', id] }),
+  });
 
   const progressMutation = useMutation({
     mutationFn: createProgress,
@@ -151,6 +168,53 @@ const UpgradeDetailsPage: React.FC = () => {
         ) : (
           <p className="text-gray-500 text-sm text-center py-4">No tracking configured yet. Configure how you'll track this upgrade.</p>
         )}
+      </Card>
+
+      <Card header={<span>Reminders ({reminders.length})</span>}>
+        {reminders.length === 0 ? (
+          <p className="text-gray-500 text-sm mb-4">No reminders yet. Add one to get notified.</p>
+        ) : (
+          <div className="space-y-2 mb-4">
+            {reminders.map((r) => (
+              <div key={r.id} className="flex items-center justify-between p-2 bg-gray-50 rounded-lg text-sm">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">⏰ {r.reminderTime.slice(0, 5)}</span>
+                  <span className="text-gray-500">{r.daysOfWeek.length ? r.daysOfWeek.join(', ') : 'Every day'}</span>
+                  {!r.enabled && <Badge variant="gray">disabled</Badge>}
+                </div>
+                <button
+                  onClick={() => deleteReminderMut.mutate(r.id)}
+                  className="text-red-500 hover:text-red-700 text-xs font-medium"
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+        <form
+          onSubmit={(e) => { e.preventDefault(); createReminderMut.mutate(); }}
+          className="flex flex-wrap items-end gap-3 border-t border-gray-100 pt-3"
+        >
+          <Input label="Time" type="time" value={reminderTime} onChange={(e) => setReminderTime(e.target.value)} />
+          <div>
+            <label className="text-sm font-medium text-gray-700 block mb-1">Days <span className="text-gray-400">(none = every day)</span></label>
+            <div className="flex gap-1">
+              {DAYS.map((d) => (
+                <button
+                  key={d}
+                  type="button"
+                  title={d}
+                  onClick={() => toggleDay(d)}
+                  className={`w-9 h-9 rounded-lg text-xs font-medium transition-colors ${reminderDays.includes(d) ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}
+                >
+                  {d[0]}
+                </button>
+              ))}
+            </div>
+          </div>
+          <Button type="submit" loading={createReminderMut.isPending}>Add reminder</Button>
+        </form>
       </Card>
 
       <Card header={

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import ProtectedRoute from './ProtectedRoute';
 import Layout from '../components/layout/Layout';
+import { NotificationProvider } from '../contexts/NotificationProvider';
 import LoginPage from '../pages/LoginPage';
 import RegisterPage from '../pages/RegisterPage';
 import DashboardPage from '../pages/DashboardPage';
@@ -12,9 +13,13 @@ import PlannedUpgradesPage from '../pages/PlannedUpgradesPage';
 import UpgradeDetailsPage from '../pages/UpgradeDetailsPage';
 import DailyCheckinPage from '../pages/DailyCheckinPage';
 import ProgressHistoryPage from '../pages/ProgressHistoryPage';
+import NotificationsPage from '../pages/NotificationsPage';
 
+// NotificationProvider lives inside the Router so toasts/items can navigate, and inside the existing
+// QueryClientProvider + AuthProvider (mounted in App.tsx) for query + auth access.
 const AppRouter: React.FC = () => (
   <BrowserRouter>
+    <NotificationProvider>
     <Routes>
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
@@ -90,8 +95,17 @@ const AppRouter: React.FC = () => (
           </ProtectedRoute>
         }
       />
+      <Route
+        path="/notifications"
+        element={
+          <ProtectedRoute>
+            <Layout><NotificationsPage /></Layout>
+          </ProtectedRoute>
+        }
+      />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
+    </NotificationProvider>
   </BrowserRouter>
 );
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -166,3 +166,43 @@ export interface CreateReflectionRequest {
   whatDidNotWork?: string;
   nextAdjustment?: string;
 }
+
+export type NotificationType =
+  | 'UPGRADE_CREATED'
+  | 'UPGRADE_PLANNED'
+  | 'UPGRADE_ACTIVATED'
+  | 'UPGRADE_PAUSED'
+  | 'UPGRADE_COMPLETED'
+  | 'UPGRADE_ABANDONED'
+  | 'STREAK_ACHIEVED'
+  | 'UPGRADE_OVERDUE'
+  | 'REFLECTION_ADDED'
+  | 'REMINDER'
+  | 'CHECKIN_REMINDER';
+
+export type NotificationCategory = 'INFO' | 'SUCCESS' | 'WARNING' | 'REMINDER';
+
+export interface AppNotification {
+  id: string;
+  type: NotificationType;
+  category: NotificationCategory;
+  title: string;
+  message?: string;
+  relatedUpgradeId?: string;
+  read: boolean;
+  createdAt: string;
+}
+
+export interface Reminder {
+  id: string;
+  upgradeId: string;
+  reminderTime: string;   // "HH:mm" / "HH:mm:ss"
+  daysOfWeek: string[];   // e.g. ["MON","WED","FRI"]; empty means every day
+  enabled: boolean;
+}
+
+export interface CreateReminderRequest {
+  reminderTime: string;   // "HH:mm"
+  daysOfWeek?: string[];
+  enabled?: boolean;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
         target: 'http://localhost:8080',
         changeOrigin: true,
       },
+      // WebSocket endpoint for real-time notifications.
+      '/ws': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        ws: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## Summary

Adds a comprehensive notification system: **real-time** (WebSocket/STOMP push → toast + live badge), **persistent** (notification center with bell, unread badge, dropdown, and a `/notifications` page, REST-backed so offline users catch up on load), and **delayed/scheduled** (overdue alerts, a daily check-in nudge, and user-configurable per-upgrade reminders), plus **browser/OS desktop notifications** when the tab is backgrounded.

> **Note on base:** this branch is stacked on the correctness branch (PR #2), which isn't merged to `main` yet, so this PR's diff also contains those 3 commits. Merging this PR brings both the correctness fixes and the notifications feature. (Alternatively merge PR #2 first, then this rebases cleanly.)

## Backend
- New `notification` module (entity, type/category enums, repository, service, controller, DTO) + a `V4` Flyway migration for the `notifications` table.
- WebSocket/STOMP endpoint `/ws` with a JWT-authenticated CONNECT handshake (`JwtChannelInterceptor` + `StompPrincipal` keyed by `userId`); per-user push via `SimpMessagingTemplate.convertAndSendToUser`.
- `NotificationEventListener` turns the existing domain events into notifications **after commit** (`AFTER_COMMIT`); per-progress entries are excluded to avoid noise.
- `NotificationScheduler` produces the delayed notifications — overdue-upgrade alerts (deduped), a daily check-in nudge, and per-minute dispatch of user reminders; enables `@Scheduled` and adds `UpgradeRepository.findByStatus`.
- Activates the previously-orphaned **Reminder** module: `ReminderService` + `ReminderController` (CRUD scoped to the parent upgrade) + `findByEnabledTrue`.
- Tests for `NotificationService`, `NotificationEventListener`, `NotificationScheduler`.

## Frontend
- `@stomp/stompjs` client in a `NotificationProvider` (mounted inside the router) that subscribes to `/user/queue/notifications`, prepends to the cache, shows a toast, and raises an OS/desktop notification when the tab is hidden.
- Notification center: Navbar bell + unread badge + dropdown, a `/notifications` page, mark-read / mark-all-read, REST hydration via TanStack Query.
- Per-upgrade reminders UI (time + day-of-week + enabled) on the upgrade details page.
- Infra: Vite `/ws` proxy (`ws: true`) and nginx `/ws` upgrade headers.

## Verification
- Backend: `mvn test` → **57 passing** (49 existing + 8 new)
- Frontend: `npm run build` (tsc typecheck) + `npm run lint` → clean

Not yet verified: the live WebSocket round-trip and the `@Scheduled` jobs against a real Postgres/browser (the `V4` table is checked by `ddl-auto: validate` on first boot).