### PR TITLE
Hexagonal migration, phase 7: enforce with ArchUnit + ADR

### DIFF
--- a/ADR-001-ddd-hexagonal-architecture.md
+++ b/ADR-001-ddd-hexagonal-architecture.md
@@ -1,0 +1,94 @@
+# ADR-001: Adopt Domain-Driven Design + Hexagonal (Ports & Adapters) for the backend
+
+- **Status:** Accepted
+- **Date:** 2026-07-09
+- **Scope:** `backend/` (Spring Boot 3 / Java 21). The React frontend is unaffected.
+
+## Context
+
+The backend already used a package-by-feature layout with `api / application / domain / infrastructure`
+folders, but the hexagonal boundaries were **nominal, not enforced**:
+
+- Domain entities were JPA `@Entity` classes with business logic mixed in.
+- The `User` entity implemented Spring Security's `UserDetails` (domain → framework).
+- The stateless domain services were Spring `@Service` beans, and one injected a JPA repository
+  (a domain → infrastructure dependency).
+- Application services depended on concrete Spring Data `JpaRepository` interfaces — there were no ports.
+- Bounded contexts called each other through concrete service classes, and web DTOs leaked across contexts.
+- Notifications used `SimpMessagingTemplate` directly; the domain event publisher was a concrete component.
+
+Nothing prevented these boundaries from eroding further over time.
+
+## Decision
+
+Adopt a **pragmatic Hexagonal (Ports & Adapters) + DDD** architecture, enforced by tests.
+
+### Key choices
+1. **Pragmatic purity.** The domain is framework-free **except** that entities keep their JPA mapping
+   annotations and remain the persistence model (no separate POJO + persistence-mapper duplication).
+2. **Enforced with ArchUnit** in a single Maven module (no multi-module split).
+3. **Canonical package layout**, identical for every bounded context
+   (`auth, user, healtharea, upgrade, tracking, reflection, reminder, dashboard, notification`):
+
+   | Package | Contents |
+   |---|---|
+   | `domain/model` | JPA entities, enums, value objects |
+   | `domain/service` | pure (framework-free) domain services |
+   | `domain/port/out` | outbound ports (repository SPI, push, event publisher) |
+   | `application` | `@Service` / `@Transactional` use-case orchestration; `*BeansConfig` wiring for domain services |
+   | `application/port/in` | inbound ports (use-case / query interfaces) + command/result records |
+   | `adapter/in/web` | controllers, request records, response DTOs, web mappers |
+   | `adapter/in/event`, `adapter/in/scheduling` | event listener / scheduler driving adapters (notification) |
+   | `adapter/out/persistence` | Spring Data `*JpaRepository` + the adapter implementing the outbound port |
+   | `adapter/out/messaging` | STOMP push adapter |
+
+   Cross-cutting `common/` is split into a framework-free shared kernel (`common/domain/event`,
+   `common/domain/exception`) and cross-cutting adapters (`common/adapter/out/event`,
+   `common/adapter/in/event`, `common/adapter/in/web`), plus `common/security` and `common/websocket`.
+
+### Patterns
+- **Outbound ports + adapters:** each aggregate has a `domain/port/out` repository port implemented by an
+  `adapter/out/persistence` adapter that delegates to a (package-private) Spring Data `*JpaRepository`.
+- **Inbound ports:** cross-context reads go through another context's `application/port/in` query ports and
+  return **domain objects**, never a repository or a foreign web DTO.
+- **Domain state machine stays on the entity** (`HealthUpgrade.plan/activate/…`); the max-concurrent-HARD
+  invariant is a **pure** domain service that receives the current count as a parameter.
+- **Security:** `SecurityUser` (a `UserDetails` wrapper) keeps Spring Security out of the `User` entity.
+- **Events & real-time push are outbound ports:** `DomainEventPublisher` (interface) +
+  `SpringDomainEventPublisher`; `NotificationPushPort` + `StompNotificationPushAdapter`. The publisher still
+  delegates to Spring's `ApplicationEventPublisher`, so `@TransactionalEventListener(AFTER_COMMIT)` is intact.
+
+### Enforced rules (`backend/src/test/.../architecture/HexagonalArchitectureTest.java`, ArchUnit)
+1. **Domain purity (strict):** `..domain..` must not depend on `org.springframework..`, `..adapter..`, or
+   `..application..`. (`jakarta.persistence` and `lombok` are intentionally allowed on entities.)
+2. **Application not on outbound adapters (strict):** `..application..` must not depend on `..adapter.out..`.
+3. **Spring Data confinement (strict):** only `..adapter.out.persistence..` may depend on Spring Data JPA.
+4. **Outbound ports are interfaces (strict):** everything in `..domain.port.out..` is an interface.
+5. **Bounded-context isolation:** contexts may depend on each other only through shared surfaces —
+   `common..`, another context's `..domain.model..`, `..application.port.in..`, or its published
+   `..adapter.in.web..` DTOs.
+
+### Pragmatic exception
+An application service **may** use its **own** context's `adapter/in/web` response DTOs (so most services
+still return/build their own DTOs). Only cross-context DTO leaks and any domain → adapter dependency are
+forbidden. `upgrade` and `dashboard` go further (services return domain; dedicated web mappers build the
+DTOs) because their DTOs compose data from other contexts.
+
+## Consequences
+
+**Positive**
+- Boundaries are now verified on every `mvn test`; violations fail the build.
+- The domain and application layers are framework-boundary-clean; every side effect (persistence, events,
+  real-time push) sits behind a port, making the core easy to unit-test without Spring.
+- Contexts are decoupled — cross-context traffic flows only through inbound ports returning domain objects.
+
+**Trade-offs**
+- More types (ports, adapters, mappers, command/result records) — deliberate, for testability and isolation.
+- The pragmatic DTO exception means the web boundary is not 100% textbook; response DTOs can still originate
+  in application services within their own context.
+- Entities remain JPA-annotated (pragmatic choice), so the domain model is not persistence-ignorant.
+
+**Neutral / notes**
+- No behavior or wire-format change was introduced by the migration; the PostgreSQL schema is unchanged
+  (Flyway-owned, Hibernate `ddl-auto: validate`). The migration landed as a sequence of independently
+  merged checkpoints.

--- a/backend/src/main/java/com/healthupgrades/auth/adapter/in/web/AuthController.java
+++ b/backend/src/main/java/com/healthupgrades/auth/adapter/in/web/AuthController.java
@@ -1,9 +1,10 @@
 package com.healthupgrades.auth.adapter.in.web;
 
+import com.healthupgrades.auth.application.AuthResult;
 import com.healthupgrades.auth.application.AuthService;
-import com.healthupgrades.auth.domain.model.TokenPair;
 import com.healthupgrades.common.security.SecurityUser;
 import com.healthupgrades.user.adapter.in.web.UserDto;
+import com.healthupgrades.user.domain.model.User;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -13,35 +14,54 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * Inbound web adapter for authentication. Drives {@link AuthService} (which returns domain results) and
+ * maps them to the {@link TokenPair} / {@link UserDto} HTTP responses.
+ */
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final AuthService authService;
+    private final AuthService authService; // application service
 
+    /** Registers a new user and returns a token pair. */
     @PostMapping("/register")
     public ResponseEntity<TokenPair> register(@Valid @RequestBody RegisterRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(authService.register(request.name(), request.email(), request.password()));
+                .body(toTokenPair(authService.register(request.name(), request.email(), request.password())));
     }
 
+    /** Authenticates and returns a token pair. */
     @PostMapping("/login")
     public ResponseEntity<TokenPair> login(@Valid @RequestBody LoginRequest request) {
-        return ResponseEntity.ok(authService.login(request.email(), request.password()));
+        return ResponseEntity.ok(toTokenPair(authService.login(request.email(), request.password())));
     }
 
+    /** Returns the authenticated user's public view. */
     @GetMapping("/me")
     public ResponseEntity<UserDto> me(@AuthenticationPrincipal SecurityUser principal) {
-        return ResponseEntity.ok(authService.getMe(principal.getUsername()));
+        return ResponseEntity.ok(toUserDto(authService.getMe(principal.getUsername())));
     }
 
+    /** Maps an auth result to the token-pair response. */
+    private TokenPair toTokenPair(AuthResult result) {
+        return new TokenPair(result.token(), toUserDto(result.user()));
+    }
+
+    /** Maps a domain user to its public DTO. */
+    private UserDto toUserDto(User user) {
+        return new UserDto(user.getId(), user.getName(), user.getEmail(), user.getCreatedAt());
+    }
+
+    /** Registration request body. */
     public record RegisterRequest(
             @NotBlank String name,
             @NotBlank @Email String email,
             @NotBlank String password
     ) {}
 
+    /** Login request body. */
     public record LoginRequest(
             @NotBlank @Email String email,
             @NotBlank String password

--- a/backend/src/main/java/com/healthupgrades/auth/adapter/in/web/TokenPair.java
+++ b/backend/src/main/java/com/healthupgrades/auth/adapter/in/web/TokenPair.java
@@ -1,0 +1,8 @@
+package com.healthupgrades.auth.adapter.in.web;
+
+import com.healthupgrades.user.adapter.in.web.UserDto; // reused published presentation model
+
+/**
+ * Web response for a successful authentication: the issued JWT plus the authenticated user's public view.
+ */
+public record TokenPair(String token, UserDto user) {}

--- a/backend/src/main/java/com/healthupgrades/auth/application/AuthResult.java
+++ b/backend/src/main/java/com/healthupgrades/auth/application/AuthResult.java
@@ -1,0 +1,9 @@
+package com.healthupgrades.auth.application;
+
+import com.healthupgrades.user.domain.model.User; // the authenticated domain user
+
+/**
+ * Result of an authentication use case, expressed with domain objects: the issued JWT and the
+ * authenticated {@link User}. The web adapter maps this to the HTTP response.
+ */
+public record AuthResult(String token, User user) {}

--- a/backend/src/main/java/com/healthupgrades/auth/application/AuthService.java
+++ b/backend/src/main/java/com/healthupgrades/auth/application/AuthService.java
@@ -1,9 +1,7 @@
 package com.healthupgrades.auth.application;
 
-import com.healthupgrades.auth.domain.model.TokenPair;
 import com.healthupgrades.common.domain.exception.BusinessRuleException;
 import com.healthupgrades.common.security.JwtTokenProvider;
-import com.healthupgrades.user.adapter.in.web.UserDto;
 import com.healthupgrades.user.application.port.in.UserDirectory;
 import com.healthupgrades.user.domain.model.User;
 import lombok.RequiredArgsConstructor;
@@ -13,46 +11,47 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Application service for authentication.
+ *
+ * <p>Reads and writes users through the user context's {@link UserDirectory} inbound port and returns
+ * domain results ({@link AuthResult} / {@link User}); the web adapter maps them to HTTP responses.
+ */
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
-    private final UserDirectory userDirectory;
-    private final PasswordEncoder passwordEncoder;
-    private final JwtTokenProvider tokenProvider;
-    private final AuthenticationManager authenticationManager;
+    private final UserDirectory userDirectory; // inbound port of the user context
+    private final PasswordEncoder passwordEncoder; // BCrypt encoder
+    private final JwtTokenProvider tokenProvider; // issues JWTs
+    private final AuthenticationManager authenticationManager; // verifies credentials on login
 
+    /** Registers a new user (rejecting a duplicate email) and issues a token. */
     @Transactional
-    public TokenPair register(String name, String email, String password) {
+    public AuthResult register(String name, String email, String password) {
         if (userDirectory.existsByEmail(email)) {
             throw new BusinessRuleException("Email already registered: " + email);
         }
         User user = User.builder()
                 .name(name)
                 .email(email)
-                .passwordHash(passwordEncoder.encode(password))
+                .passwordHash(passwordEncoder.encode(password)) // never store the raw password
                 .build();
         user = userDirectory.save(user);
-        String token = tokenProvider.generateToken(user.getEmail());
-        return new TokenPair(token, toDto(user));
+        return new AuthResult(tokenProvider.generateToken(user.getEmail()), user);
     }
 
-    public TokenPair login(String email, String password) {
-        authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(email, password));
+    /** Authenticates credentials and issues a token. */
+    public AuthResult login(String email, String password) {
+        authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password)); // throws on bad creds
         User user = userDirectory.findByEmail(email)
                 .orElseThrow(() -> new BusinessRuleException("User not found"));
-        String token = tokenProvider.generateToken(user.getEmail());
-        return new TokenPair(token, toDto(user));
+        return new AuthResult(tokenProvider.generateToken(user.getEmail()), user);
     }
 
-    public UserDto getMe(String email) {
-        User user = userDirectory.findByEmail(email)
+    /** Returns the current user by email (the JWT subject). */
+    public User getMe(String email) {
+        return userDirectory.findByEmail(email)
                 .orElseThrow(() -> new BusinessRuleException("User not found"));
-        return toDto(user);
-    }
-
-    private UserDto toDto(User user) {
-        return new UserDto(user.getId(), user.getName(), user.getEmail(), user.getCreatedAt());
     }
 }

--- a/backend/src/main/java/com/healthupgrades/auth/domain/model/TokenPair.java
+++ b/backend/src/main/java/com/healthupgrades/auth/domain/model/TokenPair.java
@@ -1,5 +1,0 @@
-package com.healthupgrades.auth.domain.model;
-
-import com.healthupgrades.user.adapter.in.web.UserDto;
-
-public record TokenPair(String token, UserDto user) {}

--- a/backend/src/test/java/com/healthupgrades/architecture/HexagonalArchitectureTest.java
+++ b/backend/src/test/java/com/healthupgrades/architecture/HexagonalArchitectureTest.java
@@ -4,22 +4,80 @@ import com.tngtech.archunit.core.importer.ImportOption; // controls which classe
 import com.tngtech.archunit.junit.AnalyzeClasses; // declares the packages ArchUnit imports for this test
 import com.tngtech.archunit.junit.ArchTest; // marks a field as an executable architecture rule
 import com.tngtech.archunit.lang.ArchRule; // the type of a single architecture rule
+import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition; // builds bounded-context slice rules
 
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes; // entry point for building rules
+import static com.tngtech.archunit.base.DescribedPredicate.alwaysTrue; // matches any origin class
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAnyPackage; // package predicate for ignores
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes; // entry point for positive rules
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses; // entry point for forbidding rules
 
 /**
- * Verifies the hexagonal (ports and adapters) architecture constraints of the backend.
+ * Enforces the hexagonal (ports and adapters) architecture of the backend.
  *
- * <p>The full rule set (domain purity with a JPA carve-out, application/adapter separation,
- * Spring Data confinement, outbound ports as interfaces, and bounded-context isolation) is
- * introduced incrementally as the migration progresses and fully enforced in the final phase.
- * Until then this class holds a single baseline sanity rule so the test suite stays green.
+ * <p>This is the "pragmatic" rule set: the domain is kept strictly framework-free (apart from the JPA
+ * mapping annotations the entities carry), Spring Data is confined to the persistence adapters, outbound
+ * ports are interfaces, and bounded contexts talk to each other only through shared surfaces (another
+ * context's inbound ports, domain model, published web DTOs, or the common shared kernel). An application
+ * service is allowed to use its own context's web DTOs.
  */
-@AnalyzeClasses(packages = "com.healthupgrades", importOptions = ImportOption.DoNotIncludeTests.class) // analyse only production classes under the root package
+@AnalyzeClasses(packages = "com.healthupgrades", importOptions = ImportOption.DoNotIncludeTests.class) // analyse only production classes
 class HexagonalArchitectureTest {
 
-    /** Baseline sanity check: every analysed production class lives under the project root package. */
-    @ArchTest // executed by the ArchUnit JUnit 5 runner
-    static final ArchRule all_production_code_lives_under_the_root_package =
-            classes().should().resideInAPackage("com.healthupgrades.."); // trivially true today; confirms ArchUnit is wired
+    /**
+     * The domain must not depend on Spring, on adapters, or on the application layer. JPA
+     * ({@code jakarta.persistence}) and Lombok are deliberately absent from the forbidden list, so the
+     * entities may keep their persistence-mapping annotations.
+     */
+    @ArchTest
+    static final ArchRule domain_is_free_of_framework_and_outer_layers =
+            noClasses().that().resideInAPackage("..domain..")
+                    .should().dependOnClassesThat().resideInAnyPackage(
+                            "org.springframework..", "..adapter..", "..application..")
+                    .as("the domain must not depend on Spring, adapters, or the application layer");
+
+    /**
+     * The application layer must not depend on outbound adapters — it drives them through outbound ports
+     * (persistence, messaging, events) instead.
+     */
+    @ArchTest
+    static final ArchRule application_does_not_depend_on_outbound_adapters =
+            noClasses().that().resideInAPackage("..application..")
+                    .should().dependOnClassesThat().resideInAPackage("..adapter.out..")
+                    .as("the application layer must not depend on outbound adapters");
+
+    /**
+     * Spring Data JPA may only be referenced from the persistence adapters, guaranteeing repositories are
+     * hidden behind outbound ports everywhere else.
+     */
+    @ArchTest
+    static final ArchRule spring_data_only_in_persistence_adapters =
+            noClasses().that().resideOutsideOfPackage("..adapter.out.persistence..")
+                    .should().dependOnClassesThat().resideInAnyPackage(
+                            "org.springframework.data.jpa..", "org.springframework.data.repository..")
+                    .as("Spring Data JPA must be used only in persistence adapters");
+
+    /** Outbound ports are contracts, so everything under {@code domain.port.out} must be an interface. */
+    @ArchTest
+    static final ArchRule outbound_ports_are_interfaces =
+            classes().that().resideInAPackage("..domain.port.out..")
+                    .should().beInterfaces()
+                    .as("outbound ports must be interfaces");
+
+    /**
+     * Bounded contexts must not depend on each other's internals. Cross-context dependencies are allowed
+     * only to shared surfaces: the common shared kernel, another context's domain model, its inbound
+     * ports, or its published web DTOs.
+     */
+    @ArchTest
+    static final ArchRule bounded_contexts_only_share_through_ports_and_published_models =
+            SlicesRuleDefinition.slices()
+                    .matching("com.healthupgrades.(*)..") // one slice per top-level package (context)
+                    .namingSlices("$1")
+                    .as("bounded contexts")
+                    .should().notDependOnEachOther()
+                    .ignoreDependency(alwaysTrue(), resideInAnyPackage(
+                            "com.healthupgrades.common..", // shared kernel + cross-cutting adapters
+                            "..domain.model..",            // another context's domain model is shareable
+                            "..application.port.in..",     // another context's inbound ports (the sanctioned entry)
+                            "..adapter.in.web.."));        // published web DTOs (presentation models)
 }


### PR DESCRIPTION
## Checkpoint 7 (final) of the DDD + Hexagonal (Ports & Adapters) migration

Switches on the full ArchUnit rule set (pragmatic enforce), removes the last boundary leak, and documents everything in an ADR. **No behavior or schema change.**

### Auth boundary fix
- `AuthService` now returns domain results (`AuthResult` / `User`); `TokenPair` moves to `auth/adapter/in/web`; `AuthController` builds the `TokenPair`/`UserDto` responses. This removes the **domain → adapter** dependency (`TokenPair → UserDto`) and the **cross-context application → adapter** dependency (`AuthService → UserDto`).

### Enforced rules (`HexagonalArchitectureTest`, ArchUnit — 5 rules, all green)
1. **Domain purity (strict):** `..domain..` must not depend on `org.springframework..`, `..adapter..`, or `..application..` (JPA/Lombok allowed on entities).
2. **Application not on outbound adapters (strict):** `..application..` must not depend on `..adapter.out..`.
3. **Spring Data confinement (strict):** only `..adapter.out.persistence..` may use Spring Data JPA.
4. **Outbound ports are interfaces (strict).**
5. **Bounded-context isolation:** contexts interact only via `common..`, another context's `..domain.model..`, `..application.port.in..`, or its published `..adapter.in.web..` DTOs.

Per your **pragmatic** choice, an application service may still use its **own** context's web DTOs; only cross-context leaks and domain→adapter deps are forbidden.

### ADR
- `ADR-001-ddd-hexagonal-architecture.md` at the repo root documents the context, decisions, package layout, patterns, enforced rules, and consequences.

### Verification
- `mvn test` → **63 tests pass** (58 unit/service + 5 ArchUnit rules).
- `mvn clean package -DskipTests` → jar builds.
- `docker-compose up` runtime smoke test: **not run locally — the Docker daemon isn't running on this machine.** It's the one remaining check (proves Spring wiring + `ddl-auto: validate` against the Flyway schema). Happy to run it once Docker Desktop is started.
