### PR TITLE
Hexagonal migration, phase 2: framework-free domain services

### DIFF
--- a/backend/src/main/java/com/healthupgrades/tracking/application/TrackingBeansConfig.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/application/TrackingBeansConfig.java
@@ -1,0 +1,28 @@
+package com.healthupgrades.tracking.application;
+
+import com.healthupgrades.tracking.domain.ProgressEvaluationService; // pure domain service being exposed
+import com.healthupgrades.tracking.domain.StreakCalculator; // pure domain service being exposed
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the tracking context's pure domain services as Spring beans.
+ *
+ * <p>Both services are framework-free (no {@code @Service}); the application layer exposes them so the
+ * tracking and dashboard services can have them injected.
+ */
+@Configuration
+public class TrackingBeansConfig {
+
+    /** Exposes the stateless {@link StreakCalculator} as an injectable bean. */
+    @Bean
+    public StreakCalculator streakCalculator() {
+        return new StreakCalculator(); // no dependencies -> plain construction
+    }
+
+    /** Exposes the stateless {@link ProgressEvaluationService} as an injectable bean. */
+    @Bean
+    public ProgressEvaluationService progressEvaluationService() {
+        return new ProgressEvaluationService(); // no dependencies -> plain construction
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/tracking/domain/ProgressEvaluationService.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/domain/ProgressEvaluationService.java
@@ -1,20 +1,28 @@
 package com.healthupgrades.tracking.domain;
 
-import org.springframework.stereotype.Service;
-
-@Service
+/**
+ * Pure domain service that decides whether a progress entry meets its tracking config's target.
+ *
+ * <p>Framework-free and stateless: the application layer provides it as a bean (see
+ * {@code TrackingBeansConfig}) instead of it being annotated as a Spring component.
+ */
 public class ProgressEvaluationService {
 
+    /**
+     * Returns whether the entry counts as a success for its configured tracking type: boolean
+     * completion, numeric value meeting the target, a rating of at least 3, or non-blank text.
+     */
     public boolean isSuccessful(ProgressEntry entry, TrackingConfig config) {
-        if (entry == null || config == null) return false;
+        if (entry == null || config == null) return false; // nothing to evaluate against
 
+        // The success rule depends on how this upgrade is tracked.
         return switch (config.getTrackingType()) {
-            case BOOLEAN -> Boolean.TRUE.equals(entry.getCompleted());
+            case BOOLEAN -> Boolean.TRUE.equals(entry.getCompleted()); // did-it / didn't
             case NUMERIC -> entry.getNumericValue() != null
                     && config.getTargetNumericValue() != null
-                    && entry.getNumericValue() >= config.getTargetNumericValue();
-            case RATING -> entry.getRating() != null && entry.getRating() >= 3;
-            case TEXT -> entry.getNote() != null && !entry.getNote().isBlank();
+                    && entry.getNumericValue() >= config.getTargetNumericValue(); // met the numeric target
+            case RATING -> entry.getRating() != null && entry.getRating() >= 3; // rated 3+ out of 5
+            case TEXT -> entry.getNote() != null && !entry.getNote().isBlank(); // wrote something
         };
     }
 }

--- a/backend/src/main/java/com/healthupgrades/tracking/domain/StreakCalculator.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/domain/StreakCalculator.java
@@ -1,34 +1,44 @@
 package com.healthupgrades.tracking.domain;
 
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Service
+/**
+ * Pure domain service that computes habit streaks from a list of progress entries.
+ *
+ * <p>Framework-free and stateless: the application layer provides it as a bean (see
+ * {@code TrackingBeansConfig}) instead of it being annotated as a Spring component.
+ */
 public class StreakCalculator {
 
+    /**
+     * Calculates the current consecutive-day completion streak. Counts back from today; if nothing was
+     * completed today yet, it counts back from yesterday so the streak is not prematurely broken.
+     */
     public int calculateCurrentStreak(List<ProgressEntry> entries) {
-        if (entries == null || entries.isEmpty()) return 0;
+        if (entries == null || entries.isEmpty()) return 0; // no data -> no streak
 
+        // Collect the distinct dates the user actually completed the habit.
         Set<LocalDate> completedDates = entries.stream()
                 .filter(e -> Boolean.TRUE.equals(e.getCompleted()))
                 .map(ProgressEntry::getDate)
                 .collect(Collectors.toSet());
 
-        if (completedDates.isEmpty()) return 0;
+        if (completedDates.isEmpty()) return 0; // logged entries but none completed
 
         LocalDate today = LocalDate.now();
         int streak = 0;
         LocalDate current = today;
 
+        // Walk backwards from today while each day was completed.
         while (completedDates.contains(current)) {
             streak++;
             current = current.minusDays(1);
         }
 
+        // If today has not been completed yet, count the run ending yesterday instead.
         if (streak == 0) {
             current = today.minusDays(1);
             while (completedDates.contains(current)) {
@@ -40,9 +50,11 @@ public class StreakCalculator {
         return streak;
     }
 
+    /** Calculates the longest run of consecutive completed days across the entire history. */
     public int calculateLongestStreak(List<ProgressEntry> entries) {
-        if (entries == null || entries.isEmpty()) return 0;
+        if (entries == null || entries.isEmpty()) return 0; // no data -> no streak
 
+        // Distinct completed dates, ascending, so consecutive runs are adjacent.
         List<LocalDate> sortedDates = entries.stream()
                 .filter(e -> Boolean.TRUE.equals(e.getCompleted()))
                 .map(ProgressEntry::getDate)
@@ -50,11 +62,12 @@ public class StreakCalculator {
                 .sorted()
                 .toList();
 
-        if (sortedDates.isEmpty()) return 0;
+        if (sortedDates.isEmpty()) return 0; // no completed days
 
-        int maxStreak = 1;
-        int currentStreak = 1;
+        int maxStreak = 1; // best run seen so far
+        int currentStreak = 1; // current run length
 
+        // Extend the run when the next date is exactly one day after the previous, else reset.
         for (int i = 1; i < sortedDates.size(); i++) {
             if (sortedDates.get(i).equals(sortedDates.get(i - 1).plusDays(1))) {
                 currentStreak++;

--- a/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeBeansConfig.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeBeansConfig.java
@@ -1,0 +1,21 @@
+package com.healthupgrades.upgrade.application;
+
+import com.healthupgrades.upgrade.domain.UpgradeSchedulingService; // pure domain service being exposed
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires the upgrade context's pure domain services as Spring beans.
+ *
+ * <p>Domain services are framework-free (no {@code @Service}), so the application layer — which is
+ * allowed to depend on Spring — is responsible for exposing them for constructor injection.
+ */
+@Configuration
+public class UpgradeBeansConfig {
+
+    /** Exposes the stateless {@link UpgradeSchedulingService} as an injectable bean. */
+    @Bean
+    public UpgradeSchedulingService upgradeSchedulingService() {
+        return new UpgradeSchedulingService(); // no dependencies -> plain construction
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/UpgradeSchedulingService.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/UpgradeSchedulingService.java
@@ -1,16 +1,15 @@
 package com.healthupgrades.upgrade.domain;
 
 import com.healthupgrades.common.exception.BusinessRuleException; // thrown when the invariant is violated
-import org.springframework.stereotype.Service;
 
 /**
  * Stateless domain service enforcing the scheduling invariant that a user may not run more than a fixed
  * number of HARD upgrades at the same time.
  *
  * <p>Pure by design: it receives the user's current active-HARD count and decides, leaving the counting
- * query to the application layer. This keeps the domain free of any repository/persistence dependency.
+ * query to the application layer. Framework-free — the application provides it as a bean (see
+ * {@code UpgradeBeansConfig}) rather than it being a Spring component.
  */
-@Service
 public class UpgradeSchedulingService {
 
     /** Maximum number of concurrently ACTIVE HARD upgrades a user may have. */


### PR DESCRIPTION
## Checkpoint 2 of the DDD + Hexagonal (Ports & Adapters) migration

Removes Spring from the domain services so the domain is framework-free (aside from the retained JPA annotations on entities). **No behavior or schema change.**

### What changed
- `StreakCalculator`, `ProgressEvaluationService` and `UpgradeSchedulingService` no longer carry `@Service` — they are plain, stateless, dependency-free domain classes.
- They are exposed as beans from the **application** layer via two new `@Configuration` classes (`UpgradeBeansConfig`, `TrackingBeansConfig`), so constructor injection into the application services is unchanged.

### Why
A pure domain must not depend on the framework. Moving bean wiring to the application layer is what lets the final ArchUnit rule forbid `org.springframework..` in `..domain..` (while still allowing `jakarta.persistence` on entities).

### Verification
- `mvn test` → **59 tests pass** (including the ArchUnit baseline).
- Runtime bean wiring is exercised end-to-end in the final checkpoint via `docker-compose up` (no Spring integration test / test DB exists in the repo yet).
