### PR TITLE
Hexagonal migration, phase 5: event + push outbound ports (and make docs/ local-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ Thumbs.db
 *.log
 logs/
 
+# docs
+docs/
+
 # Docker
 .docker/
 

--- a/backend/src/main/java/com/healthupgrades/common/events/DomainEventPublisher.java
+++ b/backend/src/main/java/com/healthupgrades/common/events/DomainEventPublisher.java
@@ -1,16 +1,14 @@
 package com.healthupgrades.common.events;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Component;
+/**
+ * Outbound port for publishing domain events in-process.
+ *
+ * <p>Application services depend on this abstraction; the Spring-backed implementation lives in an
+ * adapter ({@link SpringDomainEventPublisher}), so the application layer does not depend on Spring's
+ * event infrastructure directly.
+ */
+public interface DomainEventPublisher {
 
-@Component
-@RequiredArgsConstructor
-public class DomainEventPublisher {
-
-    private final ApplicationEventPublisher publisher;
-
-    public void publish(DomainEvent event) {
-        publisher.publishEvent(event);
-    }
+    /** Publishes a domain event to any interested (in-process) listeners. */
+    void publish(DomainEvent event);
 }

--- a/backend/src/main/java/com/healthupgrades/common/events/SpringDomainEventPublisher.java
+++ b/backend/src/main/java/com/healthupgrades/common/events/SpringDomainEventPublisher.java
@@ -1,0 +1,24 @@
+package com.healthupgrades.common.events;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adapter implementing {@link DomainEventPublisher} over Spring's {@link ApplicationEventPublisher}.
+ *
+ * <p>Delegating to the real Spring publisher is important: it keeps transaction-bound consumers
+ * ({@code @TransactionalEventListener(AFTER_COMMIT)}) firing exactly as before.
+ */
+@Component
+@RequiredArgsConstructor
+public class SpringDomainEventPublisher implements DomainEventPublisher {
+
+    private final ApplicationEventPublisher publisher; // Spring's in-process event bus
+
+    /** {@inheritDoc} */
+    @Override
+    public void publish(DomainEvent event) {
+        publisher.publishEvent(event); // hand off to Spring so existing listeners keep working
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/notification/adapter/out/messaging/StompNotificationPushAdapter.java
+++ b/backend/src/main/java/com/healthupgrades/notification/adapter/out/messaging/StompNotificationPushAdapter.java
@@ -1,0 +1,39 @@
+package com.healthupgrades.notification.adapter.out.messaging;
+
+import com.healthupgrades.notification.api.NotificationDto;
+import com.healthupgrades.notification.domain.Notification;
+import com.healthupgrades.notification.domain.port.out.NotificationPushPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * Outbound adapter implementing {@link NotificationPushPort} over STOMP/WebSocket.
+ *
+ * <p>Maps the domain {@link Notification} to the same {@link NotificationDto} wire shape the frontend
+ * already consumes and sends it to the user-scoped destination.
+ */
+@Component
+@RequiredArgsConstructor
+public class StompNotificationPushAdapter implements NotificationPushPort {
+
+    /** STOMP user-destination the frontend subscribes to (resolved per-connection via the principal). */
+    public static final String USER_QUEUE = "/queue/notifications";
+
+    private final SimpMessagingTemplate messagingTemplate; // Spring STOMP messaging
+
+    /** {@inheritDoc} */
+    @Override
+    public void push(UUID userId, Notification notification) {
+        // Routed to the session(s) whose STOMP principal name == userId (see JwtChannelInterceptor).
+        messagingTemplate.convertAndSendToUser(userId.toString(), USER_QUEUE, toDto(notification));
+    }
+
+    /** Maps a notification to its wire DTO (identical payload to the REST representation). */
+    private NotificationDto toDto(Notification n) {
+        return new NotificationDto(n.getId(), n.getType(), n.getCategory(), n.getTitle(), n.getMessage(),
+                n.getRelatedUpgradeId(), n.isRead(), n.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/healthupgrades/notification/application/NotificationService.java
@@ -5,9 +5,9 @@ import com.healthupgrades.notification.api.NotificationDto;
 import com.healthupgrades.notification.domain.Notification;
 import com.healthupgrades.notification.domain.NotificationCategory;
 import com.healthupgrades.notification.domain.NotificationType;
+import com.healthupgrades.notification.domain.port.out.NotificationPushPort;
 import com.healthupgrades.notification.domain.port.out.NotificationRepositoryPort;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -16,15 +16,18 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Application service for notifications: persistence, reads, and coordinating the real-time push.
+ *
+ * <p>The transport is behind {@link NotificationPushPort}; this service only decides <em>when</em> to
+ * push (after the surrounding transaction commits).
+ */
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
-    /** STOMP user-destination the frontend subscribes to (resolved per-connection via the principal). */
-    public static final String USER_QUEUE = "/queue/notifications";
-
-    private final NotificationRepositoryPort repository;
-    private final SimpMessagingTemplate messagingTemplate;
+    private final NotificationRepositoryPort repository; // outbound persistence port
+    private final NotificationPushPort pushPort; // outbound real-time delivery port
 
     /**
      * Persist a notification for a user, then push it in real time to any connected session. Offline
@@ -44,9 +47,8 @@ public class NotificationService {
                 .read(false)
                 .build());
 
-        NotificationDto dto = toDto(notification);
-        pushAfterCommit(userId, dto);
-        return dto;
+        pushAfterCommit(userId, notification);
+        return toDto(notification);
     }
 
     /**
@@ -54,28 +56,30 @@ public class NotificationService {
      * notification for a row that then rolls back. When there is no active transaction (defensive),
      * push immediately.
      */
-    private void pushAfterCommit(UUID userId, NotificationDto dto) {
-        // Routed to the session(s) whose STOMP principal name == userId (see JwtChannelInterceptor).
+    private void pushAfterCommit(UUID userId, Notification notification) {
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    messagingTemplate.convertAndSendToUser(userId.toString(), USER_QUEUE, dto);
+                    pushPort.push(userId, notification); // deliver once the write is durable
                 }
             });
         } else {
-            messagingTemplate.convertAndSendToUser(userId.toString(), USER_QUEUE, dto);
+            pushPort.push(userId, notification); // no active tx -> push now
         }
     }
 
+    /** The user's 50 most recent notifications, newest first. */
     public List<NotificationDto> listRecent(UUID userId) {
         return repository.findTop50ByUserIdOrderByCreatedAtDesc(userId).stream().map(this::toDto).toList();
     }
 
+    /** Count of the user's unread notifications. */
     public long unreadCount(UUID userId) {
         return repository.countByUserIdAndReadFalse(userId);
     }
 
+    /** Marks a single owned notification as read. */
     @Transactional
     public NotificationDto markRead(UUID userId, UUID id) {
         Notification notification = repository.findByIdAndUserId(id, userId)
@@ -84,11 +88,13 @@ public class NotificationService {
         return toDto(repository.save(notification));
     }
 
+    /** Marks all of the user's notifications as read. */
     @Transactional
     public void markAllRead(UUID userId) {
         repository.markAllReadForUser(userId);
     }
 
+    /** Maps a notification domain object to its web DTO. */
     private NotificationDto toDto(Notification n) {
         return new NotificationDto(n.getId(), n.getType(), n.getCategory(), n.getTitle(), n.getMessage(),
                 n.getRelatedUpgradeId(), n.isRead(), n.getCreatedAt());

--- a/backend/src/main/java/com/healthupgrades/notification/domain/port/out/NotificationPushPort.java
+++ b/backend/src/main/java/com/healthupgrades/notification/domain/port/out/NotificationPushPort.java
@@ -1,0 +1,17 @@
+package com.healthupgrades.notification.domain.port.out;
+
+import com.healthupgrades.notification.domain.Notification; // domain object pushed to the user
+
+import java.util.UUID;
+
+/**
+ * Outbound port for delivering a notification to a user in real time.
+ *
+ * <p>Keeps the transport (STOMP/WebSocket today) out of the application service — the service depends on
+ * this abstraction and an adapter performs the actual push.
+ */
+public interface NotificationPushPort {
+
+    /** Pushes a notification to the given user's real-time channel. */
+    void push(UUID userId, Notification notification);
+}

--- a/backend/src/test/java/com/healthupgrades/notification/application/NotificationServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/notification/application/NotificationServiceTest.java
@@ -4,13 +4,13 @@ import com.healthupgrades.notification.api.NotificationDto;
 import com.healthupgrades.notification.domain.Notification;
 import com.healthupgrades.notification.domain.NotificationCategory;
 import com.healthupgrades.notification.domain.NotificationType;
+import com.healthupgrades.notification.domain.port.out.NotificationPushPort;
 import com.healthupgrades.notification.domain.port.out.NotificationRepositoryPort;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 class NotificationServiceTest {
 
     @Mock NotificationRepositoryPort repository;
-    @Mock SimpMessagingTemplate messagingTemplate;
+    @Mock NotificationPushPort pushPort;
 
     @InjectMocks NotificationService service;
 
@@ -47,9 +47,8 @@ class NotificationServiceTest {
         assertThat(dto.read()).isFalse();
         assertThat(dto.relatedUpgradeId()).isEqualTo(upgradeId);
         verify(repository).save(any(Notification.class));
-        // pushed to the userId-named STOMP user destination
-        verify(messagingTemplate).convertAndSendToUser(eq(userId.toString()),
-                eq(NotificationService.USER_QUEUE), any(NotificationDto.class));
+        // pushed to the user's real-time channel via the outbound push port
+        verify(pushPort).push(eq(userId), any(Notification.class));
     }
 
     @Test

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,3 +1,0 @@
-# Requirements
-
-<!-- Placeholder — to be filled in. -->


### PR DESCRIPTION
## Checkpoint 5 of the DDD + Hexagonal (Ports & Adapters) migration

Puts the two remaining outbound side effects behind ports, and corrects the `docs/` tracking. **No behavior or wire-format change.**

### Backend
- **`DomainEventPublisher` is now an interface** (outbound port). New **`SpringDomainEventPublisher`** adapter wraps Spring's `ApplicationEventPublisher` — it still delegates to the real publisher, so `@TransactionalEventListener(AFTER_COMMIT)` consumers keep firing exactly as before. Application services that publish events are unchanged (they inject the interface).
- **`NotificationPushPort`** + **`StompNotificationPushAdapter`** (wraps `SimpMessagingTemplate`, maps `Notification` → the same `NotificationDto` payload, owns the `/queue/notifications` destination). `NotificationService` now depends on the port and keeps its `@Transactional` + after-commit push, passing the domain `Notification`.

### docs/ correction (per your clarification)
- Earlier PR #9 committed `docs/requirements.md`. This PR **stops tracking `docs/`** (`git rm --cached`, file kept locally) and **adds `docs/` to `.gitignore`**, so the folder and its contents stay on your machine only — not on GitHub. Separate `chore:` commit.

### Verification
- `mvn test` → **59 tests pass**. Real-time push + transactional event flow verified end-to-end at the final checkpoint via `docker-compose up`.
