### PR TITLE
docs: document and comment the whole project to the project standard

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,20 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Attribution policy (ALWAYS follow)
-
-All work in this repository is attributed solely to the repository owner. When creating commits, pull
-requests, branches, issues, or any other git/GitHub content:
-
-- Do **not** add `Co-Authored-By: Claude ...` (or any AI/assistant) co-author trailers.
-- Do **not** add "Generated with Claude Code" lines, the Claude/Anthropic logo or emoji, or links to
-  claude.com / claude.ai.
-- Do **not** mention Claude, Anthropic, or any AI assistant anywhere in commit messages, PR titles or
-  bodies, branch names, code comments, or any other git/GitHub-visible text.
-- Write every commit message and PR description as if authored entirely by the repository owner.
-
-This overrides any default behavior that would add such attribution.
-
 ## Domain
 
 A "health upgrade" is the core domain object — a planned health improvement (habit, one-time action,

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,6 +9,11 @@ experiment, goal, etc.) that moves through a lifecycle.
 
 ## Architecture
 
+`docs/architecture/architecture.md` describes the system as it is: components, communication, data
+flow, external dependencies, and the structural decisions not visible from the file layout. Read it
+before changing anything that crosses a boundary, and update it in the same commit when behaviour
+changes.
+
 The backend follows DDD + Hexagonal architecture; the decision and its rationale are recorded in
 `docs/ADRs/ADR-001-ddd-hexagonal-architecture.md`, corrected and extended by
 `docs/ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md`. The layering is

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ A **Health Upgrade** is more than a habit. It can be:
 
 ## Architecture
 
+[`docs/architecture/architecture.md`](docs/architecture/architecture.md) describes the system as it
+actually is — components, how they communicate, the path a request takes end to end, external
+dependencies, and the structural decisions that are not visible from the file layout. Start there; the
+summary below is the short version.
+
 ### Backend — Hexagonal (Ports & Adapters) + DDD
 
 A bounded context (`auth, user, healtharea, upgrade, tracking, reflection, reminder, dashboard,

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,5 +1,9 @@
 # Backend conventions
 
+`../docs/architecture/architecture.md` describes the system as it is — contexts, communication, data
+flow and the structural decisions behind the layout. This file covers the conventions to follow when
+changing it.
+
 Architecture is DDD + Hexagonal. The decision and its rationale are recorded in
 `../docs/ADRs/ADR-001-ddd-hexagonal-architecture.md`, corrected and extended by
 `../docs/ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md`. The layering is

--- a/backend/src/main/java/com/healthupgrades/HealthUpgradesApplication.java
+++ b/backend/src/main/java/com/healthupgrades/HealthUpgradesApplication.java
@@ -7,9 +7,21 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.time.Clock;
 
+/**
+ * Spring Boot entry point for the HealthUpgrades API.
+ *
+ * <p>Scheduling is enabled here because two driving adapters are scheduled jobs rather than HTTP
+ * endpoints: {@code UpgradeOverdueScheduler} and {@code NotificationScheduler}.
+ */
 @SpringBootApplication
 @EnableScheduling
 public class HealthUpgradesApplication {
+
+    /**
+     * Boots the application context.
+     *
+     * @param args standard Spring Boot command-line arguments
+     */
     public static void main(String[] args) {
         SpringApplication.run(HealthUpgradesApplication.class, args);
     }

--- a/backend/src/main/java/com/healthupgrades/auth/adapter/in/web/AuthController.java
+++ b/backend/src/main/java/com/healthupgrades/auth/adapter/in/web/AuthController.java
@@ -25,20 +25,40 @@ public class AuthController {
 
     private final AuthService authService; // application service
 
-    /** Registers a new user and returns a token pair. */
+    /**
+     * Registers a new user and issues a token.
+     *
+     * @param request name, email and password; all validated as non-blank, the email as well-formed
+     * @return 201 with the JWT and the new user's public view
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if the email is already
+     *         registered (surfaces as 422)
+     */
     @PostMapping("/register")
     public ResponseEntity<TokenPair> register(@Valid @RequestBody RegisterRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(toTokenPair(authService.register(request.name(), request.email(), request.password())));
     }
 
-    /** Authenticates and returns a token pair. */
+    /**
+     * Authenticates credentials and issues a token.
+     *
+     * @param request email and password
+     * @return 200 with the JWT and the user's public view
+     * @throws org.springframework.security.core.AuthenticationException if the credentials do not match
+     *         (surfaces as 401; the response never says which half was wrong)
+     */
     @PostMapping("/login")
     public ResponseEntity<TokenPair> login(@Valid @RequestBody LoginRequest request) {
         return ResponseEntity.ok(toTokenPair(authService.login(request.email(), request.password())));
     }
 
-    /** Returns the authenticated user's public view. */
+    /**
+     * Returns the caller's own profile — the endpoint the frontend uses to restore a session from a
+     * stored token.
+     *
+     * @param principal the authenticated principal, injected by Spring Security from the bearer token
+     * @return 200 with the user's public view
+     */
     @GetMapping("/me")
     public ResponseEntity<UserDto> me(@AuthenticationPrincipal SecurityUser principal) {
         return ResponseEntity.ok(toUserDto(authService.getMe(principal.getUsername())));

--- a/backend/src/main/java/com/healthupgrades/auth/application/AuthService.java
+++ b/backend/src/main/java/com/healthupgrades/auth/application/AuthService.java
@@ -28,7 +28,17 @@ public class AuthService {
     private final JwtTokenProvider tokenProvider; // issues JWTs
     private final AuthenticationManager authenticationManager; // verifies credentials on login
 
-    /** Registers a new user (rejecting a duplicate email) and issues a token. */
+    /**
+     * Registers a new user and issues a token for them.
+     *
+     * <p>The password is BCrypt-encoded before the user is saved; the raw value never leaves this method.
+     *
+     * @param name     display name
+     * @param email    login identity, unique across users
+     * @param password raw password, encoded here
+     * @return the issued JWT together with the persisted user
+     * @throws BusinessRuleException if the email is already registered
+     */
     @Transactional
     public AuthResult register(String name, String email, String password) {
         if (userQuery.existsByEmail(email)) {
@@ -43,7 +53,16 @@ public class AuthService {
         return new AuthResult(tokenProvider.generateToken(user.getEmail()), user);
     }
 
-    /** Authenticates credentials and issues a token. */
+    /**
+     * Authenticates credentials and issues a token.
+     *
+     * @param email    login identity
+     * @param password raw password, matched against the stored hash by the authentication manager
+     * @return the issued JWT together with the authenticated user
+     * @throws org.springframework.security.core.AuthenticationException if the credentials do not match
+     * @throws BusinessRuleException if the credentials matched but the user has since disappeared —
+     *         only reachable if the account is deleted mid-request
+     */
     public AuthResult login(String email, String password) {
         authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password)); // throws on bad creds
         User user = userQuery.findByEmail(email)
@@ -51,7 +70,13 @@ public class AuthService {
         return new AuthResult(tokenProvider.generateToken(user.getEmail()), user);
     }
 
-    /** Returns the current user by email (the JWT subject). */
+    /**
+     * Looks up the current user by the email carried as the JWT subject.
+     *
+     * @param email the authenticated principal's email
+     * @return the domain user
+     * @throws BusinessRuleException if no user has that email
+     */
     public User getMe(String email) {
         return userQuery.findByEmail(email)
                 .orElseThrow(() -> new BusinessRuleException("User not found"));

--- a/backend/src/main/java/com/healthupgrades/common/adapter/in/web/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/healthupgrades/common/adapter/in/web/GlobalExceptionHandler.java
@@ -14,33 +14,71 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Single place where an exception becomes an HTTP status and an error body.
+ *
+ * <p>This is the whole exception → status contract, so controllers and services never build a status
+ * by hand; they throw the domain exception that says what went wrong and this advice decides how it
+ * surfaces:
+ *
+ * <table>
+ *   <caption>Exception to status mapping</caption>
+ *   <tr><th>Exception</th><th>Status</th></tr>
+ *   <tr><td>{@link ResourceNotFoundException}</td><td>404 Not Found</td></tr>
+ *   <tr><td>{@link BusinessRuleException}</td><td>422 Unprocessable Entity</td></tr>
+ *   <tr><td>{@link DuplicateProgressException}</td><td>409 Conflict</td></tr>
+ *   <tr><td>{@link OptimisticLockException} and the JPA one</td><td>409 Conflict</td></tr>
+ *   <tr><td>{@link MethodArgumentNotValidException}</td><td>400 Bad Request, with field errors</td></tr>
+ *   <tr><td>{@link AccessDeniedException}</td><td>403 Forbidden</td></tr>
+ *   <tr><td>anything else</td><td>500 Internal Server Error, message withheld</td></tr>
+ * </table>
+ *
+ * <p>The mapping is pinned by {@code GlobalExceptionHandlerTest}; changing a status here is a wire
+ * contract change and breaks that test on purpose.
+ */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /** Maps a missing (or foreign-owned) resource to 404. */
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleNotFound(ResourceNotFoundException ex, HttpServletRequest req) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage(), req.getRequestURI()));
     }
 
+    /**
+     * Maps a violated domain rule to 422 — the request was understood and well-formed, but the domain
+     * refuses it (illegal transition, HARD-slot limit).
+     */
     @ExceptionHandler(BusinessRuleException.class)
     public ResponseEntity<ErrorResponse> handleBusinessRule(BusinessRuleException ex, HttpServletRequest req) {
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
                 .body(new ErrorResponse(HttpStatus.UNPROCESSABLE_ENTITY.value(), ex.getMessage(), req.getRequestURI()));
     }
 
+    /** Maps a second progress entry for the same upgrade and day to 409. */
     @ExceptionHandler(DuplicateProgressException.class)
     public ResponseEntity<ErrorResponse> handleDuplicateProgress(DuplicateProgressException ex, HttpServletRequest req) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(new ErrorResponse(HttpStatus.CONFLICT.value(), ex.getMessage(), req.getRequestURI()));
     }
 
+    /**
+     * Maps a concurrent-edit conflict to 409, from either the domain or the JPA exception.
+     *
+     * <p>The original message is replaced: a version clash is meaningless to a client, whereas "retry"
+     * is the action it can actually take.
+     */
     @ExceptionHandler({OptimisticLockException.class, jakarta.persistence.OptimisticLockException.class})
     public ResponseEntity<ErrorResponse> handleOptimisticLock(Exception ex, HttpServletRequest req) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(new ErrorResponse(HttpStatus.CONFLICT.value(), "Resource was modified concurrently. Please retry.", req.getRequestURI()));
     }
 
+    /**
+     * Maps bean-validation failures on a request body to 400, with a field → message map so the client
+     * can attach each message to the input that produced it.
+     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest req) {
         Map<String, String> errors = new HashMap<>();
@@ -52,18 +90,31 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
+    /** Maps a Spring Security authorization failure to 403. */
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException ex, HttpServletRequest req) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(new ErrorResponse(HttpStatus.FORBIDDEN.value(), "Access denied", req.getRequestURI()));
     }
 
+    /**
+     * Catch-all for anything unmapped: 500 with a fixed message.
+     *
+     * <p>The exception's own message is deliberately withheld — an unanticipated failure can carry a
+     * stack detail, a SQL fragment or a value that must not reach a client.
+     */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGeneral(Exception ex, HttpServletRequest req) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Internal server error", req.getRequestURI()));
     }
 
+    /**
+     * The error body every failed request returns.
+     *
+     * <p>{@code fieldErrors} is populated only for validation failures and is omitted from the JSON
+     * otherwise (it is null, and null fields are not serialized).
+     */
     public static class ErrorResponse {
         private int status;
         private String message;
@@ -71,6 +122,11 @@ public class GlobalExceptionHandler {
         private LocalDateTime timestamp;
         private Map<String, String> fieldErrors;
 
+        /**
+         * @param status  HTTP status code, repeated in the body for clients that only read the payload
+         * @param message user-facing description of the failure
+         * @param path    request URI that failed, for correlating a report with a log line
+         */
         public ErrorResponse(int status, String message, String path) {
             this.status = status;
             this.message = message;

--- a/backend/src/main/java/com/healthupgrades/common/domain/event/DomainEvent.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/event/DomainEvent.java
@@ -2,6 +2,19 @@ package com.healthupgrades.common.domain.event;
 
 import java.time.LocalDateTime;
 
+/**
+ * Marker for an in-process domain event.
+ *
+ * <p>This marker is the only event type shared between bounded contexts: each event itself belongs to
+ * the context that raises it ({@code upgrade/domain/event}, {@code tracking/domain/event},
+ * {@code reflection/domain/event}), because a context's events are part of its published language.
+ * See ADR-002.
+ *
+ * <p>Implementations are records and must be immutable — an event states something that already
+ * happened, so it cannot be edited after the fact.
+ */
 public interface DomainEvent {
+
+    /** When the state change this event describes occurred. */
     LocalDateTime occurredAt();
 }

--- a/backend/src/main/java/com/healthupgrades/common/domain/exception/BusinessRuleException.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/exception/BusinessRuleException.java
@@ -1,6 +1,15 @@
 package com.healthupgrades.common.domain.exception;
 
+/**
+ * Thrown when an operation is well-formed but violates a domain rule — an illegal state transition,
+ * or the max-concurrent-HARD-upgrade limit.
+ *
+ * <p>Mapped to HTTP 422 (Unprocessable Entity) by {@code GlobalExceptionHandler}. The message reaches
+ * the client verbatim, so it must be phrased for a user and must not carry internal detail.
+ */
 public class BusinessRuleException extends RuntimeException {
+
+    /** @param message user-facing explanation of which rule was violated */
     public BusinessRuleException(String message) {
         super(message);
     }

--- a/backend/src/main/java/com/healthupgrades/common/domain/exception/DuplicateProgressException.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/exception/DuplicateProgressException.java
@@ -1,6 +1,16 @@
 package com.healthupgrades.common.domain.exception;
 
+/**
+ * Thrown when a progress entry already exists for the same upgrade and date.
+ *
+ * <p>One entry per upgrade per day is a domain invariant, also backed by a unique constraint in the
+ * schema. Mapped to HTTP 409 (Conflict) by {@code GlobalExceptionHandler} — separate from
+ * {@link BusinessRuleException} precisely because the client should treat it as a conflict to resolve
+ * (edit the existing entry) rather than as invalid input.
+ */
 public class DuplicateProgressException extends RuntimeException {
+
+    /** @param message user-facing explanation naming the upgrade and date that already have an entry */
     public DuplicateProgressException(String message) {
         super(message);
     }

--- a/backend/src/main/java/com/healthupgrades/common/domain/exception/OptimisticLockException.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/exception/OptimisticLockException.java
@@ -1,6 +1,16 @@
 package com.healthupgrades.common.domain.exception;
 
+/**
+ * Thrown when a concurrent edit is detected — the aggregate's {@code @Version} moved between load and
+ * save.
+ *
+ * <p>Domain-level counterpart to {@code jakarta.persistence.OptimisticLockException}, so the
+ * application layer can signal the conflict without leaking JPA. Both are mapped to HTTP 409
+ * (Conflict) by {@code GlobalExceptionHandler}, which replaces the message with a retry instruction.
+ */
 public class OptimisticLockException extends RuntimeException {
+
+    /** @param message diagnostic description of the conflicting update */
     public OptimisticLockException(String message) {
         super(message);
     }

--- a/backend/src/main/java/com/healthupgrades/common/domain/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/exception/ResourceNotFoundException.java
@@ -1,6 +1,15 @@
 package com.healthupgrades.common.domain.exception;
 
+/**
+ * Thrown when a requested resource does not exist <em>for the requesting user</em>.
+ *
+ * <p>Every repository query is scoped by user id, so a row that belongs to somebody else is
+ * indistinguishable from one that does not exist. That is deliberate: answering 403 would confirm the
+ * resource exists. Mapped to HTTP 404 (Not Found) by {@code GlobalExceptionHandler}.
+ */
 public class ResourceNotFoundException extends RuntimeException {
+
+    /** @param message user-facing description of what was not found */
     public ResourceNotFoundException(String message) {
         super(message);
     }

--- a/backend/src/main/java/com/healthupgrades/common/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/healthupgrades/common/security/JwtAuthenticationFilter.java
@@ -15,6 +15,13 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+/**
+ * Populates the security context from a {@code Bearer} token on every HTTP request.
+ *
+ * <p>Registered before {@code UsernamePasswordAuthenticationFilter} by {@link SecurityConfig}. Its
+ * WebSocket counterpart is {@code JwtChannelInterceptor}, which authenticates the STOMP CONNECT frame
+ * instead — the two exist because the JWT arrives in a different place on each transport.
+ */
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -22,6 +29,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider tokenProvider;
     private final UserDetailsServiceImpl userDetailsService;
 
+    /**
+     * Authenticates the request when it carries a valid token, then continues the chain either way.
+     *
+     * <p>A missing or invalid token is not rejected here: the request simply stays anonymous and the
+     * authorization rules decide. That is what lets the permitted endpoints ({@code /api/auth/**},
+     * {@code /actuator/**}) work without a token while everything else returns 401.
+     */
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
@@ -30,6 +44,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
         if (StringUtils.hasText(token) && tokenProvider.validateToken(token)) {
             String email = tokenProvider.extractEmail(token);
+            // Re-loading on every request is what makes a deleted account stop working immediately,
+            // rather than at token expiry.
             UserDetails userDetails = userDetailsService.loadUserByUsername(email);
             UsernamePasswordAuthenticationToken auth =
                     new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
@@ -39,6 +55,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    /** Extracts the token from an {@code Authorization: Bearer <token>} header, or null if absent. */
     private String resolveToken(HttpServletRequest request) {
         String bearer = request.getHeader("Authorization");
         if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {

--- a/backend/src/main/java/com/healthupgrades/common/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/healthupgrades/common/security/JwtTokenProvider.java
@@ -9,12 +9,28 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
+/**
+ * Issues and verifies the HMAC-signed JWTs this API authenticates with.
+ *
+ * <p>The token carries the user's email as its subject and nothing else — no roles, no user id. Every
+ * request therefore re-loads the user, which keeps a deleted or renamed account from staying usable for
+ * the lifetime of an already-issued token.
+ *
+ * <p>The signing key is derived from {@code app.jwt.secret}. It must be at least 256 bits, or
+ * {@link Keys#hmacShaKeyFor} rejects it at startup — deliberately, so a too-short secret fails the boot
+ * rather than weakening every token silently.
+ */
 @Component
 public class JwtTokenProvider {
 
     private final SecretKey secretKey;
     private final long expirationMs;
 
+    /**
+     * @param secret       HMAC signing secret, at least 256 bits ({@code app.jwt.secret})
+     * @param expirationMs token lifetime in milliseconds ({@code app.jwt.expiration})
+     * @throws io.jsonwebtoken.security.WeakKeyException if the secret is shorter than 256 bits
+     */
     public JwtTokenProvider(
             @Value("${app.jwt.secret}") String secret,
             @Value("${app.jwt.expiration}") long expirationMs) {
@@ -22,6 +38,12 @@ public class JwtTokenProvider {
         this.expirationMs = expirationMs;
     }
 
+    /**
+     * Issues a signed token for the given user.
+     *
+     * @param email the user's email, stored as the token subject
+     * @return a compact, signed JWT valid for the configured lifetime
+     */
     public String generateToken(String email) {
         return Jwts.builder()
                 .subject(email)
@@ -31,6 +53,14 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    /**
+     * Reads the subject out of a token, verifying the signature first.
+     *
+     * @param token compact JWT
+     * @return the email the token was issued for
+     * @throws JwtException if the signature, structure or expiry does not check out — callers must
+     *                      therefore call {@link #validateToken} first, or be prepared to handle it
+     */
     public String extractEmail(String token) {
         return Jwts.parser()
                 .verifyWith(secretKey)
@@ -40,6 +70,12 @@ public class JwtTokenProvider {
                 .getSubject();
     }
 
+    /**
+     * Reports whether a token is well-formed, correctly signed and unexpired.
+     *
+     * @param token candidate JWT, from an {@code Authorization} header or a STOMP header
+     * @return true if the token can be trusted
+     */
     public boolean validateToken(String token) {
         try {
             Jwts.parser()
@@ -48,6 +84,9 @@ public class JwtTokenProvider {
                     .parseSignedClaims(token);
             return true;
         } catch (JwtException | IllegalArgumentException e) {
+            // A rejected token is an expected outcome on a public endpoint, not a fault: the caller's
+            // contract is a boolean, and the reason is withheld on purpose — telling an unauthenticated
+            // caller whether a token expired or was forged is free information for an attacker.
             return false;
         }
     }

--- a/backend/src/main/java/com/healthupgrades/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/healthupgrades/common/security/SecurityConfig.java
@@ -23,6 +23,15 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Web security wiring: a stateless, token-authenticated API.
+ *
+ * <p>Defines the filter chain, the password encoder, the DAO authentication provider used by the login
+ * endpoint, and the CORS policy. Authorization is coarse — a request is either on the small permitted
+ * list or it needs a valid token. Ownership is <em>not</em> decided here: every query is scoped by user
+ * id at the repository, so one user cannot read another's rows even though both are "authenticated"
+ * (see {@code backend/CLAUDE.md}).
+ */
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -34,6 +43,14 @@ public class SecurityConfig {
     @Value("${app.cors.allowed-origins:http://localhost:3000}")
     private String allowedOrigins;
 
+    /**
+     * Builds the filter chain: stateless sessions, CORS from configuration, and the JWT filter ahead of
+     * the username/password filter.
+     *
+     * @param http Spring Security's chain builder
+     * @return the configured chain
+     * @throws Exception if the chain cannot be built
+     */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -56,6 +73,7 @@ public class SecurityConfig {
         return http.build();
     }
 
+    /** Authentication provider used by the login endpoint to match a submitted password against the stored hash. */
     @Bean
     public AuthenticationProvider authenticationProvider() {
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
@@ -64,16 +82,28 @@ public class SecurityConfig {
         return provider;
     }
 
+    /**
+     * Exposes the {@link AuthenticationManager} so {@code AuthService} can authenticate a login attempt.
+     *
+     * @throws Exception if the manager cannot be resolved from the configuration
+     */
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
         return config.getAuthenticationManager();
     }
 
+    /** BCrypt encoder — the algorithm the stored password hashes (including the seeded demo user) use. */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    /**
+     * CORS policy for cross-origin browsers, from the comma-separated {@code app.cors.allowed-origins}.
+     *
+     * <p>Only needed when the frontend is served from another origin; the default setup proxies
+     * {@code /api} same-origin (Vite in dev, nginx in prod) and never reaches this.
+     */
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         List<String> origins = Arrays.stream(allowedOrigins.split(","))

--- a/backend/src/main/java/com/healthupgrades/common/websocket/JwtChannelInterceptor.java
+++ b/backend/src/main/java/com/healthupgrades/common/websocket/JwtChannelInterceptor.java
@@ -25,6 +25,17 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
     private final JwtTokenProvider tokenProvider;
     private final UserQuery userQuery;
 
+    /**
+     * Authenticates a CONNECT frame and lets every other frame pass through untouched.
+     *
+     * @param message the inbound STOMP message
+     * @param channel the client inbound channel
+     * @return the same message, with the session principal attached on CONNECT
+     * @throws IllegalArgumentException if a CONNECT frame carries no bearer token, an invalid one, or a
+     *                                  token whose subject no longer exists — Spring turns this into a
+     *                                  refused connection, which is the only way to reject a STOMP
+     *                                  session from an interceptor
+     */
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);

--- a/backend/src/main/java/com/healthupgrades/common/websocket/StompPrincipal.java
+++ b/backend/src/main/java/com/healthupgrades/common/websocket/StompPrincipal.java
@@ -6,8 +6,12 @@ import java.security.Principal;
  * STOMP session principal whose name is the user's id (as a string). Using the userId as the principal
  * name lets {@code SimpMessagingTemplate.convertAndSendToUser(userId, ...)} route messages without an
  * email lookup, and lets the client subscribe to {@code /user/queue/...} without knowing its own name.
+ *
+ * @param name the user's id in string form
  */
 public record StompPrincipal(String name) implements Principal {
+
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;

--- a/backend/src/main/java/com/healthupgrades/common/websocket/WebSocketConfig.java
+++ b/backend/src/main/java/com/healthupgrades/common/websocket/WebSocketConfig.java
@@ -11,6 +11,18 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 import java.util.Arrays;
 
+/**
+ * STOMP-over-WebSocket wiring for real-time notification push.
+ *
+ * <p>The broker is Spring's in-memory simple broker — there is no external message broker, which is why
+ * push only reaches clients connected to <em>this</em> instance. Horizontal scaling would need a real
+ * broker relay; until then a notification is also persisted, so a client that missed the push still sees
+ * it on the next fetch.
+ *
+ * <p>The endpoint is left unauthenticated in {@code SecurityConfig} on purpose: the JWT cannot travel on
+ * a browser's WebSocket handshake, so {@link JwtChannelInterceptor} authenticates the STOMP CONNECT
+ * frame instead.
+ */
 @Configuration
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
@@ -21,6 +33,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Value("${app.cors.allowed-origins:http://localhost:3000}")
     private String allowedOrigins;
 
+    /** Registers the {@code /ws} endpoint, permitting the same origins as the REST API. */
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // Native WebSocket (no SockJS). Same-origin requests via the Vite/nginx proxy need no CORS,
@@ -32,6 +45,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws").setAllowedOriginPatterns(origins);
     }
 
+    /**
+     * Configures destinations: {@code /queue} and {@code /topic} for broker-managed messages,
+     * {@code /app} for inbound frames, and {@code /user} for per-session routing.
+     *
+     * <p>The user prefix is what makes {@code convertAndSendToUser} deliver to one subscriber only; the
+     * name it routes by is the user id set by {@link JwtChannelInterceptor}.
+     */
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/queue", "/topic");
@@ -39,6 +59,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.setUserDestinationPrefix("/user");
     }
 
+    /** Puts {@link JwtChannelInterceptor} on the inbound channel so CONNECT frames are authenticated. */
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(jwtChannelInterceptor);

--- a/backend/src/main/java/com/healthupgrades/dashboard/adapter/in/web/DashboardController.java
+++ b/backend/src/main/java/com/healthupgrades/dashboard/adapter/in/web/DashboardController.java
@@ -21,7 +21,15 @@ public class DashboardController {
     private final DashboardQuery dashboardQuery; // application aggregation port
     private final DashboardWebMapper mapper; // domain view -> HTTP DTO
 
-    /** Returns the caller's dashboard. */
+    /**
+     * Builds and returns the caller's dashboard.
+     *
+     * <p>Read-only and computed per request: nothing here is cached or stored, so the figures are always
+     * consistent with the data behind them.
+     *
+     * @param principal the authenticated caller, whose id scopes every section
+     * @return 200 with the dashboard; the buckets are empty rather than absent for a new account
+     */
     @GetMapping
     public ResponseEntity<DashboardDto> getDashboard(@AuthenticationPrincipal SecurityUser principal) {
         return ResponseEntity.ok(mapper.toDto(dashboardQuery.getDashboard(principal.getId())));

--- a/backend/src/main/java/com/healthupgrades/dashboard/adapter/in/web/DashboardDto.java
+++ b/backend/src/main/java/com/healthupgrades/dashboard/adapter/in/web/DashboardDto.java
@@ -6,6 +6,26 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * The whole dashboard in one response.
+ *
+ * <p>Composed rather than stored: every bucket is derived at request time from the user's upgrades,
+ * progress entries and health areas. The buckets overlap on purpose — an upgrade can be ACTIVE, due
+ * today and overdue at once, and appears in each list it qualifies for. Each is nevertheless serialized
+ * from a single mapped instance, so the repeated upgrades are identical rather than merely equal.
+ *
+ * <p>One request replaces the five or so a client would otherwise make to draw the same page.
+ *
+ * @param activeUpgrades       upgrades currently running
+ * @param plannedUpgrades      upgrades committed to a date but not yet started
+ * @param todayUpgrades        upgrades running today, i.e. within their date window
+ * @param overdueUpgrades      running upgrades past their target end date
+ * @param weeklyCompletionRate percentage of the last seven days' entries that count as successful;
+ *                             zero when nothing was logged, which is indistinguishable from all-missed
+ * @param streaks              current streak by upgrade id, for running upgrades only
+ * @param recentlyCompleted    the five most recently finished upgrades
+ * @param areaSummary          per-health-area counts
+ */
 public record DashboardDto(
         List<UpgradeDto> activeUpgrades,
         List<UpgradeDto> plannedUpgrades,
@@ -16,5 +36,14 @@ public record DashboardDto(
         List<UpgradeDto> recentlyCompleted,
         List<AreaSummary> areaSummary
 ) {
+    /**
+     * Upgrade counts for one health area.
+     *
+     * @param areaId         the area
+     * @param areaName       its display name, denormalised so the client needs no second call
+     * @param totalUpgrades  how many upgrades are filed under it, in any state
+     * @param activeCount    how many are running
+     * @param completedCount how many are finished
+     */
     public record AreaSummary(UUID areaId, String areaName, int totalUpgrades, int activeCount, int completedCount) {}
 }

--- a/backend/src/main/java/com/healthupgrades/dashboard/application/port/in/DashboardQuery.java
+++ b/backend/src/main/java/com/healthupgrades/dashboard/application/port/in/DashboardQuery.java
@@ -8,6 +8,11 @@ import java.util.UUID;
  */
 public interface DashboardQuery {
 
-    /** Builds the dashboard aggregate for a user. */
+    /**
+     * Builds the dashboard aggregate for a user.
+     *
+     * @param userId the owner whose data is summarised
+     * @return the assembled view; empty buckets rather than null for a user with no upgrades
+     */
     DashboardView getDashboard(UUID userId);
 }

--- a/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaController.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaController.java
@@ -13,6 +13,13 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * REST adapter for health areas — the folders a user organises upgrades into.
+ *
+ * <p>Every endpoint is scoped to the authenticated principal: the owner id comes from the token, never
+ * from the request, so one user cannot address another's areas. An area that belongs to somebody else
+ * is reported as not found (404), not forbidden.
+ */
 @RestController
 @RequestMapping("/api/health-areas")
 @RequiredArgsConstructor
@@ -21,6 +28,12 @@ public class HealthAreaController {
     private final HealthAreaService service;
     private final HealthAreaWebMapper mapper;
 
+    /**
+     * Creates a health area for the caller.
+     *
+     * @param req name (required), plus optional description, priority, icon and colour
+     * @return 201 with the created area
+     */
     @PostMapping
     public ResponseEntity<HealthAreaDto> create(@AuthenticationPrincipal SecurityUser principal,
                                                  @Valid @RequestBody HealthAreaRequest req) {
@@ -28,17 +41,41 @@ public class HealthAreaController {
         return ResponseEntity.status(HttpStatus.CREATED).body(mapper.toDto(created));
     }
 
+    /**
+     * Lists the caller's health areas.
+     *
+     * @return 200 with every area the caller owns, in persistence order
+     */
     @GetMapping
     public ResponseEntity<List<HealthAreaDto>> findAll(@AuthenticationPrincipal SecurityUser principal) {
         return ResponseEntity.ok(mapper.toDtos(service.listByUser(principal.getId())));
     }
 
+    /**
+     * Fetches one of the caller's health areas.
+     *
+     * @param id the area's identifier
+     * @return 200 with the area
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such area is
+     *         owned by the caller (404)
+     */
     @GetMapping("/{id}")
     public ResponseEntity<HealthAreaDto> findById(@AuthenticationPrincipal SecurityUser principal,
                                                    @PathVariable UUID id) {
         return ResponseEntity.ok(mapper.toDto(service.findById(principal.getId(), id)));
     }
 
+    /**
+     * Replaces the editable attributes of one of the caller's health areas.
+     *
+     * <p>A full replacement, not a patch: an omitted optional field is written as null.
+     *
+     * @param id  the area's identifier
+     * @param req the new attribute values
+     * @return 200 with the updated area
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such area is
+     *         owned by the caller (404)
+     */
     @PutMapping("/{id}")
     public ResponseEntity<HealthAreaDto> update(@AuthenticationPrincipal SecurityUser principal,
                                                  @PathVariable UUID id,
@@ -47,6 +84,14 @@ public class HealthAreaController {
         return ResponseEntity.ok(mapper.toDto(updated));
     }
 
+    /**
+     * Deletes one of the caller's health areas.
+     *
+     * @param id the area's identifier
+     * @return 204 with no body
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such area is
+     *         owned by the caller (404)
+     */
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@AuthenticationPrincipal SecurityUser principal, @PathVariable UUID id) {
         service.delete(principal.getId(), id);

--- a/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaDto.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaDto.java
@@ -3,6 +3,19 @@ package com.healthupgrades.healtharea.adapter.in.web;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Health area as returned on the wire.
+ *
+ * @param id          the area's identifier
+ * @param userId      the owner; echoed back so a client can assert what it received
+ * @param name        display name, e.g. "Nutrition"
+ * @param description free-text note, may be null
+ * @param priority    ordering hint chosen by the user, may be null
+ * @param icon        icon key the frontend resolves to a glyph, may be null
+ * @param color       colour token the frontend resolves to a class, may be null
+ * @param createdAt   when the area was created
+ * @param updatedAt   when it was last modified
+ */
 public record HealthAreaDto(
         UUID id,
         UUID userId,

--- a/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaRequest.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaRequest.java
@@ -2,6 +2,18 @@ package com.healthupgrades.healtharea.adapter.in.web;
 
 import jakarta.validation.constraints.NotBlank;
 
+/**
+ * Request body for creating or replacing a health area.
+ *
+ * <p>Used by both {@code POST} and {@code PUT}: an update is a full replacement, so every optional
+ * field left out is stored as null rather than kept at its previous value.
+ *
+ * @param name        display name; required and non-blank
+ * @param description free-text note, optional
+ * @param priority    ordering hint, optional
+ * @param icon        icon key, optional
+ * @param color       colour token, optional
+ */
 public record HealthAreaRequest(
         @NotBlank String name,
         String description,

--- a/backend/src/main/java/com/healthupgrades/healtharea/adapter/out/persistence/HealthAreaRepositoryAdapter.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/adapter/out/persistence/HealthAreaRepositoryAdapter.java
@@ -11,6 +11,9 @@ import java.util.UUID;
 
 /**
  * Persistence adapter implementing {@link HealthAreaRepositoryPort} by delegating to Spring Data JPA.
+ *
+ * <p>The adapter exists so the Spring Data interface can stay package-private: the port is the only
+ * thing the rest of the application sees, which is what keeps JPA confined to this package.
  */
 @Component
 @RequiredArgsConstructor
@@ -18,23 +21,27 @@ class HealthAreaRepositoryAdapter implements HealthAreaRepositoryPort {
 
     private final HealthAreaJpaRepository jpa; // Spring Data proxy
 
+    /** {@inheritDoc} */
     @Override
     public HealthArea save(HealthArea area) {
-        return jpa.save(area); // delegate persist
+        return jpa.save(area);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void delete(HealthArea area) {
-        jpa.delete(area); // delegate delete
+        jpa.delete(area);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<HealthArea> findByUserId(UUID userId) {
-        return jpa.findByUserId(userId); // delegate
+        return jpa.findByUserId(userId);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<HealthArea> findByIdAndUserId(UUID id, UUID userId) {
-        return jpa.findByIdAndUserId(id, userId); // delegate ownership-scoped lookup
+        return jpa.findByIdAndUserId(id, userId);
     }
 }

--- a/backend/src/main/java/com/healthupgrades/healtharea/application/HealthAreaService.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/application/HealthAreaService.java
@@ -12,13 +12,25 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Use cases for health areas: create, read, update and delete, all scoped to one owner.
+ *
+ * <p>Every method takes the owner's id explicitly — there is no ambient "current user" in this layer —
+ * and every lookup goes through {@code getOwnedArea}, so ownership is checked in exactly one place.
+ */
 @Service
 @RequiredArgsConstructor
 public class HealthAreaService implements HealthAreaQuery {
 
     private final HealthAreaRepositoryPort repository;
 
-    /** Creates a health area owned by the given user. */
+    /**
+     * Creates a health area owned by the given user.
+     *
+     * @param userId  the owner
+     * @param details the attributes to store
+     * @return the persisted area, with its generated id and timestamps
+     */
     @Transactional
     public HealthArea create(UUID userId, HealthAreaDetails details) {
         HealthArea area = HealthArea.builder()
@@ -32,12 +44,27 @@ public class HealthAreaService implements HealthAreaQuery {
         return repository.save(area);
     }
 
-    /** A single owned area. */
+    /**
+     * Reads one of the user's areas.
+     *
+     * @param userId the owner
+     * @param id     the area's identifier
+     * @return the owned area
+     * @throws ResourceNotFoundException if the area does not exist or belongs to somebody else
+     */
     public HealthArea findById(UUID userId, UUID id) {
         return getOwnedArea(userId, id);
     }
 
-    /** Replaces the editable attributes of an owned area. */
+    /**
+     * Replaces the editable attributes of an owned area.
+     *
+     * @param userId  the owner
+     * @param id      the area's identifier
+     * @param details the replacement attributes; nulls overwrite previous values
+     * @return the saved area
+     * @throws ResourceNotFoundException if the area does not exist or belongs to somebody else
+     */
     @Transactional
     public HealthArea update(UUID userId, UUID id, HealthAreaDetails details) {
         HealthArea area = getOwnedArea(userId, id);
@@ -49,7 +76,15 @@ public class HealthAreaService implements HealthAreaQuery {
         return repository.save(area);
     }
 
-    /** Deletes an owned area. */
+    /**
+     * Deletes an owned area.
+     *
+     * <p>Upgrades filed under it are left untouched and keep the now-dangling area id.
+     *
+     * @param userId the owner
+     * @param id     the area's identifier
+     * @throws ResourceNotFoundException if the area does not exist or belongs to somebody else
+     */
     @Transactional
     public void delete(UUID userId, UUID id) {
         repository.delete(getOwnedArea(userId, id));
@@ -64,6 +99,7 @@ public class HealthAreaService implements HealthAreaQuery {
         return repository.findByUserId(userId);
     }
 
+    /** Single ownership guard: a foreign or missing area is indistinguishable, both are "not found". */
     private HealthArea getOwnedArea(UUID userId, UUID id) {
         return repository.findByIdAndUserId(id, userId)
                 .orElseThrow(() -> new ResourceNotFoundException("HealthArea not found: " + id)); // ownership guard

--- a/backend/src/main/java/com/healthupgrades/healtharea/domain/model/HealthArea.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/domain/model/HealthArea.java
@@ -6,6 +6,16 @@ import lombok.*;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Health area aggregate — a user-defined grouping ("Fitness", "Sleep") that upgrades are filed under.
+ *
+ * <p>Unlike {@code HealthUpgrade}, this aggregate keeps its setters: it has no state machine and no
+ * invariant beyond "belongs to a user and has a name", so there is nothing for a factory or transition
+ * method to protect.
+ *
+ * <p>An area is referenced by upgrades through its id only, so deleting one leaves those upgrades
+ * pointing at a missing area rather than cascading.
+ */
 @Entity
 @Table(name = "health_areas")
 @Getter
@@ -39,12 +49,14 @@ public class HealthArea {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+    /** Stamps the creation and update timestamps before the row is first inserted. */
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
     }
 
+    /** Refreshes the update timestamp before each update. */
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();

--- a/backend/src/main/java/com/healthupgrades/notification/adapter/in/event/NotificationEventListener.java
+++ b/backend/src/main/java/com/healthupgrades/notification/adapter/in/event/NotificationEventListener.java
@@ -37,12 +37,14 @@ public class NotificationEventListener {
     private final NotificationService notificationService;
     private final UpgradeQuery upgradeQuery;
 
+    /** Tells the user their idea was captured. Titles come off the event, so no lookup is needed. */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onCreated(HealthUpgradeCreated e) {
         notificationService.create(e.userId(), NotificationType.UPGRADE_CREATED, NotificationCategory.INFO,
                 "New upgrade idea", "\"" + e.title() + "\" was added to your backlog.", e.upgradeId());
     }
 
+    /** Confirms the start date the user committed to. Also fires when an abandoned upgrade is revived. */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onPlanned(HealthUpgradePlanned e) {
         notificationService.create(e.userId(), NotificationType.UPGRADE_PLANNED, NotificationCategory.INFO,
@@ -50,6 +52,7 @@ public class NotificationEventListener {
                         + e.plannedStartDate() + ".", e.upgradeId());
     }
 
+    /** Marks the start of a run, or its resumption after a pause. */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onActivated(HealthUpgradeActivated e) {
         notificationService.create(e.userId(), NotificationType.UPGRADE_ACTIVATED, NotificationCategory.SUCCESS,
@@ -57,12 +60,14 @@ public class NotificationEventListener {
                 e.upgradeId());
     }
 
+    /** Acknowledges a pause without editorialising: stopping for a while is not a failure. */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onPaused(HealthUpgradePaused e) {
         notificationService.create(e.userId(), NotificationType.UPGRADE_PAUSED, NotificationCategory.INFO,
                 "Upgrade paused", "\"" + title(e.upgradeId(), e.userId()) + "\" is paused.", e.upgradeId());
     }
 
+    /** Celebrates a finished upgrade. */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onCompleted(HealthUpgradeCompleted e) {
         notificationService.create(e.userId(), NotificationType.UPGRADE_COMPLETED, NotificationCategory.SUCCESS,
@@ -70,12 +75,14 @@ public class NotificationEventListener {
                 e.upgradeId());
     }
 
+    /** Records an abandonment neutrally — this is a lifestyle tool, not a disciplinarian. */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onAbandoned(HealthUpgradeAbandoned e) {
         notificationService.create(e.userId(), NotificationType.UPGRADE_ABANDONED, NotificationCategory.INFO,
                 "Upgrade abandoned", "\"" + title(e.upgradeId(), e.userId()) + "\" was abandoned.", e.upgradeId());
     }
 
+    /** Celebrates a streak milestone. The tracking context decides which lengths qualify. */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onStreak(StreakAchieved e) {
         notificationService.create(e.userId(), NotificationType.STREAK_ACHIEVED, NotificationCategory.SUCCESS,
@@ -83,6 +90,7 @@ public class NotificationEventListener {
                 "\"" + title(e.upgradeId(), e.userId()) + "\" — keep the momentum going.", e.upgradeId());
     }
 
+    /** Confirms a reflection was saved. The event carries no content, and neither does this. */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onReflection(ReflectionAdded e) {
         notificationService.create(e.userId(), NotificationType.REFLECTION_ADDED, NotificationCategory.INFO,
@@ -103,6 +111,13 @@ public class NotificationEventListener {
                 () -> "\"" + title(e.upgradeId(), e.userId()) + "\" is past its target date.", e.upgradeId());
     }
 
+    /**
+     * Resolves an upgrade's title for a message, falling back to a generic phrase.
+     *
+     * <p>The fallback matters: an event can outlive the upgrade it refers to — deletion publishes
+     * nothing but does remove the row — and a notification that reads "your upgrade" is better than one
+     * that fails to be created at all.
+     */
     private String title(UUID upgradeId, UUID userId) {
         return upgradeQuery.findOwned(userId, upgradeId)
                 .map(HealthUpgrade::getTitle)

--- a/backend/src/main/java/com/healthupgrades/notification/adapter/in/scheduling/NotificationScheduler.java
+++ b/backend/src/main/java/com/healthupgrades/notification/adapter/in/scheduling/NotificationScheduler.java
@@ -49,7 +49,13 @@ public class NotificationScheduler {
     private final NotificationService notificationService; // own application service (create + push)
     private final Clock clock; // injectable clock for deterministic scheduling
 
-    /** Nudges users with active upgrades who haven't logged any progress today (once per day). */
+    /**
+     * Nudges every user who has running upgrades but has logged nothing today.
+     *
+     * <p>Two guards keep this from becoming noise: a user who has already logged something today is
+     * skipped, and so is one who has already been nudged since midnight — the second matters because
+     * nothing stops this cron from being configured to run more than once a day.
+     */
     @Scheduled(cron = "${app.notifications.schedules.daily-checkin}")
     public void notifyDailyCheckin() {
         LocalDate today = LocalDate.now(clock);
@@ -69,7 +75,17 @@ public class NotificationScheduler {
         });
     }
 
-    /** Dispatches user-configured per-upgrade reminders whose time/day matches now (runs every minute). */
+    /**
+     * Fires the reminders that are due at this minute.
+     *
+     * <p>Runs every minute, which is what a reminder configured to the minute requires. It sweeps every
+     * enabled reminder each time, so the two costly parts are avoided deliberately: due-ness is decided
+     * by the reminder itself without a database round trip, and the upgrades behind the due ones are
+     * loaded in one batch rather than one query each.
+     *
+     * <p>Unlike the check-in nudge there is no dedup guard, and none is needed: a given minute occurs
+     * once, so a reminder cannot match twice.
+     */
     @Scheduled(cron = "${app.notifications.schedules.reminders}")
     public void dispatchReminders() {
         LocalTime now = LocalTime.now(clock);

--- a/backend/src/main/java/com/healthupgrades/notification/adapter/in/web/NotificationController.java
+++ b/backend/src/main/java/com/healthupgrades/notification/adapter/in/web/NotificationController.java
@@ -11,6 +11,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * REST adapter for the notification inbox.
+ *
+ * <p>Read and acknowledge only — notifications are never created through the API. They are produced by
+ * {@code NotificationEventListener} reacting to domain events and by {@code NotificationScheduler}, so
+ * there is no endpoint a client could post one to.
+ *
+ * <p>This is also the fallback transport: the same payloads are pushed over STOMP as they happen, and
+ * a client that was offline sees them here on its next load.
+ */
 @RestController
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
@@ -19,21 +29,49 @@ public class NotificationController {
     private final NotificationService service;
     private final NotificationWebMapper mapper;
 
+    /**
+     * Lists the caller's most recent notifications, newest first.
+     *
+     * <p>Capped at fifty and not paginated: the inbox is a recent-activity feed, not an archive.
+     *
+     * @return 200 with up to fifty notifications, read and unread alike
+     */
     @GetMapping
     public ResponseEntity<List<NotificationDto>> list(@AuthenticationPrincipal SecurityUser principal) {
         return ResponseEntity.ok(mapper.toDtos(service.listRecent(principal.getId())));
     }
 
+    /**
+     * Returns how many of the caller's notifications are unread.
+     *
+     * <p>Wrapped in an object rather than returned as a bare number so the response stays extensible
+     * without breaking clients that parse it.
+     *
+     * @return 200 with {@code {"count": n}}, counting every unread notification, not only the listed fifty
+     */
     @GetMapping("/unread-count")
     public ResponseEntity<Map<String, Long>> unreadCount(@AuthenticationPrincipal SecurityUser principal) {
         return ResponseEntity.ok(Map.of("count", service.unreadCount(principal.getId())));
     }
 
+    /**
+     * Marks one of the caller's notifications as read.
+     *
+     * @param id the notification to acknowledge
+     * @return 200 with the updated notification
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         notification is owned by the caller (404)
+     */
     @PostMapping("/{id}/read")
     public ResponseEntity<NotificationDto> markRead(@AuthenticationPrincipal SecurityUser principal, @PathVariable UUID id) {
         return ResponseEntity.ok(mapper.toDto(service.markRead(principal.getId(), id)));
     }
 
+    /**
+     * Marks every one of the caller's unread notifications as read in a single update.
+     *
+     * @return 204 with no body
+     */
     @PostMapping("/read-all")
     public ResponseEntity<Void> markAllRead(@AuthenticationPrincipal SecurityUser principal) {
         service.markAllRead(principal.getId());

--- a/backend/src/main/java/com/healthupgrades/notification/adapter/in/web/NotificationDto.java
+++ b/backend/src/main/java/com/healthupgrades/notification/adapter/in/web/NotificationDto.java
@@ -6,6 +6,23 @@ import com.healthupgrades.notification.domain.model.NotificationType;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * A notification as delivered to the client.
+ *
+ * <p>Delivered over both transports — pushed over STOMP when it is created, and returned by the REST
+ * inbox afterwards — and rendered by the same component either way, which is why one mapper builds it
+ * for both.
+ *
+ * @param id               the notification's identifier
+ * @param type             what happened; the frontend maps this to an icon and a destination
+ * @param category         how it should read: informational, positive, a warning, or a nudge
+ * @param title            short headline, already composed server-side
+ * @param message          the body, already composed server-side, may be null
+ * @param relatedUpgradeId the upgrade it concerns, so the client can link to it; null for
+ *                         account-wide notifications such as the daily check-in nudge
+ * @param read             whether the user has acknowledged it
+ * @param createdAt        when it was raised
+ */
 public record NotificationDto(
         UUID id,
         NotificationType type,

--- a/backend/src/main/java/com/healthupgrades/notification/adapter/out/persistence/NotificationRepositoryAdapter.java
+++ b/backend/src/main/java/com/healthupgrades/notification/adapter/out/persistence/NotificationRepositoryAdapter.java
@@ -20,38 +20,45 @@ class NotificationRepositoryAdapter implements NotificationRepositoryPort {
 
     private final NotificationJpaRepository jpa; // Spring Data proxy
 
+    /** {@inheritDoc} */
     @Override
     public Notification save(Notification notification) {
-        return jpa.save(notification); // delegate persist
+        return jpa.save(notification);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Notification> findTop50ByUserIdOrderByCreatedAtDesc(UUID userId) {
-        return jpa.findTop50ByUserIdOrderByCreatedAtDesc(userId); // delegate
+        return jpa.findTop50ByUserIdOrderByCreatedAtDesc(userId);
     }
 
+    /** {@inheritDoc} */
     @Override
     public long countByUserIdAndReadFalse(UUID userId) {
-        return jpa.countByUserIdAndReadFalse(userId); // delegate unread count
+        return jpa.countByUserIdAndReadFalse(userId);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<Notification> findByIdAndUserId(UUID id, UUID userId) {
-        return jpa.findByIdAndUserId(id, userId); // delegate ownership-scoped lookup
+        return jpa.findByIdAndUserId(id, userId);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean existsByUserIdAndRelatedUpgradeIdAndType(UUID userId, UUID relatedUpgradeId, NotificationType type) {
-        return jpa.existsByUserIdAndRelatedUpgradeIdAndType(userId, relatedUpgradeId, type); // delegate dedup check
+        return jpa.existsByUserIdAndRelatedUpgradeIdAndType(userId, relatedUpgradeId, type);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean existsByUserIdAndTypeAndCreatedAtAfter(UUID userId, NotificationType type, LocalDateTime after) {
-        return jpa.existsByUserIdAndTypeAndCreatedAtAfter(userId, type, after); // delegate dedup check
+        return jpa.existsByUserIdAndTypeAndCreatedAtAfter(userId, type, after);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void markAllReadForUser(UUID userId) {
-        jpa.markAllReadForUser(userId); // delegate bulk update
+        jpa.markAllReadForUser(userId);
     }
 }

--- a/backend/src/main/java/com/healthupgrades/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/healthupgrades/notification/application/NotificationService.java
@@ -84,25 +84,48 @@ public class NotificationService {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    pushPort.push(userId, notification); // deliver once the write is durable
+                    pushPort.push(userId, notification);
                 }
             });
         } else {
-            pushPort.push(userId, notification); // no active tx -> push now
+            pushPort.push(userId, notification);
         }
     }
 
-    /** The user's 50 most recent notifications, newest first. */
+    /**
+     * The user's fifty most recent notifications, newest first.
+     *
+     * <p>Capped rather than paginated: this backs an inbox of recent activity, and older notifications
+     * are not retrievable through the API at all.
+     *
+     * @param userId the owner
+     * @return up to fifty notifications, read and unread alike
+     */
     public List<Notification> listRecent(UUID userId) {
         return repository.findTop50ByUserIdOrderByCreatedAtDesc(userId);
     }
 
-    /** Count of the user's unread notifications. */
+    /**
+     * Counts the user's unread notifications.
+     *
+     * <p>Counts all of them, not only the fifty {@link #listRecent} returns, so the badge can exceed
+     * what the list shows.
+     *
+     * @param userId the owner
+     * @return the number unread, zero when there are none
+     */
     public long unreadCount(UUID userId) {
         return repository.countByUserIdAndReadFalse(userId);
     }
 
-    /** Marks a single owned notification as read. */
+    /**
+     * Marks one of the user's notifications as read. Idempotent — marking a read one again is a no-op.
+     *
+     * @param userId the owner
+     * @param id     the notification to acknowledge
+     * @return the saved notification
+     * @throws ResourceNotFoundException if the notification does not exist or belongs to somebody else
+     */
     @Transactional
     public Notification markRead(UUID userId, UUID id) {
         Notification notification = repository.findByIdAndUserId(id, userId)
@@ -111,7 +134,14 @@ public class NotificationService {
         return repository.save(notification);
     }
 
-    /** Marks all of the user's notifications as read. */
+    /**
+     * Marks every one of the user's unread notifications as read.
+     *
+     * <p>A single bulk update rather than a load-and-save loop, so the cost does not grow with the size
+     * of the inbox. The entities are therefore not loaded, and no push follows.
+     *
+     * @param userId the owner
+     */
     @Transactional
     public void markAllRead(UUID userId) {
         repository.markAllReadForUser(userId);

--- a/backend/src/main/java/com/healthupgrades/notification/domain/model/Notification.java
+++ b/backend/src/main/java/com/healthupgrades/notification/domain/model/Notification.java
@@ -6,6 +6,14 @@ import lombok.*;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * A message raised for a user by the system.
+ *
+ * <p>Never created by a user action directly: notifications are produced by the event listener and the
+ * scheduler, which is why the only state change the aggregate offers is {@link #markAsRead()}. The title
+ * and message are composed when it is raised and stored as text, so a notification keeps saying what it
+ * said even after the upgrade behind it is renamed or deleted.
+ */
 @Entity
 @Table(name = "notifications")
 @Getter
@@ -35,6 +43,7 @@ public class Notification {
     @Column(columnDefinition = "TEXT")
     private String message;
 
+    /** The upgrade this concerns, letting the client link to it. Null for account-wide notifications. */
     private UUID relatedUpgradeId;
 
     // Mapped to the column "is_read" because "read" is a reserved word in several SQL dialects.
@@ -49,6 +58,12 @@ public class Notification {
         this.read = true;
     }
 
+    /**
+     * Stamps the creation timestamp, unless one was supplied.
+     *
+     * <p>Conditional, unlike the other entities' callbacks: notifications are the one aggregate whose
+     * timestamp a caller may set deliberately, and overwriting it here would discard that.
+     */
     @PrePersist
     protected void onCreate() {
         if (createdAt == null) createdAt = LocalDateTime.now();

--- a/backend/src/main/java/com/healthupgrades/notification/domain/model/NotificationCategory.java
+++ b/backend/src/main/java/com/healthupgrades/notification/domain/model/NotificationCategory.java
@@ -1,9 +1,22 @@
 package com.healthupgrades.notification.domain.model;
 
-/** Drives the icon/colour the frontend shows for a notification. */
+/**
+ * How a notification should read, which drives the icon and colour the frontend gives it.
+ *
+ * <p>Orthogonal to {@code NotificationType}: the type says what happened, the category says how to
+ * present it. Several types share a category.
+ */
 public enum NotificationCategory {
+
+    /** Neutral: something was recorded. */
     INFO,
+
+    /** Positive: something went well and is worth celebrating. */
     SUCCESS,
+
+    /** Needs attention: something has slipped. */
     WARNING,
+
+    /** A nudge to act now. */
     REMINDER
 }

--- a/backend/src/main/java/com/healthupgrades/notification/domain/model/NotificationType.java
+++ b/backend/src/main/java/com/healthupgrades/notification/domain/model/NotificationType.java
@@ -1,15 +1,47 @@
 package com.healthupgrades.notification.domain.model;
 
+/**
+ * What a notification is about.
+ *
+ * <p>The frontend switches on this to choose an icon and where clicking the notification leads, so a new
+ * value needs a matching entry there — an unmapped type renders with a fallback rather than failing.
+ *
+ * <p>Most values mirror a domain event; the last two are raised by the scheduler instead, having no
+ * event behind them.
+ */
 public enum NotificationType {
+
+    /** An upgrade was added to the backlog. */
     UPGRADE_CREATED,
+
+    /** An upgrade was committed to a start date. */
     UPGRADE_PLANNED,
+
+    /** An upgrade started or resumed. */
     UPGRADE_ACTIVATED,
+
+    /** An upgrade was suspended. */
     UPGRADE_PAUSED,
+
+    /** An upgrade was finished. */
     UPGRADE_COMPLETED,
+
+    /** An upgrade was given up on. */
     UPGRADE_ABANDONED,
+
+    /** A streak reached a milestone length. */
     STREAK_ACHIEVED,
+
+    /** A running upgrade passed its target end date. Raised at most once per upgrade. */
     UPGRADE_OVERDUE,
+
+    /** A reflection was written. */
     REFLECTION_ADDED,
+
+    /** A reminder the user configured came due. Scheduler-raised. */
     REMINDER,
+
+    /** The daily nudge for a user with running upgrades who has logged nothing today. Scheduler-raised,
+     *  at most once a day. */
     CHECKIN_REMINDER
 }

--- a/backend/src/main/java/com/healthupgrades/reflection/adapter/in/web/ReflectionController.java
+++ b/backend/src/main/java/com/healthupgrades/reflection/adapter/in/web/ReflectionController.java
@@ -13,6 +13,12 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * REST adapter for reflections — the periodic reviews a user writes about how an upgrade is going.
+ *
+ * <p>A sub-resource of an upgrade, and append-only: reflections can be written and read but never
+ * edited or deleted, because a review is a record of what the user thought at the time.
+ */
 @RestController
 @RequestMapping("/api/upgrades/{upgradeId}/reflections")
 @RequiredArgsConstructor
@@ -21,6 +27,15 @@ public class ReflectionController {
     private final ReflectionService service;
     private final ReflectionWebMapper mapper;
 
+    /**
+     * Writes a reflection about an upgrade.
+     *
+     * @param upgradeId the upgrade being reflected on
+     * @param req       the reflection; every field is optional and the date defaults to today
+     * @return 201 with the stored reflection
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     */
     @PostMapping
     public ResponseEntity<ReflectionDto> create(@AuthenticationPrincipal SecurityUser principal,
                                                  @PathVariable UUID upgradeId,
@@ -29,6 +44,14 @@ public class ReflectionController {
         return ResponseEntity.status(HttpStatus.CREATED).body(mapper.toDto(created));
     }
 
+    /**
+     * Lists an upgrade's reflections, newest first.
+     *
+     * @param upgradeId the upgrade to read
+     * @return 200 with its reflections; empty when none have been written
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     */
     @GetMapping
     public ResponseEntity<List<ReflectionDto>> getAll(@AuthenticationPrincipal SecurityUser principal,
                                                        @PathVariable UUID upgradeId) {

--- a/backend/src/main/java/com/healthupgrades/reflection/adapter/in/web/ReflectionDto.java
+++ b/backend/src/main/java/com/healthupgrades/reflection/adapter/in/web/ReflectionDto.java
@@ -4,6 +4,20 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * A reflection as returned on the wire.
+ *
+ * @param id               the reflection's identifier
+ * @param upgradeId        the upgrade it is about
+ * @param userId           the author
+ * @param date             the day it reflects on
+ * @param difficultyRating how hard it felt, one to five, may be null
+ * @param benefitRating    how worthwhile it felt, one to five, may be null
+ * @param whatWorked       free text, may be null
+ * @param whatDidNotWork   free text, may be null
+ * @param nextAdjustment   what the user intends to change, may be null
+ * @param createdAt        when it was written, which may differ from {@code date}
+ */
 public record ReflectionDto(
         UUID id,
         UUID upgradeId,

--- a/backend/src/main/java/com/healthupgrades/reflection/adapter/in/web/ReflectionRequest.java
+++ b/backend/src/main/java/com/healthupgrades/reflection/adapter/in/web/ReflectionRequest.java
@@ -5,6 +5,19 @@ import jakarta.validation.constraints.Min;
 
 import java.time.LocalDate;
 
+/**
+ * Request body for writing a reflection.
+ *
+ * <p>Everything is optional, including the ratings: a reflection with only a note is a legitimate one,
+ * and demanding a score to record a thought would just stop people writing them.
+ *
+ * @param date             the day being reflected on; today when null
+ * @param difficultyRating how hard it felt, one to five inclusive
+ * @param benefitRating    how worthwhile it felt, one to five inclusive
+ * @param whatWorked       free text
+ * @param whatDidNotWork   free text
+ * @param nextAdjustment   what the user intends to change
+ */
 public record ReflectionRequest(
         LocalDate date,
         @Min(1) @Max(5) Integer difficultyRating,

--- a/backend/src/main/java/com/healthupgrades/reflection/adapter/out/persistence/ReflectionRepositoryAdapter.java
+++ b/backend/src/main/java/com/healthupgrades/reflection/adapter/out/persistence/ReflectionRepositoryAdapter.java
@@ -17,13 +17,15 @@ class ReflectionRepositoryAdapter implements ReflectionRepositoryPort {
 
     private final ReflectionJpaRepository jpa; // Spring Data proxy
 
+    /** {@inheritDoc} */
     @Override
     public Reflection save(Reflection reflection) {
-        return jpa.save(reflection); // delegate persist
+        return jpa.save(reflection);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Reflection> findByUpgradeIdOrderByDateDesc(UUID upgradeId) {
-        return jpa.findByUpgradeIdOrderByDateDesc(upgradeId); // delegate
+        return jpa.findByUpgradeIdOrderByDateDesc(upgradeId);
     }
 }

--- a/backend/src/main/java/com/healthupgrades/reflection/application/ReflectionService.java
+++ b/backend/src/main/java/com/healthupgrades/reflection/application/ReflectionService.java
@@ -16,6 +16,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Use cases for reflections: write one against an upgrade, and read an upgrade's history of them.
+ *
+ * <p>Ownership of the upgrade is confirmed through the upgrade context's inbound {@link UpgradeQuery}
+ * port before either operation, so a reflection can never be filed against somebody else's upgrade.
+ */
 @Service
 @RequiredArgsConstructor
 public class ReflectionService {
@@ -25,7 +31,19 @@ public class ReflectionService {
     private final DomainEventPublisher eventPublisher;
     private final Clock clock; // decides the date a reflection defaults to
 
-    /** Records a reflection against an owned upgrade, defaulting the date to today. */
+    /**
+     * Writes a reflection against an owned upgrade and announces it.
+     *
+     * <p>Unlike a progress entry there is no one-per-day rule: a user may reflect as often as they like,
+     * including several times about the same day.
+     *
+     * @param userId    the author, who must own the upgrade
+     * @param upgradeId the upgrade being reflected on
+     * @param details   the reflection; a null date means today by the injected clock
+     * @return the persisted reflection
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if the upgrade does
+     *         not exist or belongs to somebody else
+     */
     @Transactional
     public Reflection create(UUID userId, UUID upgradeId, ReflectionDetails details) {
         upgradeQuery.getOwnedUpgrade(userId, upgradeId);
@@ -44,7 +62,15 @@ public class ReflectionService {
         return reflection;
     }
 
-    /** An owned upgrade's reflections, newest first. */
+    /**
+     * Reads an owned upgrade's reflections.
+     *
+     * @param userId    the owner
+     * @param upgradeId the upgrade to read
+     * @return its reflections, newest first; empty when none have been written
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if the upgrade does
+     *         not exist or belongs to somebody else
+     */
     public List<Reflection> getForUpgrade(UUID userId, UUID upgradeId) {
         upgradeQuery.getOwnedUpgrade(userId, upgradeId);
         return repository.findByUpgradeIdOrderByDateDesc(upgradeId);

--- a/backend/src/main/java/com/healthupgrades/reflection/domain/event/ReflectionAdded.java
+++ b/backend/src/main/java/com/healthupgrades/reflection/domain/event/ReflectionAdded.java
@@ -5,4 +5,15 @@ import com.healthupgrades.common.domain.event.DomainEvent;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Raised when a user writes a reflection about an upgrade.
+ *
+ * <p>Carries ids only, no content: a reflection is where a user writes candidly about what is not
+ * working, and that text has no business travelling to consumers that only need to know one was added.
+ *
+ * @param reflectionId the reflection that was written
+ * @param upgradeId    the upgrade it is about
+ * @param userId       the author
+ * @param occurredAt   when it was written
+ */
 public record ReflectionAdded(UUID reflectionId, UUID upgradeId, UUID userId, LocalDateTime occurredAt) implements DomainEvent {}

--- a/backend/src/main/java/com/healthupgrades/reflection/domain/model/Reflection.java
+++ b/backend/src/main/java/com/healthupgrades/reflection/domain/model/Reflection.java
@@ -7,6 +7,16 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * A user's periodic review of how one upgrade is going.
+ *
+ * <p>Append-only in practice: nothing in the application updates or deletes a reflection, because its
+ * value is being a record of what the user thought at the time. Several may exist for the same upgrade
+ * and the same date.
+ *
+ * <p>Every field but the identifiers and the date is optional — a reflection that is only a sentence
+ * about what went wrong is a useful one, and requiring more would mean fewer get written.
+ */
 @Entity
 @Table(name = "reflections")
 @Getter
@@ -26,11 +36,14 @@ public class Reflection {
     @Column(nullable = false)
     private UUID userId;
 
+    /** The day being reflected on, which need not be the day it was written. */
     @Column(nullable = false)
     private LocalDate date;
 
+    /** How hard the user found it, one to five; optional. */
     private Integer difficultyRating;
 
+    /** How worthwhile the user found it, one to five; optional. */
     private Integer benefitRating;
 
     private String whatWorked;
@@ -45,12 +58,14 @@ public class Reflection {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+    /** Stamps the creation and update timestamps before the row is first inserted. */
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
     }
 
+    /** Refreshes the update timestamp before each update. */
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();

--- a/backend/src/main/java/com/healthupgrades/reminder/adapter/in/web/ReminderController.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/adapter/in/web/ReminderController.java
@@ -13,6 +13,15 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * REST adapter for reminders — the recurring nudges attached to an upgrade.
+ *
+ * <p>The routes are deliberately asymmetric: creating and listing are addressed through the parent
+ * upgrade ({@code /api/upgrades/&#123;id&#125;/reminders}), while updating and deleting address the
+ * reminder itself ({@code /api/reminders/&#123;id&#125;}), since a reminder has its own identity once
+ * it exists. Ownership is established through the parent upgrade either way — a reminder has no owner
+ * column of its own.
+ */
 @RestController
 @RequiredArgsConstructor
 public class ReminderController {
@@ -20,12 +29,31 @@ public class ReminderController {
     private final ReminderService service;
     private final ReminderWebMapper mapper;
 
+    /**
+     * Lists an upgrade's reminders, enabled or not.
+     *
+     * @param upgradeId the upgrade to read
+     * @return 200 with its reminders; empty when none are configured
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     */
     @GetMapping("/api/upgrades/{upgradeId}/reminders")
     public ResponseEntity<List<ReminderDto>> list(@AuthenticationPrincipal SecurityUser principal,
                                                    @PathVariable UUID upgradeId) {
         return ResponseEntity.ok(mapper.toDtos(service.getForUpgrade(principal.getId(), upgradeId)));
     }
 
+    /**
+     * Adds a reminder to an upgrade. An upgrade may have several.
+     *
+     * @param upgradeId the upgrade to attach it to
+     * @param req       the schedule; time is required, and an absent day list means every day
+     * @return 201 with the created reminder, enabled unless the body says otherwise
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if a day token is not
+     *         a recognisable day (422)
+     */
     @PostMapping("/api/upgrades/{upgradeId}/reminders")
     public ResponseEntity<ReminderDto> create(@AuthenticationPrincipal SecurityUser principal,
                                               @PathVariable UUID upgradeId,
@@ -34,6 +62,20 @@ public class ReminderController {
         return ResponseEntity.status(HttpStatus.CREATED).body(mapper.toDto(created));
     }
 
+    /**
+     * Reschedules a reminder, and switches it on or off when the body says so.
+     *
+     * <p>Omitting {@code enabled} leaves the current state alone, so rescheduling a disabled reminder
+     * does not silently switch it back on.
+     *
+     * @param id  the reminder to change
+     * @param req the new schedule
+     * @return 200 with the updated reminder
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if the reminder
+     *         does not exist, or its upgrade is not the caller's (404)
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if a day token is not
+     *         a recognisable day (422)
+     */
     @PutMapping("/api/reminders/{id}")
     public ResponseEntity<ReminderDto> update(@AuthenticationPrincipal SecurityUser principal,
                                               @PathVariable UUID id,
@@ -42,6 +84,14 @@ public class ReminderController {
         return ResponseEntity.ok(mapper.toDto(updated));
     }
 
+    /**
+     * Deletes a reminder.
+     *
+     * @param id the reminder to remove
+     * @return 204 with no body
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if the reminder
+     *         does not exist, or its upgrade is not the caller's (404)
+     */
     @DeleteMapping("/api/reminders/{id}")
     public ResponseEntity<Void> delete(@AuthenticationPrincipal SecurityUser principal, @PathVariable UUID id) {
         service.delete(principal.getId(), id);

--- a/backend/src/main/java/com/healthupgrades/reminder/adapter/in/web/ReminderDto.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/adapter/in/web/ReminderDto.java
@@ -4,6 +4,18 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * A reminder as returned on the wire.
+ *
+ * <p>{@code daysOfWeek} is rendered from the domain's own day type, so what a client reads back is the
+ * normalised three-letter form regardless of how it was written. An empty list means every day.
+ *
+ * @param id           the reminder's identifier
+ * @param upgradeId    the upgrade it belongs to
+ * @param reminderTime the local time it fires at
+ * @param daysOfWeek   the days it fires on, in calendar order; empty means every day
+ * @param enabled      whether it is switched on
+ */
 public record ReminderDto(
         UUID id,
         UUID upgradeId,

--- a/backend/src/main/java/com/healthupgrades/reminder/adapter/in/web/ReminderRequest.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/adapter/in/web/ReminderRequest.java
@@ -5,6 +5,18 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalTime;
 import java.util.List;
 
+/**
+ * Request body for creating or rescheduling a reminder.
+ *
+ * <p>Day tokens are accepted in the three-letter or full form, in any case, but an unrecognisable one
+ * is rejected rather than dropped — silently discarding it would leave an empty filter, which means
+ * every day, and turn a twice-weekly reminder into a daily one.
+ *
+ * @param reminderTime the local time to fire at; required
+ * @param daysOfWeek   the days to fire on, e.g. {@code ["MON","WED","FRI"]}; null or empty means daily
+ * @param enabled      whether it is switched on; null creates it enabled and leaves an existing one
+ *                     unchanged
+ */
 public record ReminderRequest(
         @NotNull LocalTime reminderTime,
         List<String> daysOfWeek,   // e.g. ["MON","WED","FRI"]; empty/null means every day

--- a/backend/src/main/java/com/healthupgrades/reminder/adapter/out/persistence/ReminderRepositoryAdapter.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/adapter/out/persistence/ReminderRepositoryAdapter.java
@@ -18,28 +18,33 @@ class ReminderRepositoryAdapter implements ReminderRepositoryPort {
 
     private final ReminderJpaRepository jpa; // Spring Data proxy
 
+    /** {@inheritDoc} */
     @Override
     public Reminder save(Reminder reminder) {
-        return jpa.save(reminder); // delegate persist
+        return jpa.save(reminder);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void delete(Reminder reminder) {
-        jpa.delete(reminder); // delegate delete
+        jpa.delete(reminder);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<Reminder> findById(UUID id) {
-        return jpa.findById(id); // delegate to inherited lookup
+        return jpa.findById(id);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Reminder> findByUpgradeId(UUID upgradeId) {
-        return jpa.findByUpgradeId(upgradeId); // delegate
+        return jpa.findByUpgradeId(upgradeId);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Reminder> findByEnabledTrue() {
-        return jpa.findByEnabledTrue(); // delegate
+        return jpa.findByEnabledTrue();
     }
 }

--- a/backend/src/main/java/com/healthupgrades/reminder/application/ReminderService.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/application/ReminderService.java
@@ -14,6 +14,13 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Use cases for reminders: attach one to an upgrade, reschedule it, remove it, and expose the enabled
+ * ones for dispatch.
+ *
+ * <p>A reminder has no owner of its own — ownership is established through the upgrade it belongs to,
+ * which is why every method here starts by resolving that upgrade through {@link UpgradeQuery}.
+ */
 @Service
 @RequiredArgsConstructor
 public class ReminderService implements ReminderQuery {
@@ -21,7 +28,17 @@ public class ReminderService implements ReminderQuery {
     private final ReminderRepositoryPort repository;
     private final UpgradeQuery upgradeQuery;
 
-    /** Creates a reminder on an owned upgrade. New reminders are enabled unless told otherwise. */
+    /**
+     * Attaches a reminder to an owned upgrade.
+     *
+     * @param userId    the owner
+     * @param upgradeId the upgrade to attach it to
+     * @param schedule  when it should fire; a null enabled flag creates it enabled
+     * @return the persisted reminder
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if a day token is not a
+     *         recognisable day
+     */
     @Transactional
     public Reminder create(UUID userId, UUID upgradeId, ReminderSchedule schedule) {
         upgradeQuery.getOwnedUpgrade(userId, upgradeId); // ownership check (throws if not owned)
@@ -30,13 +47,30 @@ public class ReminderService implements ReminderQuery {
         return repository.save(reminder);
     }
 
-    /** An owned upgrade's reminders. */
+    /**
+     * Reads an owned upgrade's reminders, enabled or not.
+     *
+     * @param userId    the owner
+     * @param upgradeId the upgrade to read
+     * @return its reminders; empty when none are configured
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     */
     public List<Reminder> getForUpgrade(UUID userId, UUID upgradeId) {
         upgradeQuery.getOwnedUpgrade(userId, upgradeId);
         return repository.findByUpgradeId(upgradeId);
     }
 
-    /** Reschedules an owned reminder, leaving its enabled state alone unless one is supplied. */
+    /**
+     * Reschedules an owned reminder, and switches it on or off when the schedule says so.
+     *
+     * @param userId     the owner
+     * @param reminderId the reminder to change
+     * @param schedule   the new time and days; a null enabled flag leaves the current state alone
+     * @return the saved reminder
+     * @throws ResourceNotFoundException if the reminder does not exist, or its upgrade is not the user's
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if a day token is not a
+     *         recognisable day
+     */
     @Transactional
     public Reminder update(UUID userId, UUID reminderId, ReminderSchedule schedule) {
         Reminder reminder = getOwnedReminder(userId, reminderId);
@@ -45,12 +79,20 @@ public class ReminderService implements ReminderQuery {
         return repository.save(reminder);
     }
 
+    /**
+     * Deletes an owned reminder.
+     *
+     * @param userId     the owner
+     * @param reminderId the reminder to remove
+     * @throws ResourceNotFoundException if the reminder does not exist, or its upgrade is not the user's
+     */
     @Transactional
     public void delete(UUID userId, UUID reminderId) {
         Reminder reminder = getOwnedReminder(userId, reminderId);
         repository.delete(reminder);
     }
 
+    /** Single ownership guard: a reminder is the caller's only if the upgrade it hangs off is. */
     private Reminder getOwnedReminder(UUID userId, UUID reminderId) {
         Reminder reminder = repository.findById(reminderId)
                 .orElseThrow(() -> new ResourceNotFoundException("Reminder not found: " + reminderId));

--- a/backend/src/main/java/com/healthupgrades/reminder/domain/model/Reminder.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/domain/model/Reminder.java
@@ -43,7 +43,15 @@ public class Reminder {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
-    /** Creates a reminder for an upgrade. A reminder is enabled unless explicitly created disabled. */
+    /**
+     * Creates a reminder for an upgrade.
+     *
+     * @param upgradeId    the upgrade it belongs to, and through which it is owned
+     * @param reminderTime the local time it fires at
+     * @param days         the days it fires on; an empty filter means every day
+     * @param enabled      whether it starts switched on
+     * @return the new reminder
+     */
     public static Reminder create(UUID upgradeId, LocalTime reminderTime, ReminderDays days, boolean enabled) {
         return Reminder.builder()
                 .upgradeId(upgradeId)
@@ -53,13 +61,22 @@ public class Reminder {
                 .build();
     }
 
-    /** Changes when the reminder fires. */
+    /**
+     * Changes when the reminder fires, leaving its enabled state untouched.
+     *
+     * @param reminderTime the new local time
+     * @param days         the new day filter; empty means every day
+     */
     public void reschedule(LocalTime reminderTime, ReminderDays days) {
         this.reminderTime = reminderTime;
         this.daysOfWeek = days.toStorageValue();
     }
 
-    /** Turns the reminder on or off without otherwise changing its schedule. */
+    /**
+     * Turns the reminder on or off without otherwise changing its schedule.
+     *
+     * @param enabled whether it should fire
+     */
     public void changeEnabled(boolean enabled) {
         this.enabled = enabled;
     }
@@ -77,6 +94,13 @@ public class Reminder {
     /**
      * Whether this reminder should fire at the given moment: it is enabled, the day matches its filter,
      * and the wall-clock hour and minute match its configured time.
+     *
+     * <p>Compared to the minute, not to the second, because the dispatch job wakes once a minute — an
+     * exact-instant comparison would miss almost every reminder.
+     *
+     * @param day  the day being checked
+     * @param time the wall-clock time being checked
+     * @return true if the reminder is due right now
      */
     public boolean isDueAt(DayOfWeek day, LocalTime time) {
         return isEnabled()
@@ -86,12 +110,14 @@ public class Reminder {
                 && reminderTime.getMinute() == time.getMinute();
     }
 
+    /** Stamps the creation and update timestamps before the row is first inserted. */
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
     }
 
+    /** Refreshes the update timestamp before each update. */
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();

--- a/backend/src/main/java/com/healthupgrades/reminder/domain/model/ReminderDays.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/domain/model/ReminderDays.java
@@ -105,16 +105,19 @@ public final class ReminderDays {
         return days.isEmpty() || days.contains(day);
     }
 
+    /** Value equality: two filters are equal when they cover the same set of days. */
     @Override
     public boolean equals(Object other) {
         return other instanceof ReminderDays that && days.equals(that.days);
     }
 
+    /** {@inheritDoc} Consistent with {@link #equals(Object)}. */
     @Override
     public int hashCode() {
         return days.hashCode();
     }
 
+    /** Diagnostic form: the day tokens, or "every day" when there is no filter. */
     @Override
     public String toString() {
         return days.isEmpty() ? "every day" : String.join(SEPARATOR, toTokens());

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/ProgressController.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/ProgressController.java
@@ -12,6 +12,17 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * REST adapter for logging and reading progress.
+ *
+ * <p>The routes are split across two prefixes rather than one, and deliberately: entries filed against a
+ * single upgrade live under {@code /api/upgrades/&#123;id&#125;/…}, while the cross-upgrade views the daily
+ * check-in and dashboard need live under {@code /api/progress/…}. That is why this controller declares
+ * no class-level {@code @RequestMapping}.
+ *
+ * <p>Every endpoint is scoped to the authenticated principal, and the ones addressing a single upgrade
+ * confirm ownership before touching progress.
+ */
 @RestController
 @RequiredArgsConstructor
 public class ProgressController {
@@ -19,6 +30,21 @@ public class ProgressController {
     private final TrackingService trackingService;
     private final TrackingWebMapper mapper;
 
+    /**
+     * Logs a day's progress against an upgrade.
+     *
+     * <p>The {@code completed} flag in the body is advisory: when the upgrade has a tracking
+     * configuration the server recomputes it from the target, so a client cannot mark a missed target
+     * as done.
+     *
+     * @param upgradeId the upgrade being logged against
+     * @param req       the entry; date defaults to today
+     * @return 201 with the stored entry, carrying the server's completion verdict
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     * @throws com.healthupgrades.common.domain.exception.DuplicateProgressException if an entry
+     *         already exists for that upgrade and date (409)
+     */
     @PostMapping("/api/upgrades/{upgradeId}/progress")
     public ResponseEntity<ProgressDto> recordProgress(
             @AuthenticationPrincipal SecurityUser principal,
@@ -28,6 +54,14 @@ public class ProgressController {
                 trackingService.recordProgress(principal.getId(), upgradeId, mapper.toDetails(req))));
     }
 
+    /**
+     * Lists an upgrade's progress history, newest first.
+     *
+     * @param upgradeId the upgrade to read
+     * @return 200 with every entry logged against it
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     */
     @GetMapping("/api/upgrades/{upgradeId}/progress")
     public ResponseEntity<List<ProgressDto>> getProgress(
             @AuthenticationPrincipal SecurityUser principal,
@@ -35,6 +69,14 @@ public class ProgressController {
         return ResponseEntity.ok(mapper.toDtos(trackingService.getProgress(principal.getId(), upgradeId)));
     }
 
+    /**
+     * Returns an upgrade's current and longest streak, both computed on the fly from its entries.
+     *
+     * @param upgradeId the upgrade to measure
+     * @return 200 with the streak figures
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     */
     @GetMapping("/api/upgrades/{upgradeId}/streak")
     public ResponseEntity<StreakDto> getStreak(
             @AuthenticationPrincipal SecurityUser principal,
@@ -42,11 +84,22 @@ public class ProgressController {
         return ResponseEntity.ok(mapper.toDto(trackingService.getStreakSummary(principal.getId(), upgradeId)));
     }
 
+    /**
+     * Returns everything the caller has logged today, across all upgrades — what the daily check-in
+     * page uses to tell logged from unlogged.
+     *
+     * @return 200 with today's entries, empty when nothing has been logged
+     */
     @GetMapping("/api/progress/today")
     public ResponseEntity<List<ProgressDto>> getToday(@AuthenticationPrincipal SecurityUser principal) {
         return ResponseEntity.ok(mapper.toDtos(trackingService.getTodayProgress(principal.getId())));
     }
 
+    /**
+     * Returns the caller's entries for the last seven days, today inclusive.
+     *
+     * @return 200 with the week's entries
+     */
     @GetMapping("/api/progress/week")
     public ResponseEntity<List<ProgressDto>> getWeek(@AuthenticationPrincipal SecurityUser principal) {
         return ResponseEntity.ok(mapper.toDtos(trackingService.getWeekProgress(principal.getId())));

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/ProgressDto.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/ProgressDto.java
@@ -4,6 +4,24 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * A logged progress entry as returned on the wire.
+ *
+ * <p>Which value field is meaningful depends on the upgrade's tracking type; the others are null.
+ * {@code completed} is the server's verdict, not the client's claim — for a configured upgrade it is
+ * recomputed from the target when the entry is recorded.
+ *
+ * @param id           the entry's identifier
+ * @param upgradeId    the upgrade it was logged against
+ * @param userId       the owner
+ * @param date         the day the entry is for
+ * @param completed    whether it counts as a success
+ * @param numericValue NUMERIC tracking: the value achieved, else null
+ * @param unit         NUMERIC tracking: the unit that value is in, else null
+ * @param rating       RATING tracking: the one-to-five self-rating, else null
+ * @param note         free-text note, and the scored field under TEXT tracking
+ * @param createdAt    when the entry was logged, which may differ from {@code date}
+ */
 public record ProgressDto(
         UUID id,
         UUID upgradeId,

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/ProgressRequest.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/ProgressRequest.java
@@ -6,6 +6,20 @@ import jakarta.validation.constraints.PositiveOrZero;
 
 import java.time.LocalDate;
 
+/**
+ * Request body for logging a day's progress.
+ *
+ * <p>Every field is optional because which one matters depends on the upgrade's tracking type. Sending
+ * the field a type does not use is accepted and stored; it simply plays no part in scoring.
+ *
+ * @param date         the day being logged; today when null. A past date is allowed, a duplicate is not
+ * @param completed    claimed completion; overridden by the server when the upgrade has a configuration
+ * @param numericValue NUMERIC tracking: the value achieved; must be zero or positive
+ * @param unit         NUMERIC tracking: the unit the value is in. Unstated is read as the target's unit;
+ *                     a unit that disagrees with the target's means the entry is not a success
+ * @param rating       RATING tracking: one to five inclusive
+ * @param note         free-text note; the scored field under TEXT tracking
+ */
 public record ProgressRequest(
         LocalDate date,
         Boolean completed,

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/StreakDto.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/StreakDto.java
@@ -1,3 +1,9 @@
 package com.healthupgrades.tracking.adapter.in.web;
 
+/**
+ * An upgrade's streak figures, both counted in consecutive completed days.
+ *
+ * @param current days in the run ending today, or ending yesterday when today is not logged yet
+ * @param longest the longest run across the upgrade's whole history
+ */
 public record StreakDto(int current, int longest) {}

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigController.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigController.java
@@ -10,6 +10,13 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+/**
+ * REST adapter for an upgrade's tracking configuration — how its progress is measured and what counts
+ * as success.
+ *
+ * <p>A sub-resource of an upgrade, and one per upgrade at most, which is why it is written with
+ * {@code PUT} (create-or-replace) rather than {@code POST}.
+ */
 @RestController
 @RequestMapping("/api/upgrades/{upgradeId}/tracking-config")
 @RequiredArgsConstructor
@@ -18,6 +25,18 @@ public class TrackingConfigController {
     private final TrackingService trackingService;
     private final TrackingWebMapper mapper;
 
+    /**
+     * Creates or replaces an upgrade's tracking configuration.
+     *
+     * <p>Idempotent: repeating the call with the same body leaves the same single configuration.
+     * Changing the type later does not rescore entries already logged.
+     *
+     * @param upgradeId the upgrade to configure
+     * @param req       the configuration; tracking type is required
+     * @return 200 with the stored configuration
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     */
     @PutMapping
     public ResponseEntity<TrackingConfigDto> saveConfig(
             @AuthenticationPrincipal SecurityUser principal,
@@ -27,6 +46,16 @@ public class TrackingConfigController {
                 trackingService.saveConfig(principal.getId(), upgradeId, mapper.toDetails(req))));
     }
 
+    /**
+     * Reads an upgrade's tracking configuration.
+     *
+     * @param upgradeId the upgrade to read
+     * @return 200 with the configuration
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if the upgrade has
+     *         no tracking configuration (404)
+     */
     @GetMapping
     public ResponseEntity<TrackingConfigDto> getConfig(
             @AuthenticationPrincipal SecurityUser principal,

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigDto.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigDto.java
@@ -5,6 +5,21 @@ import com.healthupgrades.tracking.domain.model.TrackingType;
 
 import java.util.UUID;
 
+/**
+ * An upgrade's tracking configuration as returned on the wire.
+ *
+ * <p>The same data is embedded in an upgrade response as {@code UpgradeTrackingConfigDto}, which
+ * restates these fields in the upgrade context's own types. The duplication is deliberate — it is what
+ * lets either contract change without breaking the other.
+ *
+ * @param id                 the configuration's identifier
+ * @param upgradeId          the upgrade it configures
+ * @param trackingType       how progress is measured, and therefore how success is judged
+ * @param frequency          how often the upgrade is expected to be acted on, may be null
+ * @param targetNumericValue NUMERIC tracking: the value to reach, else null
+ * @param targetUnit         NUMERIC tracking: the unit the target is stated in, else null
+ * @param requiredDaily      whether the user treats this as a must-do each day, may be null
+ */
 public record TrackingConfigDto(
         UUID id,
         UUID upgradeId,

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigRequest.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigRequest.java
@@ -6,6 +6,19 @@ import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
+/**
+ * Request body for creating or replacing an upgrade's tracking configuration.
+ *
+ * <p>A full replacement: an omitted optional field is stored as null rather than left at its previous
+ * value.
+ *
+ * @param trackingType       how progress is measured; required, and it decides which of the rest apply
+ * @param frequency          how often the upgrade is expected to be acted on, optional
+ * @param targetNumericValue NUMERIC tracking: the value an entry must reach, optional
+ * @param targetUnit         NUMERIC tracking: the unit the target is in; an entry logged in a different
+ *                           unit is never scored as a success, optional
+ * @param requiredDaily      whether this is a must-do each day, optional
+ */
 public record TrackingConfigRequest(
         @NotNull TrackingType trackingType,
         Frequency frequency,

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/out/persistence/ProgressEntryRepositoryAdapter.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/out/persistence/ProgressEntryRepositoryAdapter.java
@@ -18,33 +18,39 @@ class ProgressEntryRepositoryAdapter implements ProgressEntryRepositoryPort {
 
     private final ProgressEntryJpaRepository jpa; // Spring Data proxy
 
+    /** {@inheritDoc} */
     @Override
     public ProgressEntry save(ProgressEntry entry) {
-        return jpa.save(entry); // delegate persist
+        return jpa.save(entry);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean existsByUpgradeIdAndDate(UUID upgradeId, LocalDate date) {
-        return jpa.existsByUpgradeIdAndDate(upgradeId, date); // delegate dedup check
+        return jpa.existsByUpgradeIdAndDate(upgradeId, date);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<ProgressEntry> findByUpgradeId(UUID upgradeId) {
-        return jpa.findByUpgradeId(upgradeId); // delegate
+        return jpa.findByUpgradeId(upgradeId);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<ProgressEntry> findByUpgradeIdOrderByDateDesc(UUID upgradeId) {
-        return jpa.findByUpgradeIdOrderByDateDesc(upgradeId); // delegate
+        return jpa.findByUpgradeIdOrderByDateDesc(upgradeId);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<ProgressEntry> findByUserIdAndDate(UUID userId, LocalDate date) {
-        return jpa.findByUserIdAndDate(userId, date); // delegate
+        return jpa.findByUserIdAndDate(userId, date);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<ProgressEntry> findByUserIdAndDateBetween(UUID userId, LocalDate start, LocalDate end) {
-        return jpa.findByUserIdAndDateBetween(userId, start, end); // delegate range query
+        return jpa.findByUserIdAndDateBetween(userId, start, end);
     }
 }

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/out/persistence/TrackingConfigRepositoryAdapter.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/out/persistence/TrackingConfigRepositoryAdapter.java
@@ -19,18 +19,21 @@ class TrackingConfigRepositoryAdapter implements TrackingConfigRepositoryPort {
 
     private final TrackingConfigJpaRepository jpa; // Spring Data proxy
 
+    /** {@inheritDoc} */
     @Override
     public TrackingConfig save(TrackingConfig config) {
-        return jpa.save(config); // delegate persist
+        return jpa.save(config);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<TrackingConfig> findByUpgradeId(UUID upgradeId) {
-        return jpa.findByUpgradeId(upgradeId); // delegate
+        return jpa.findByUpgradeId(upgradeId);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<TrackingConfig> findByUpgradeIdIn(Collection<UUID> upgradeIds) {
-        return jpa.findByUpgradeIdIn(upgradeIds); // delegate batch load
+        return jpa.findByUpgradeIdIn(upgradeIds);
     }
 }

--- a/backend/src/main/java/com/healthupgrades/tracking/application/TrackingBeansConfig.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/application/TrackingBeansConfig.java
@@ -17,12 +17,12 @@ public class TrackingBeansConfig {
     /** Exposes the stateless {@link StreakCalculator} as an injectable bean. */
     @Bean
     public StreakCalculator streakCalculator() {
-        return new StreakCalculator(); // no dependencies -> plain construction
+        return new StreakCalculator();
     }
 
     /** Exposes the stateless {@link ProgressEvaluationService} as an injectable bean. */
     @Bean
     public ProgressEvaluationService progressEvaluationService() {
-        return new ProgressEvaluationService(); // no dependencies -> plain construction
+        return new ProgressEvaluationService();
     }
 }

--- a/backend/src/main/java/com/healthupgrades/tracking/application/TrackingService.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/application/TrackingService.java
@@ -49,7 +49,18 @@ public class TrackingService implements TrackingConfigQuery, ProgressQuery, Stre
     private final DomainEventPublisher eventPublisher; // in-process domain events
     private final Clock clock; // single source of "today" for defaulting and streaks
 
-    /** Creates or updates the tracking config for an owned upgrade. */
+    /**
+     * Creates or replaces the tracking configuration for an owned upgrade.
+     *
+     * <p>Existing entries are not rescored when the configuration changes: a past day was judged by the
+     * rule in force when it was logged, and rewriting history would move streaks the user already saw.
+     *
+     * @param userId    the owner
+     * @param upgradeId the upgrade to configure
+     * @param details   the configuration to store
+     * @return the saved configuration
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     */
     @Transactional
     public TrackingConfig saveConfig(UUID userId, UUID upgradeId, TrackingConfigDetails details) {
         upgradeQuery.getOwnedUpgrade(userId, upgradeId); // ownership check (throws if not owned)
@@ -64,14 +75,34 @@ public class TrackingService implements TrackingConfigQuery, ProgressQuery, Stre
         return configRepository.save(config);
     }
 
-    /** Returns the tracking config for an owned upgrade. */
+    /**
+     * Reads the tracking configuration of an owned upgrade.
+     *
+     * @param userId    the owner
+     * @param upgradeId the upgrade to read
+     * @return the configuration
+     * @throws ResourceNotFoundException if the upgrade is not the caller's, or has no configuration
+     */
     public TrackingConfig getConfig(UUID userId, UUID upgradeId) {
         upgradeQuery.getOwnedUpgrade(userId, upgradeId);
         return configRepository.findByUpgradeId(upgradeId)
                 .orElseThrow(() -> new ResourceNotFoundException("Tracking config not found for upgrade: " + upgradeId));
     }
 
-    /** Records a progress entry for an owned upgrade, deriving completion from the config when present. */
+    /**
+     * Logs a day's progress against an owned upgrade and announces it.
+     *
+     * <p>Two things happen that the caller does not ask for. Completion is recomputed from the tracking
+     * configuration, so the stored verdict is the server's rather than the client's; and the resulting
+     * streak is measured, raising {@link StreakAchieved} when it lands on a milestone.
+     *
+     * @param userId    the owner
+     * @param upgradeId the upgrade being logged against
+     * @param details   the entry; a null date means today by the injected clock
+     * @return the persisted entry, carrying the server's completion verdict
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     * @throws DuplicateProgressException if an entry already exists for that upgrade and date
+     */
     @Transactional
     public ProgressEntry recordProgress(UUID userId, UUID upgradeId, ProgressEntryDetails details) {
         upgradeQuery.getOwnedUpgrade(userId, upgradeId);
@@ -105,25 +136,52 @@ public class TrackingService implements TrackingConfigQuery, ProgressQuery, Stre
 
         List<ProgressEntry> allEntries = progressRepository.findByUpgradeIdOrderByDateDesc(upgradeId);
         int streak = streakCalculator.calculateCurrentStreak(allEntries, LocalDate.now(clock));
-        if (streak > 0 && streak % 7 == 0) { // celebrate every 7-day milestone
+        // Every seventh day only. Announcing each consecutive day would make the milestone worthless
+        // and would put a notification in the user's list once a day per tracked upgrade.
+        if (streak > 0 && streak % 7 == 0) {
             eventPublisher.publish(new StreakAchieved(upgradeId, userId, streak, LocalDateTime.now()));
         }
 
         return entry;
     }
 
-    /** Lists progress entries for an owned upgrade, newest first. */
+    /**
+     * Lists an owned upgrade's progress entries, newest first.
+     *
+     * @param userId    the owner
+     * @param upgradeId the upgrade to read
+     * @return its entries, newest first; empty when nothing has been logged
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     */
     public List<ProgressEntry> getProgress(UUID userId, UUID upgradeId) {
         upgradeQuery.getOwnedUpgrade(userId, upgradeId);
         return progressRepository.findByUpgradeIdOrderByDateDesc(upgradeId);
     }
 
-    /** Today's progress entries for the caller across all upgrades. */
+    /**
+     * Everything the user has logged today, across every upgrade.
+     *
+     * <p>No ownership check is needed: the query is scoped by user id, so it can only return the
+     * caller's own entries.
+     *
+     * @param userId the owner
+     * @return today's entries by the injected clock
+     */
     public List<ProgressEntry> getTodayProgress(UUID userId) {
         return progressRepository.findByUserIdAndDate(userId, LocalDate.now(clock));
     }
 
-    /** Current and longest streak for an owned upgrade. */
+    /**
+     * Computes an owned upgrade's current and longest streaks from its history.
+     *
+     * <p>Computed on each call rather than stored, so a streak cannot drift out of step with the entries
+     * behind it.
+     *
+     * @param userId    the owner
+     * @param upgradeId the upgrade to measure
+     * @return the streak figures
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     */
     public StreakSummary getStreakSummary(UUID userId, UUID upgradeId) {
         upgradeQuery.getOwnedUpgrade(userId, upgradeId);
         List<ProgressEntry> entries = progressRepository.findByUpgradeIdOrderByDateDesc(upgradeId);
@@ -132,7 +190,12 @@ public class TrackingService implements TrackingConfigQuery, ProgressQuery, Stre
                 streakCalculator.calculateLongestStreak(entries));
     }
 
-    /** The caller's progress entries over the last 7 days. */
+    /**
+     * The user's entries over the last seven days, today inclusive.
+     *
+     * @param userId the owner
+     * @return the week's entries, ordered as the store returns them
+     */
     public List<ProgressEntry> getWeekProgress(UUID userId) {
         LocalDate today = LocalDate.now(clock);
         LocalDate weekAgo = today.minusDays(6);
@@ -163,10 +226,14 @@ public class TrackingService implements TrackingConfigQuery, ProgressQuery, Stre
 
     // ---- StreakQuery (inbound port) ----
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Unscoped by user, unlike the rest of this service: the caller is the dashboard, which has
+     * already established ownership of the upgrades it is summarising.
+     */
     @Override
     public int currentStreak(UUID upgradeId) {
-        // Load the upgrade's entries and delegate to the pure domain streak calculator.
         return streakCalculator.calculateCurrentStreak(
                 progressRepository.findByUpgradeIdOrderByDateDesc(upgradeId), LocalDate.now(clock));
     }

--- a/backend/src/main/java/com/healthupgrades/tracking/domain/event/ProgressEntryRecorded.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/domain/event/ProgressEntryRecorded.java
@@ -6,4 +6,16 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Raised when a user logs progress against an upgrade for a given day.
+ *
+ * <p>Fires once per entry, and there can only ever be one entry per upgrade per date — a second is
+ * rejected as a duplicate rather than replacing the first.
+ *
+ * @param progressId the entry that was recorded
+ * @param upgradeId  the upgrade it was logged against
+ * @param userId     the owner
+ * @param date       the day the entry is for, which need not be the day it was logged
+ * @param occurredAt when the entry was recorded
+ */
 public record ProgressEntryRecorded(UUID progressId, UUID upgradeId, UUID userId, LocalDate date, LocalDateTime occurredAt) implements DomainEvent {}

--- a/backend/src/main/java/com/healthupgrades/tracking/domain/event/StreakAchieved.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/domain/event/StreakAchieved.java
@@ -5,4 +5,15 @@ import com.healthupgrades.common.domain.event.DomainEvent;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Raised when a newly recorded entry lands the user on a streak worth remarking on.
+ *
+ * <p>Only milestone lengths raise this — every consecutive day would otherwise produce a notification a
+ * day, which is how a streak stops being an achievement. The milestones live in the tracking service.
+ *
+ * @param upgradeId  the upgrade being kept up
+ * @param userId     the owner
+ * @param streakDays the streak length reached
+ * @param occurredAt when the milestone was reached
+ */
 public record StreakAchieved(UUID upgradeId, UUID userId, int streakDays, LocalDateTime occurredAt) implements DomainEvent {}

--- a/backend/src/main/java/com/healthupgrades/tracking/domain/model/Frequency.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/domain/model/Frequency.java
@@ -1,7 +1,19 @@
 package com.healthupgrades.tracking.domain.model;
 
+/**
+ * How often an upgrade is expected to be acted on.
+ *
+ * <p>Descriptive rather than enforced: nothing rejects a daily entry on a weekly upgrade. Streaks are
+ * counted in consecutive days regardless of this value, so a weekly upgrade does not accumulate one.
+ */
 public enum Frequency {
+
+    /** Expected every day. */
     DAILY,
+
+    /** Expected once a week. */
     WEEKLY,
+
+    /** Expected once a month. */
     MONTHLY
 }

--- a/backend/src/main/java/com/healthupgrades/tracking/domain/model/ProgressEntry.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/domain/model/ProgressEntry.java
@@ -7,6 +7,16 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * One day's progress against one upgrade.
+ *
+ * <p>At most one entry may exist per upgrade per date. That is a domain invariant checked before
+ * insertion and backed by a unique constraint here, so a race that slips past the check still fails at
+ * the database rather than producing two entries for a day.
+ *
+ * <p>Which of the value fields is meaningful depends on the upgrade's {@link TrackingType}: an entry
+ * carries all of them and fills in the one its type calls for, so the columns are nullable by design.
+ */
 @Entity
 @Table(name = "progress_entries",
         uniqueConstraints = @UniqueConstraint(columnNames = {"upgrade_id", "date"}))
@@ -27,17 +37,23 @@ public class ProgressEntry {
     @Column(nullable = false)
     private UUID userId;
 
+    /** The day this entry is for, which is not necessarily the day it was logged. */
     @Column(nullable = false)
     private LocalDate date;
 
+    /** BOOLEAN tracking: whether the user did it. Also what streaks are counted from. */
     private Boolean completed;
 
+    /** NUMERIC tracking: the value achieved. */
     private Double numericValue;
 
+    /** NUMERIC tracking: the unit the value is in; compared against the target's unit before scoring. */
     private String unit;
 
+    /** RATING tracking: a one-to-five self-assessment. */
     private Integer rating;
 
+    /** TEXT tracking: the note. Free-text on any entry type, but only here is it what is scored. */
     private String note;
 
     @Column(nullable = false, updatable = false)
@@ -46,12 +62,14 @@ public class ProgressEntry {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+    /** Stamps the creation and update timestamps before the row is first inserted. */
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
     }
 
+    /** Refreshes the update timestamp before each update. */
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();

--- a/backend/src/main/java/com/healthupgrades/tracking/domain/model/TrackingConfig.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/domain/model/TrackingConfig.java
@@ -5,6 +5,16 @@ import lombok.*;
 
 import java.util.UUID;
 
+/**
+ * How one upgrade is tracked: the measurement type, how often it is expected, and the target to beat.
+ *
+ * <p>One configuration per upgrade at most, enforced by the unique constraint on {@code upgradeId}. An
+ * upgrade with none simply cannot be scored — progress can still be logged against it, and
+ * {@code ProgressEvaluationService} reports every such entry as unsuccessful rather than guessing.
+ *
+ * <p>Referenced across the context boundary by upgrade responses, but only through
+ * {@code UpgradeTrackingSummary}, which restates these fields in the upgrade context's own terms.
+ */
 @Entity
 @Table(name = "tracking_configs")
 @Getter
@@ -18,19 +28,25 @@ public class TrackingConfig {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    /** The upgrade this configures; unique, so an upgrade has at most one configuration. */
     @Column(nullable = false, unique = true)
     private UUID upgradeId;
 
+    /** What kind of measurement an entry carries, and therefore how success is judged. */
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private TrackingType trackingType;
 
+    /** How often the upgrade is expected to be acted on; descriptive, not enforced. */
     @Enumerated(EnumType.STRING)
     private Frequency frequency;
 
+    /** NUMERIC tracking: the value an entry must reach to count as a success. */
     private Double targetNumericValue;
 
+    /** NUMERIC tracking: the unit the target is stated in; an entry in another unit is not scored. */
     private String targetUnit;
 
+    /** Whether the user considers this a must-do every day; presentation only. */
     private Boolean requiredDaily;
 }

--- a/backend/src/main/java/com/healthupgrades/tracking/domain/model/TrackingType.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/domain/model/TrackingType.java
@@ -1,8 +1,23 @@
 package com.healthupgrades.tracking.domain.model;
 
+/**
+ * How progress on an upgrade is measured, which decides both what a progress entry must carry and what
+ * counts as a success.
+ *
+ * <p>The success rule for each is applied by {@code ProgressEvaluationService} — the single place that
+ * knows what "done" means for a given type.
+ */
 public enum TrackingType {
+
+    /** Did it or did not: the entry's completion flag decides. */
     BOOLEAN,
+
+    /** A measured quantity: success is reaching the target, and only when the units agree. */
     NUMERIC,
+
+    /** A one-to-five self-rating: three or better counts as a success. */
     RATING,
+
+    /** A written note: any non-blank text counts as a success. */
     TEXT
 }

--- a/backend/src/main/java/com/healthupgrades/tracking/domain/service/ProgressEvaluationService.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/domain/service/ProgressEvaluationService.java
@@ -18,17 +18,20 @@ public class ProgressEvaluationService {
      * non-blank text.
      */
     public boolean isSuccessful(ProgressEntry entry, TrackingConfig config) {
-        if (entry == null || config == null) return false; // nothing to evaluate against
+        // An upgrade with no tracking configuration has no definition of success, so nothing
+        // logged against it can be scored as one.
+        if (entry == null || config == null) return false;
 
         // The success rule depends on how this upgrade is tracked.
         return switch (config.getTrackingType()) {
-            case BOOLEAN -> Boolean.TRUE.equals(entry.getCompleted()); // did-it / didn't
+            case BOOLEAN -> Boolean.TRUE.equals(entry.getCompleted());
             case NUMERIC -> entry.getNumericValue() != null
                     && config.getTargetNumericValue() != null
                     && unitsAreComparable(entry.getUnit(), config.getTargetUnit())
-                    && entry.getNumericValue() >= config.getTargetNumericValue(); // met the numeric target
-            case RATING -> entry.getRating() != null && entry.getRating() >= 3; // rated 3+ out of 5
-            case TEXT -> entry.getNote() != null && !entry.getNote().isBlank(); // wrote something
+                    && entry.getNumericValue() >= config.getTargetNumericValue();
+            // 3 is the midpoint of the one-to-five scale: an average day counts, a bad one does not.
+            case RATING -> entry.getRating() != null && entry.getRating() >= 3;
+            case TEXT -> entry.getNote() != null && !entry.getNote().isBlank();
         };
     }
 

--- a/backend/src/main/java/com/healthupgrades/tracking/domain/service/StreakCalculator.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/domain/service/StreakCalculator.java
@@ -23,7 +23,7 @@ public class StreakCalculator {
      * pure and lets callers that inject a {@link java.time.Clock} decide what "today" means.
      */
     public int calculateCurrentStreak(List<ProgressEntry> entries, LocalDate today) {
-        if (entries == null || entries.isEmpty()) return 0; // no data -> no streak
+        if (entries == null || entries.isEmpty()) return 0;
 
         // Collect the distinct dates the user actually completed the habit.
         Set<LocalDate> completedDates = entries.stream()
@@ -31,7 +31,7 @@ public class StreakCalculator {
                 .map(ProgressEntry::getDate)
                 .collect(Collectors.toSet());
 
-        if (completedDates.isEmpty()) return 0; // logged entries but none completed
+        if (completedDates.isEmpty()) return 0;
 
         int streak = 0;
         LocalDate current = today;
@@ -56,7 +56,7 @@ public class StreakCalculator {
 
     /** Calculates the longest run of consecutive completed days across the entire history. */
     public int calculateLongestStreak(List<ProgressEntry> entries) {
-        if (entries == null || entries.isEmpty()) return 0; // no data -> no streak
+        if (entries == null || entries.isEmpty()) return 0;
 
         // Distinct completed dates, ascending, so consecutive runs are adjacent.
         List<LocalDate> sortedDates = entries.stream()
@@ -66,10 +66,10 @@ public class StreakCalculator {
                 .sorted()
                 .toList();
 
-        if (sortedDates.isEmpty()) return 0; // no completed days
+        if (sortedDates.isEmpty()) return 0;
 
-        int maxStreak = 1; // best run seen so far
-        int currentStreak = 1; // current run length
+        int maxStreak = 1;
+        int currentStreak = 1;
 
         // Extend the run when the next date is exactly one day after the previous, else reset.
         for (int i = 1; i < sortedDates.size(); i++) {

--- a/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/ActivateRequest.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/ActivateRequest.java
@@ -2,4 +2,12 @@ package com.healthupgrades.upgrade.adapter.in.web;
 
 import java.time.LocalDate;
 
+/**
+ * Optional body for the activate endpoint.
+ *
+ * <p>The whole body may be omitted, which is why every field is optional: activating without one starts
+ * the upgrade today.
+ *
+ * @param startDate the date the upgrade starts running; today when null
+ */
 public record ActivateRequest(LocalDate startDate) {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/PlanRequest.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/PlanRequest.java
@@ -4,4 +4,10 @@ import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 
+/**
+ * Body for the plan endpoint.
+ *
+ * @param plannedStartDate the date the user intends to start; required, and free to be in the past,
+ *                         since users plan retroactively
+ */
 public record PlanRequest(@NotNull LocalDate plannedStartDate) {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/RescheduleRequest.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/RescheduleRequest.java
@@ -4,4 +4,9 @@ import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 
+/**
+ * Body for the reschedule endpoint.
+ *
+ * @param newDate the new planned start date; required
+ */
 public record RescheduleRequest(@NotNull LocalDate newDate) {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeController.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeController.java
@@ -16,8 +16,17 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Inbound web adapter for the upgrade lifecycle. Delegates to {@link UpgradeService} (which returns domain
- * objects) and maps the results to {@link UpgradeDto} via {@link UpgradeWebMapper}.
+ * REST adapter for the upgrade lifecycle — the API's central resource.
+ *
+ * <p>Beyond the CRUD endpoints, each lifecycle transition is its own {@code POST} sub-resource
+ * ({@code /plan}, {@code /activate}, {@code /pause}, {@code /complete}, {@code /abandon},
+ * {@code /reschedule}) rather than a status field a client may set. The transitions are guarded by the
+ * aggregate, so naming them keeps an illegal move a 422 with a reason instead of a silently accepted
+ * write.
+ *
+ * <p>Every endpoint is scoped to the authenticated principal; an upgrade owned by somebody else is
+ * reported as not found. Delegates to {@link UpgradeService}, which returns domain objects, and maps
+ * them with {@link UpgradeWebMapper}.
  */
 @RestController
 @RequestMapping("/api/upgrades")
@@ -27,7 +36,12 @@ public class UpgradeController {
     private final UpgradeService service; // application service (returns domain aggregates)
     private final UpgradeWebMapper mapper; // maps domain -> UpgradeDto (with tracking config)
 
-    /** Creates a new upgrade. */
+    /**
+     * Creates an upgrade, which always starts as an IDEA.
+     *
+     * @param req title and type are required; the rest is optional
+     * @return 201 with the created upgrade
+     */
     @PostMapping
     public ResponseEntity<UpgradeDto> create(@AuthenticationPrincipal SecurityUser principal,
                                               @Valid @RequestBody UpgradeRequest req) {
@@ -35,7 +49,18 @@ public class UpgradeController {
                 .body(mapper.toDto(service.create(principal.getId(), mapper.toDetails(req))));
     }
 
-    /** Lists the caller's upgrades, optionally filtered. */
+    /**
+     * Lists the caller's upgrades, narrowed by at most one filter.
+     *
+     * <p>The query parameters are alternatives, not a conjunction: the first one supplied wins, in the
+     * order status, type, areaId, difficulty.
+     *
+     * @param status     lifecycle filter, optional
+     * @param type       type filter, optional
+     * @param areaId     health-area filter, optional
+     * @param difficulty difficulty filter, optional
+     * @return 200 with the matching upgrades, each carrying its tracking configuration
+     */
     @GetMapping
     public ResponseEntity<List<UpgradeDto>> findAll(@AuthenticationPrincipal SecurityUser principal,
                                                      @RequestParam(required = false) UpgradeStatus status,
@@ -45,13 +70,33 @@ public class UpgradeController {
         return ResponseEntity.ok(mapper.toDtos(service.findAll(principal.getId(), status, type, areaId, difficulty)));
     }
 
-    /** Fetches a single owned upgrade. */
+    /**
+     * Fetches one of the caller's upgrades.
+     *
+     * @param id the upgrade's identifier
+     * @return 200 with the upgrade and its tracking configuration
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     */
     @GetMapping("/{id}")
     public ResponseEntity<UpgradeDto> findById(@AuthenticationPrincipal SecurityUser principal, @PathVariable UUID id) {
         return ResponseEntity.ok(mapper.toDto(service.getOwnedUpgrade(principal.getId(), id)));
     }
 
-    /** Updates an owned upgrade. */
+    /**
+     * Replaces the editable attributes of one of the caller's upgrades.
+     *
+     * <p>Status is not editable here — use the transition endpoints. Changing difficulty to HARD is
+     * subject to the concurrent-HARD limit when the upgrade is running.
+     *
+     * @param id  the upgrade's identifier
+     * @param req the replacement attributes
+     * @return 200 with the updated upgrade
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if the change would exceed the
+     *         concurrent-HARD limit (422)
+     */
     @PutMapping("/{id}")
     public ResponseEntity<UpgradeDto> update(@AuthenticationPrincipal SecurityUser principal,
                                               @PathVariable UUID id,
@@ -59,14 +104,31 @@ public class UpgradeController {
         return ResponseEntity.ok(mapper.toDto(service.update(principal.getId(), id, mapper.toDetails(req))));
     }
 
-    /** Deletes an owned upgrade. */
+    /**
+     * Deletes one of the caller's upgrades, along with nothing else — progress entries and
+     * reflections filed against it are not cascaded.
+     *
+     * @param id the upgrade's identifier
+     * @return 204 with no body
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     */
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@AuthenticationPrincipal SecurityUser principal, @PathVariable UUID id) {
         service.delete(principal.getId(), id);
         return ResponseEntity.noContent().build();
     }
 
-    /** Moves an owned upgrade to PLANNED. */
+    /**
+     * Commits an idea to a start date: IDEA to PLANNED.
+     *
+     * @param id the upgrade's identifier
+     * @param req the intended start date, required
+     * @return 200 with the updated upgrade
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if the upgrade is not an IDEA (422)
+     */
     @PostMapping("/{id}/plan")
     public ResponseEntity<UpgradeDto> plan(@AuthenticationPrincipal SecurityUser principal,
                                             @PathVariable UUID id,
@@ -74,7 +136,17 @@ public class UpgradeController {
         return ResponseEntity.ok(mapper.toDto(service.plan(principal.getId(), id, req.plannedStartDate())));
     }
 
-    /** Activates an owned upgrade. */
+    /**
+     * Starts or resumes an upgrade: PLANNED or PAUSED to ACTIVE.
+     *
+     * @param id the upgrade's identifier
+     * @param req optional body carrying the start date; today when the body is absent
+     * @return 200 with the updated upgrade
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if the upgrade is not PLANNED or PAUSED,
+     *         or activating it would exceed the concurrent-HARD limit (422)
+     */
     @PostMapping("/{id}/activate")
     public ResponseEntity<UpgradeDto> activate(@AuthenticationPrincipal SecurityUser principal,
                                                 @PathVariable UUID id,
@@ -83,25 +155,59 @@ public class UpgradeController {
                 req != null ? req.startDate() : null)));
     }
 
-    /** Pauses an owned upgrade. */
+    /**
+     * Suspends a running upgrade: ACTIVE to PAUSED, releasing any HARD slot it held.
+     *
+     * @param id the upgrade's identifier
+     * @return 200 with the updated upgrade
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if the upgrade is not ACTIVE (422)
+     */
     @PostMapping("/{id}/pause")
     public ResponseEntity<UpgradeDto> pause(@AuthenticationPrincipal SecurityUser principal, @PathVariable UUID id) {
         return ResponseEntity.ok(mapper.toDto(service.pause(principal.getId(), id)));
     }
 
-    /** Completes an owned upgrade. */
+    /**
+     * Finishes a running upgrade: ACTIVE to COMPLETED, which is terminal.
+     *
+     * @param id the upgrade's identifier
+     * @return 200 with the updated upgrade
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if the upgrade is not ACTIVE (422)
+     */
     @PostMapping("/{id}/complete")
     public ResponseEntity<UpgradeDto> complete(@AuthenticationPrincipal SecurityUser principal, @PathVariable UUID id) {
         return ResponseEntity.ok(mapper.toDto(service.complete(principal.getId(), id)));
     }
 
-    /** Abandons an owned upgrade. */
+    /**
+     * Gives an upgrade up. Reversible by rescheduling it.
+     *
+     * @param id the upgrade's identifier
+     * @return 200 with the updated upgrade
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if it is already COMPLETED or
+     *         ABANDONED (422)
+     */
     @PostMapping("/{id}/abandon")
     public ResponseEntity<UpgradeDto> abandon(@AuthenticationPrincipal SecurityUser principal, @PathVariable UUID id) {
         return ResponseEntity.ok(mapper.toDto(service.abandon(principal.getId(), id)));
     }
 
-    /** Reschedules an owned upgrade. */
+    /**
+     * Moves the planned start date, reviving an ABANDONED upgrade into PLANNED.
+     *
+     * @param id the upgrade's identifier
+     * @param req the new planned start date, required
+     * @return 200 with the updated upgrade
+     * @throws com.healthupgrades.common.domain.exception.ResourceNotFoundException if no such
+     *         upgrade is owned by the caller (404)
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if the upgrade is COMPLETED (422)
+     */
     @PostMapping("/{id}/reschedule")
     public ResponseEntity<UpgradeDto> reschedule(@AuthenticationPrincipal SecurityUser principal,
                                                   @PathVariable UUID id,

--- a/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeDto.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeDto.java
@@ -8,6 +8,36 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * An upgrade as returned on the wire.
+ *
+ * <p>Two fields are not stored on the aggregate: {@code overdue} is derived at mapping time from the
+ * target date and the current status, and {@code trackingConfig} is composed in through
+ * {@code UpgradeTrackingSummaryPort} — null when the upgrade has no tracking set up. {@code version}
+ * is the optimistic-lock counter; a client that echoes a stale one back gets a 409.
+ *
+ * <p>The field order is part of the contract in practice and is pinned by
+ * {@code UpgradeDtoSerializationTest}.
+ *
+ * @param id               the upgrade's identifier
+ * @param userId           the owner
+ * @param areaId           the health area it is filed under, may be null
+ * @param title            short name
+ * @param description      longer explanation, may be null
+ * @param type             what kind of change this is
+ * @param status           where it stands in its lifecycle
+ * @param difficulty       how demanding it is, may be null
+ * @param plannedStartDate the intended start date, may be null
+ * @param actualStartDate  when it actually started, null until activated
+ * @param targetEndDate    the date it should be done by, may be null
+ * @param motivation       why the user wants it, may be null
+ * @param successCriteria  how the user will know it worked, may be null
+ * @param overdue          derived: ACTIVE and past the target end date
+ * @param version          optimistic-lock version
+ * @param trackingConfig   how progress is measured, null when tracking is not configured
+ * @param createdAt        when the upgrade was created
+ * @param updatedAt        when it was last modified
+ */
 public record UpgradeDto(
         UUID id,
         UUID userId,

--- a/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeRequest.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeRequest.java
@@ -8,6 +8,23 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.UUID;
 
+/**
+ * Request body for creating or replacing an upgrade.
+ *
+ * <p>Used by both {@code POST} and {@code PUT}. Status is absent by design — it moves only through the
+ * transition endpoints — and {@code plannedStartDate} is honoured on creation only; afterwards the date
+ * belongs to {@code /plan} and {@code /reschedule}.
+ *
+ * @param areaId           health area to file it under, optional
+ * @param title            short name; required and non-blank
+ * @param description      longer explanation, optional
+ * @param type             what kind of change this is; required
+ * @param difficulty       how demanding it is, optional
+ * @param plannedStartDate intended start date, optional and only meaningful on creation
+ * @param targetEndDate    the date it should be done by, optional
+ * @param motivation       why the user wants it, optional
+ * @param successCriteria  how the user will know it worked, optional
+ */
 public record UpgradeRequest(
         UUID areaId,
         @NotBlank String title,

--- a/backend/src/main/java/com/healthupgrades/upgrade/adapter/out/persistence/UpgradeRepositoryAdapter.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/adapter/out/persistence/UpgradeRepositoryAdapter.java
@@ -22,58 +22,69 @@ class UpgradeRepositoryAdapter implements UpgradeRepositoryPort {
 
     private final UpgradeJpaRepository jpa; // Spring Data proxy injected by constructor
 
+    /** {@inheritDoc} */
     @Override
     public HealthUpgrade save(HealthUpgrade upgrade) {
-        return jpa.save(upgrade); // delegate persist
+        return jpa.save(upgrade);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void delete(HealthUpgrade upgrade) {
-        jpa.delete(upgrade); // delegate delete
+        jpa.delete(upgrade);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<HealthUpgrade> findByIdAndUserId(UUID id, UUID userId) {
-        return jpa.findByIdAndUserId(id, userId); // delegate ownership-scoped lookup
+        return jpa.findByIdAndUserId(id, userId);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<HealthUpgrade> findByUserId(UUID userId) {
-        return jpa.findByUserId(userId); // delegate
+        return jpa.findByUserId(userId);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<HealthUpgrade> findByUserIdAndStatus(UUID userId, UpgradeStatus status) {
-        return jpa.findByUserIdAndStatus(userId, status); // delegate
+        return jpa.findByUserIdAndStatus(userId, status);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<HealthUpgrade> findByUserIdAndType(UUID userId, UpgradeType type) {
-        return jpa.findByUserIdAndType(userId, type); // delegate
+        return jpa.findByUserIdAndType(userId, type);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<HealthUpgrade> findByUserIdAndAreaId(UUID userId, UUID areaId) {
-        return jpa.findByUserIdAndAreaId(userId, areaId); // delegate
+        return jpa.findByUserIdAndAreaId(userId, areaId);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<HealthUpgrade> findByUserIdAndDifficulty(UUID userId, Difficulty difficulty) {
-        return jpa.findByUserIdAndDifficulty(userId, difficulty); // delegate
+        return jpa.findByUserIdAndDifficulty(userId, difficulty);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<HealthUpgrade> findByStatus(UpgradeStatus status) {
-        return jpa.findByStatus(status); // delegate
+        return jpa.findByStatus(status);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<HealthUpgrade> findAllById(Iterable<UUID> ids) {
-        return jpa.findAllById(ids); // delegate to the inherited JpaRepository batch lookup
+        return jpa.findAllById(ids);
     }
 
+    /** {@inheritDoc} */
     @Override
     public long countByUserIdAndStatusAndDifficulty(UUID userId, UpgradeStatus status, Difficulty difficulty) {
-        return jpa.countByUserIdAndStatusAndDifficulty(userId, status, difficulty); // delegate count
+        return jpa.countByUserIdAndStatusAndDifficulty(userId, status, difficulty);
     }
 }

--- a/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeBeansConfig.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeBeansConfig.java
@@ -16,6 +16,6 @@ public class UpgradeBeansConfig {
     /** Exposes the stateless {@link UpgradeSchedulingService} as an injectable bean. */
     @Bean
     public UpgradeSchedulingService upgradeSchedulingService() {
-        return new UpgradeSchedulingService(); // no dependencies -> plain construction
+        return new UpgradeSchedulingService();
     }
 }

--- a/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeService.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeService.java
@@ -36,7 +36,14 @@ public class UpgradeService implements UpgradeQuery {
     private final DomainEventPublisher eventPublisher; // in-process domain events
     private final Clock clock; // decides the start date an activation defaults to
 
-    /** Creates a new upgrade in the IDEA state and publishes a creation event. */
+    /**
+     * Creates a new upgrade in the IDEA state and announces it.
+     *
+     * @param userId  the owner
+     * @param details the attributes to store
+     * @return the persisted aggregate
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if the title or type is missing
+     */
     @Transactional
     public HealthUpgrade create(UUID userId, UpgradeDetails details) {
         HealthUpgrade upgrade = HealthUpgrade.create(userId, details.areaId(), details.title(), details.description(),
@@ -47,16 +54,42 @@ public class UpgradeService implements UpgradeQuery {
         return upgrade;
     }
 
-    /** Lists a user's upgrades, optionally narrowed by the first non-null filter. */
+    /**
+     * Lists a user's upgrades, narrowed by at most one filter.
+     *
+     * <p>The filters are not combined: the first non-null one wins, in the order status, type, area,
+     * difficulty. A caller that needs a conjunction has to narrow the result itself.
+     *
+     * @param userId     the owner
+     * @param status     lifecycle filter, or null
+     * @param type       type filter, or null
+     * @param areaId     health-area filter, or null
+     * @param difficulty difficulty filter, or null
+     * @return the matching upgrades, or all of the user's when every filter is null
+     */
     public List<HealthUpgrade> findAll(UUID userId, UpgradeStatus status, UpgradeType type, UUID areaId, Difficulty difficulty) {
-        if (status != null) return repository.findByUserIdAndStatus(userId, status); // filter by status
-        if (type != null) return repository.findByUserIdAndType(userId, type); // filter by type
-        if (areaId != null) return repository.findByUserIdAndAreaId(userId, areaId); // filter by area
-        if (difficulty != null) return repository.findByUserIdAndDifficulty(userId, difficulty); // filter by difficulty
-        return repository.findByUserId(userId); // no filter -> all
+        if (status != null) return repository.findByUserIdAndStatus(userId, status);
+        if (type != null) return repository.findByUserIdAndType(userId, type);
+        if (areaId != null) return repository.findByUserIdAndAreaId(userId, areaId);
+        if (difficulty != null) return repository.findByUserIdAndDifficulty(userId, difficulty);
+        return repository.findByUserId(userId);
     }
 
-    /** Updates the editable fields of an owned upgrade. */
+    /**
+     * Updates the editable fields of an owned upgrade, and its difficulty when that changed.
+     *
+     * <p>Promoting an already-ACTIVE upgrade to HARD is one of the two ways to occupy a HARD slot, so
+     * the limit is checked here as well as on activation — and checked before anything is mutated, so a
+     * rejected update leaves the aggregate untouched.
+     *
+     * @param userId  the owner
+     * @param id      the upgrade's identifier
+     * @param details the replacement attributes
+     * @return the saved aggregate
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if the title or type is
+     *         missing, or the change would exceed the concurrent-HARD limit
+     */
     @Transactional
     public HealthUpgrade update(UUID userId, UUID id, UpgradeDetails details) {
         HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
@@ -87,14 +120,31 @@ public class UpgradeService implements UpgradeQuery {
         schedulingService.validateWithinHardLimit(difficulty, activeHardCount);
     }
 
-    /** Deletes an owned upgrade. */
+    /**
+     * Deletes an owned upgrade.
+     *
+     * <p>Publishes nothing: the upgrade is gone, so there is no aggregate left for a listener to act on.
+     *
+     * @param userId the owner
+     * @param id     the upgrade's identifier
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     */
     @Transactional
     public void delete(UUID userId, UUID id) {
         HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
         repository.delete(upgrade);
     }
 
-    /** Moves an owned upgrade to PLANNED with a planned start date. */
+    /**
+     * Commits an owned idea to a start date: IDEA to PLANNED.
+     *
+     * @param userId           the owner
+     * @param id               the upgrade's identifier
+     * @param plannedStartDate the intended start date
+     * @return the saved aggregate
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if it is not an IDEA
+     */
     @Transactional
     public HealthUpgrade plan(UUID userId, UUID id, LocalDate plannedStartDate) {
         HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
@@ -104,7 +154,20 @@ public class UpgradeService implements UpgradeQuery {
         return upgrade;
     }
 
-    /** Activates an owned upgrade, enforcing the max-concurrent-HARD invariant first. */
+    /**
+     * Starts or resumes an owned upgrade: PLANNED or PAUSED to ACTIVE.
+     *
+     * <p>The HARD limit is checked before the transition, so a rejected activation leaves the aggregate
+     * as it was.
+     *
+     * @param userId    the owner
+     * @param id        the upgrade's identifier
+     * @param startDate the date it starts running; today by the injected clock when null
+     * @return the saved aggregate
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if it is not PLANNED or
+     *         PAUSED, or activating it would exceed the concurrent-HARD limit
+     */
     @Transactional
     public HealthUpgrade activate(UUID userId, UUID id, LocalDate startDate) {
         HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
@@ -115,7 +178,15 @@ public class UpgradeService implements UpgradeQuery {
         return upgrade;
     }
 
-    /** Pauses an owned ACTIVE upgrade. */
+    /**
+     * Suspends an owned running upgrade: ACTIVE to PAUSED, releasing any HARD slot it held.
+     *
+     * @param userId the owner
+     * @param id     the upgrade's identifier
+     * @return the saved aggregate
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if it is not ACTIVE
+     */
     @Transactional
     public HealthUpgrade pause(UUID userId, UUID id) {
         HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
@@ -125,7 +196,15 @@ public class UpgradeService implements UpgradeQuery {
         return upgrade;
     }
 
-    /** Completes an owned ACTIVE upgrade. */
+    /**
+     * Finishes an owned running upgrade: ACTIVE to COMPLETED, which is terminal.
+     *
+     * @param userId the owner
+     * @param id     the upgrade's identifier
+     * @return the saved aggregate
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if it is not ACTIVE
+     */
     @Transactional
     public HealthUpgrade complete(UUID userId, UUID id) {
         HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
@@ -135,7 +214,16 @@ public class UpgradeService implements UpgradeQuery {
         return upgrade;
     }
 
-    /** Abandons an owned upgrade. */
+    /**
+     * Gives an owned upgrade up: to ABANDONED.
+     *
+     * @param userId the owner
+     * @param id     the upgrade's identifier
+     * @return the saved aggregate
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if it is already
+     *         COMPLETED or ABANDONED
+     */
     @Transactional
     public HealthUpgrade abandon(UUID userId, UUID id) {
         HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
@@ -145,7 +233,16 @@ public class UpgradeService implements UpgradeQuery {
         return upgrade;
     }
 
-    /** Reschedules an owned upgrade to a new date (reactivates an abandoned one to PLANNED). */
+    /**
+     * Moves an owned upgrade's planned start date, reviving an abandoned one into PLANNED.
+     *
+     * @param userId  the owner
+     * @param id      the upgrade's identifier
+     * @param newDate the new planned start date
+     * @return the saved aggregate
+     * @throws ResourceNotFoundException if the upgrade does not exist or belongs to somebody else
+     * @throws com.healthupgrades.common.domain.exception.BusinessRuleException if it is COMPLETED
+     */
     @Transactional
     public HealthUpgrade reschedule(UUID userId, UUID id, LocalDate newDate) {
         HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
@@ -167,13 +264,13 @@ public class UpgradeService implements UpgradeQuery {
     @Override
     public HealthUpgrade getOwnedUpgrade(UUID userId, UUID id) {
         return repository.findByIdAndUserId(id, userId)
-                .orElseThrow(() -> new ResourceNotFoundException("Upgrade not found: " + id)); // ownership guard
+                .orElseThrow(() -> new ResourceNotFoundException("Upgrade not found: " + id));
     }
 
     /** {@inheritDoc} */
     @Override
     public Optional<HealthUpgrade> findOwned(UUID userId, UUID id) {
-        return repository.findByIdAndUserId(id, userId); // best-effort, no throw
+        return repository.findByIdAndUserId(id, userId);
     }
 
     /** {@inheritDoc} */

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/event/HealthUpgradeAbandoned.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/event/HealthUpgradeAbandoned.java
@@ -5,4 +5,12 @@ import com.healthupgrades.common.domain.event.DomainEvent;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Raised when a user gives an upgrade up. Unlike completion this is reversible: rescheduling an
+ * ABANDONED upgrade puts it back into PLANNED.
+ *
+ * @param upgradeId  the upgrade that was abandoned
+ * @param userId     its owner
+ * @param occurredAt when the transition happened
+ */
 public record HealthUpgradeAbandoned(UUID upgradeId, UUID userId, LocalDateTime occurredAt) implements DomainEvent {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/event/HealthUpgradeActivated.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/event/HealthUpgradeActivated.java
@@ -6,4 +6,15 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Raised when an upgrade starts running — from PLANNED, or resumed from PAUSED.
+ *
+ * <p>An activated upgrade occupies a HARD slot if its difficulty is HARD; see
+ * {@code UpgradeSchedulingService}.
+ *
+ * @param upgradeId  the upgrade that became ACTIVE
+ * @param userId     its owner
+ * @param startDate  the date it actually started
+ * @param occurredAt when the transition happened
+ */
 public record HealthUpgradeActivated(UUID upgradeId, UUID userId, LocalDate startDate, LocalDateTime occurredAt) implements DomainEvent {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/event/HealthUpgradeCompleted.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/event/HealthUpgradeCompleted.java
@@ -5,4 +5,12 @@ import com.healthupgrades.common.domain.event.DomainEvent;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Raised when a running upgrade is finished successfully — a terminal transition, since a COMPLETED
+ * upgrade can no longer be reactivated, paused or rescheduled.
+ *
+ * @param upgradeId  the upgrade that was completed
+ * @param userId     its owner
+ * @param occurredAt when the transition happened
+ */
 public record HealthUpgradeCompleted(UUID upgradeId, UUID userId, LocalDateTime occurredAt) implements DomainEvent {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/event/HealthUpgradeCreated.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/event/HealthUpgradeCreated.java
@@ -5,4 +5,12 @@ import com.healthupgrades.common.domain.event.DomainEvent;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Raised when a user records a new upgrade, which always enters the lifecycle as an IDEA.
+ *
+ * @param upgradeId  the new upgrade
+ * @param userId     its owner
+ * @param title      the upgrade's title, carried so a consumer can compose a message without a lookup
+ * @param occurredAt when the upgrade was created
+ */
 public record HealthUpgradeCreated(UUID upgradeId, UUID userId, String title, LocalDateTime occurredAt) implements DomainEvent {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/event/HealthUpgradePaused.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/event/HealthUpgradePaused.java
@@ -5,4 +5,11 @@ import com.healthupgrades.common.domain.event.DomainEvent;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Raised when a running upgrade is paused, releasing any HARD slot it held.
+ *
+ * @param upgradeId  the upgrade that was paused
+ * @param userId     its owner
+ * @param occurredAt when the transition happened
+ */
 public record HealthUpgradePaused(UUID upgradeId, UUID userId, LocalDateTime occurredAt) implements DomainEvent {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/event/HealthUpgradePlanned.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/event/HealthUpgradePlanned.java
@@ -6,4 +6,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Raised when an IDEA is committed to a start date and becomes PLANNED.
+ *
+ * @param upgradeId        the upgrade that was planned
+ * @param userId           its owner
+ * @param plannedStartDate the date the user intends to start
+ * @param occurredAt       when the transition happened
+ */
 public record HealthUpgradePlanned(UUID upgradeId, UUID userId, LocalDate plannedStartDate, LocalDateTime occurredAt) implements DomainEvent {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/event/UpgradeOverdueDetected.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/event/UpgradeOverdueDetected.java
@@ -5,4 +5,15 @@ import com.healthupgrades.common.domain.event.DomainEvent;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Raised by the scheduled overdue sweep when an ACTIVE upgrade is found past its target end date.
+ *
+ * <p>The only event here that no user action produces, and the reason the sweep exists: nothing else
+ * notices that a date has passed. It fires once per sweep for as long as the upgrade stays overdue —
+ * the notification listener is what decides not to notify twice.
+ *
+ * @param upgradeId  the overdue upgrade
+ * @param userId     its owner
+ * @param occurredAt when the sweep observed it
+ */
 public record UpgradeOverdueDetected(UUID upgradeId, UUID userId, LocalDateTime occurredAt) implements DomainEvent {}

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/model/Difficulty.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/model/Difficulty.java
@@ -1,7 +1,19 @@
 package com.healthupgrades.upgrade.domain.model;
 
+/**
+ * How demanding an upgrade is, as judged by the user who created it.
+ *
+ * <p>Not merely descriptive: HARD is rationed. A user may run at most three HARD upgrades at once, an
+ * invariant enforced by {@code UpgradeSchedulingService} on every route into a running HARD upgrade.
+ */
 public enum Difficulty {
+
+    /** Little effort or disruption; unlimited. */
     EASY,
+
+    /** Noticeable effort; unlimited. */
     MEDIUM,
+
+    /** Demanding enough to compete for attention — capped at three concurrently ACTIVE. */
     HARD
 }

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/model/HealthUpgrade.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/model/HealthUpgrade.java
@@ -129,17 +129,26 @@ public class HealthUpgrade {
         this.successCriteria = successCriteria;
     }
 
+    /** Stamps the creation and update timestamps before the row is first inserted. */
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
     }
 
+    /** Refreshes the update timestamp before each update. */
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
     }
 
+    /**
+     * Commits an idea to a start date: IDEA → PLANNED.
+     *
+     * @param plannedStart the date the user intends to start; not required to be in the future, since
+     *                     users plan retroactively
+     * @throws BusinessRuleException if the upgrade is not an IDEA
+     */
     public void plan(LocalDate plannedStart) {
         if (status != UpgradeStatus.IDEA) {
             throw new BusinessRuleException("Only IDEA upgrades can be planned");
@@ -148,6 +157,16 @@ public class HealthUpgrade {
         this.status = UpgradeStatus.PLANNED;
     }
 
+    /**
+     * Starts or resumes an upgrade: PLANNED → ACTIVE, or PAUSED → ACTIVE.
+     *
+     * <p>Records the date it actually started, which is what progress and streaks are measured from.
+     * The max-concurrent-HARD rule is <em>not</em> checked here — it needs a count across the user's
+     * other upgrades, which the aggregate cannot see; {@code UpgradeService} applies it first.
+     *
+     * @param startDate the date the upgrade starts running
+     * @throws BusinessRuleException if the upgrade is not PLANNED or PAUSED
+     */
     public void activate(LocalDate startDate) {
         if (status != UpgradeStatus.PLANNED && status != UpgradeStatus.PAUSED) {
             throw new BusinessRuleException("Only PLANNED or PAUSED upgrades can be activated");
@@ -156,6 +175,11 @@ public class HealthUpgrade {
         this.status = UpgradeStatus.ACTIVE;
     }
 
+    /**
+     * Suspends a running upgrade: ACTIVE → PAUSED, releasing any HARD slot it held.
+     *
+     * @throws BusinessRuleException if the upgrade is not ACTIVE
+     */
     public void pause() {
         if (status != UpgradeStatus.ACTIVE) {
             throw new BusinessRuleException("Only ACTIVE upgrades can be paused");
@@ -163,6 +187,11 @@ public class HealthUpgrade {
         this.status = UpgradeStatus.PAUSED;
     }
 
+    /**
+     * Finishes a running upgrade successfully: ACTIVE → COMPLETED, which is terminal.
+     *
+     * @throws BusinessRuleException if the upgrade is not ACTIVE
+     */
     public void complete() {
         if (status != UpgradeStatus.ACTIVE) {
             throw new BusinessRuleException("Only ACTIVE upgrades can be completed");
@@ -170,6 +199,13 @@ public class HealthUpgrade {
         this.status = UpgradeStatus.COMPLETED;
     }
 
+    /**
+     * Gives an upgrade up, from any state that is not already final: → ABANDONED.
+     *
+     * <p>Reversible through {@link #reschedule}, unlike completion.
+     *
+     * @throws BusinessRuleException if the upgrade is already COMPLETED or ABANDONED
+     */
     public void abandon() {
         if (status == UpgradeStatus.COMPLETED || status == UpgradeStatus.ABANDONED) {
             throw new BusinessRuleException("Cannot abandon a COMPLETED or already ABANDONED upgrade");
@@ -177,6 +213,15 @@ public class HealthUpgrade {
         this.status = UpgradeStatus.ABANDONED;
     }
 
+    /**
+     * Moves the planned start date, and revives an abandoned upgrade back to PLANNED.
+     *
+     * <p>The revival is the one transition that is not named after its target state: rescheduling
+     * something you had given up on is how you take it back on.
+     *
+     * @param newDate the new planned start date
+     * @throws BusinessRuleException if the upgrade is COMPLETED
+     */
     public void reschedule(LocalDate newDate) {
         if (status == UpgradeStatus.COMPLETED) {
             throw new BusinessRuleException("Cannot reschedule a COMPLETED upgrade");
@@ -187,6 +232,14 @@ public class HealthUpgrade {
         }
     }
 
+    /**
+     * Sets the difficulty.
+     *
+     * <p>Unguarded here on purpose: promoting an upgrade to HARD may breach the concurrent-HARD limit,
+     * and that check needs the user's other upgrades. {@code UpgradeService} validates before calling.
+     *
+     * @param difficulty the new difficulty, may be null
+     */
     public void changeDifficulty(Difficulty difficulty) {
         this.difficulty = difficulty;
     }
@@ -203,6 +256,15 @@ public class HealthUpgrade {
                 && asOf.isAfter(targetEndDate);
     }
 
+    /**
+     * Whether the upgrade is running on the given date, i.e. ACTIVE and within its date window.
+     *
+     * <p>Used to decide what belongs on a day's check-in list. An absent start or end date is treated as
+     * open-ended rather than as a failed match.
+     *
+     * @param date the day being asked about
+     * @return true if progress is expected on that date
+     */
     public boolean isActiveOn(LocalDate date) {
         if (status != UpgradeStatus.ACTIVE) return false;
         if (actualStartDate != null && date.isBefore(actualStartDate)) return false;

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/model/UpgradeStatus.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/model/UpgradeStatus.java
@@ -1,10 +1,37 @@
 package com.healthupgrades.upgrade.domain.model;
 
+/**
+ * Where an upgrade stands in its lifecycle.
+ *
+ * <p>The transitions, all guarded by {@code HealthUpgrade}:
+ *
+ * <pre>
+ * IDEA → PLANNED → ACTIVE ⇄ PAUSED
+ *                  ACTIVE → COMPLETED
+ *   (any but COMPLETED/ABANDONED) → ABANDONED
+ *   ABANDONED --reschedule--&gt; PLANNED
+ * </pre>
+ *
+ * <p>The value is {@code IDEA}, not {@code DRAFT} — the backend enum, the frontend union type and the
+ * seed data all have to agree on that spelling.
+ */
 public enum UpgradeStatus {
+
+    /** Captured but not committed to: the state every upgrade is created in. */
     IDEA,
+
+    /** Committed to a start date, not yet running. */
     PLANNED,
+
+    /** Running: the only state in which progress is expected and a HARD slot is occupied. */
     ACTIVE,
+
+    /** Temporarily stopped, resumable by activating it again. */
     PAUSED,
+
+    /** Finished successfully. Terminal — no transition leaves this state. */
     COMPLETED,
+
+    /** Given up on. Reversible only by rescheduling, which returns it to PLANNED. */
     ABANDONED
 }

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/model/UpgradeType.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/model/UpgradeType.java
@@ -1,8 +1,22 @@
 package com.healthupgrades.upgrade.domain.model;
 
+/**
+ * What kind of change an upgrade is, which is what makes "health upgrade" broader than "habit".
+ *
+ * <p>The type is descriptive — it drives presentation and filtering, not domain rules. How progress is
+ * measured is decided separately by the tracking configuration.
+ */
 public enum UpgradeType {
+
+    /** A recurring behaviour to establish, e.g. drinking two litres of water a day. */
     HABIT,
+
+    /** An outcome to reach by a date, e.g. running 10km by summer. */
     GOAL,
+
+    /** A time-boxed trial to learn from, e.g. no caffeine after 2pm for two weeks. */
     EXPERIMENT,
+
+    /** A defined routine or one-off procedure to follow, e.g. a morning stretch sequence. */
     PROTOCOL
 }

--- a/backend/src/main/java/com/healthupgrades/user/adapter/in/web/UserDto.java
+++ b/backend/src/main/java/com/healthupgrades/user/adapter/in/web/UserDto.java
@@ -3,6 +3,18 @@ package com.healthupgrades.user.adapter.in.web;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Public view of a user on the wire.
+ *
+ * <p>This is the user context's published presentation model: the {@code auth} context reuses it in
+ * {@code TokenPair} rather than declaring a second shape for the same thing. It deliberately carries no
+ * password hash and no {@code updatedAt} — everything here is safe to hand to the browser.
+ *
+ * @param id        the user's identifier
+ * @param name      display name
+ * @param email     login identity
+ * @param createdAt when the account was created
+ */
 public record UserDto(
         UUID id,
         String name,

--- a/backend/src/main/java/com/healthupgrades/user/adapter/out/persistence/UserRepositoryAdapter.java
+++ b/backend/src/main/java/com/healthupgrades/user/adapter/out/persistence/UserRepositoryAdapter.java
@@ -9,6 +9,9 @@ import java.util.Optional;
 
 /**
  * Persistence adapter implementing {@link UserRepositoryPort} by delegating to Spring Data JPA.
+ *
+ * <p>The adapter exists so the Spring Data interface can stay package-private: the port is the only
+ * thing the rest of the application sees, which is what keeps JPA confined to this package.
  */
 @Component
 @RequiredArgsConstructor
@@ -16,18 +19,21 @@ class UserRepositoryAdapter implements UserRepositoryPort {
 
     private final UserJpaRepository jpa; // Spring Data proxy
 
+    /** {@inheritDoc} */
     @Override
     public User save(User user) {
-        return jpa.save(user); // delegate persist
+        return jpa.save(user);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Optional<User> findByEmail(String email) {
-        return jpa.findByEmail(email); // delegate
+        return jpa.findByEmail(email);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean existsByEmail(String email) {
-        return jpa.existsByEmail(email); // delegate
+        return jpa.existsByEmail(email);
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     password: ${DB_PASSWORD:healthupgrades}
   jpa:
     hibernate:
+      # Flyway owns the schema; Hibernate only checks the entities against it and refuses to start on a
+      # mismatch. An entity change therefore needs a new V{n}__*.sql migration, never a schema update here.
       ddl-auto: validate
     show-sql: false
     properties:
@@ -15,12 +17,16 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
   flyway:
     enabled: true
+    # Lets Flyway adopt a database that already has tables but no schema history, so an environment
+    # created before Flyway was introduced does not have to be dropped.
     baseline-on-migrate: true
 
 app:
   jwt:
+    # The fallback exists so a clone runs with no setup; it is a published value and gives no security.
+    # Set JWT_SECRET in any deployment. At least 256 bits, or the application refuses to start.
     secret: ${JWT_SECRET:a-very-long-default-secret-key-that-should-be-changed-in-production-at-least-256-bits}
-    expiration: 86400000
+    expiration: 86400000 # 24h in milliseconds. Tokens are not refreshable, so this is the whole session.
   cors:
     # Comma-separated list of origins allowed to call the API directly (cross-origin).
     # Not needed when the frontend is served behind the Vite dev proxy or nginx (same-origin /api).
@@ -40,4 +46,5 @@ app:
 
 logging:
   level:
+    # DEBUG for this application's own packages only; everything else stays at Spring's default INFO.
     com.healthupgrades: DEBUG

--- a/backend/src/test/java/com/healthupgrades/dashboard/application/DashboardAggregationServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/dashboard/application/DashboardAggregationServiceTest.java
@@ -26,6 +26,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+/**
+ * Covers the dashboard's aggregation rules: which upgrade lands in which bucket, and how the weekly
+ * completion rate is computed.
+ *
+ * <p>Every collaborator is a mocked inbound port, so what is under test is the composition itself —
+ * the bucketing and arithmetic — rather than any other context's behaviour.
+ */
 class DashboardAggregationServiceTest {
 
     @Mock UpgradeQuery upgradeQuery;

--- a/backend/src/test/java/com/healthupgrades/notification/adapter/in/event/NotificationEventListenerTest.java
+++ b/backend/src/test/java/com/healthupgrades/notification/adapter/in/event/NotificationEventListenerTest.java
@@ -29,6 +29,14 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+/**
+ * Covers the translation from domain event to notification: the category each event produces, and where
+ * the upgrade title in the message comes from.
+ *
+ * <p>The title source is the part worth pinning. Creation carries the title on the event and must not
+ * look it up, while the other events do not and must; and the overdue sweep must notify only once per
+ * upgrade however many times it rediscovers the same overdue upgrade.
+ */
 class NotificationEventListenerTest {
 
     @Mock NotificationService notificationService;

--- a/backend/src/test/java/com/healthupgrades/notification/adapter/in/scheduling/NotificationSchedulerTest.java
+++ b/backend/src/test/java/com/healthupgrades/notification/adapter/in/scheduling/NotificationSchedulerTest.java
@@ -27,6 +27,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+/**
+ * Covers the scheduled notifications: whether a reminder is dispatched at a given moment, and when the
+ * daily check-in nudge is suppressed.
+ *
+ * <p>Deterministic through a fixed {@link java.time.Clock} — a scheduler test that read the system clock
+ * would pass or fail depending on the minute it ran in.
+ */
 class NotificationSchedulerTest {
 
     @Mock UpgradeQuery upgradeQuery;

--- a/backend/src/test/java/com/healthupgrades/notification/application/NotificationServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/notification/application/NotificationServiceTest.java
@@ -23,6 +23,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+/**
+ * Covers the notification service: that creating one both persists and pushes it, that the read flags
+ * behave, and that the once-per-upgrade guard suppresses a repeat.
+ */
 class NotificationServiceTest {
 
     @Mock NotificationRepositoryPort repository;

--- a/backend/src/test/java/com/healthupgrades/reminder/domain/model/ReminderTest.java
+++ b/backend/src/test/java/com/healthupgrades/reminder/domain/model/ReminderTest.java
@@ -11,6 +11,12 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+/**
+ * Covers the reminder aggregate's due-ness rule: the day filter, the time match, and the enabled flag.
+ *
+ * <p>These conditions used to be evaluated by the notification scheduler against a raw CSV column, so
+ * this test is also what keeps that logic from drifting back out of the aggregate.
+ */
 class ReminderTest {
 
     private static final LocalTime NINE_AM = LocalTime.of(9, 0);

--- a/backend/src/test/java/com/healthupgrades/tracking/application/TrackingServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/tracking/application/TrackingServiceTest.java
@@ -34,6 +34,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+/**
+ * Covers the tracking service: that the server decides completion from the tracking configuration rather
+ * than trusting the client, that a second entry for the same day is refused, and that streak milestones
+ * are announced.
+ */
 class TrackingServiceTest {
 
     @Mock TrackingConfigRepositoryPort configRepository;

--- a/backend/src/test/java/com/healthupgrades/tracking/domain/service/ProgressEvaluationServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/tracking/domain/service/ProgressEvaluationServiceTest.java
@@ -11,6 +11,12 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Covers what counts as a successful entry for each tracking type.
+ *
+ * <p>Includes the unit-comparison cases: a value logged in a unit that disagrees with the target's must
+ * not be scored, which is the defect that motivated the check.
+ */
 class ProgressEvaluationServiceTest {
 
     private ProgressEvaluationService service;

--- a/backend/src/test/java/com/healthupgrades/tracking/domain/service/StreakCalculatorTest.java
+++ b/backend/src/test/java/com/healthupgrades/tracking/domain/service/StreakCalculatorTest.java
@@ -11,6 +11,10 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Covers streak counting, boundaries included: an unlogged today must not break the run, gaps must end
+ * it, and duplicate or unsuccessful entries must not extend it.
+ */
 class StreakCalculatorTest {
 
     /** A fixed reference day: the calculator is told what "today" is, so nothing here reads the clock. */

--- a/backend/src/test/java/com/healthupgrades/upgrade/adapter/in/scheduling/UpgradeOverdueSchedulerTest.java
+++ b/backend/src/test/java/com/healthupgrades/upgrade/adapter/in/scheduling/UpgradeOverdueSchedulerTest.java
@@ -26,6 +26,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+/**
+ * Covers the overdue sweep: which active upgrades it announces, and that it announces nothing for those
+ * still within their target date.
+ *
+ * <p>Driven by a fixed {@link java.time.Clock}, so "past its target date" means the same thing on every
+ * run.
+ */
 class UpgradeOverdueSchedulerTest {
 
     @Mock UpgradeQuery upgradeQuery;

--- a/backend/src/test/java/com/healthupgrades/upgrade/application/UpgradeServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/upgrade/application/UpgradeServiceTest.java
@@ -32,6 +32,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+/**
+ * Covers the upgrade use cases: that each transition delegates to the aggregate and announces the
+ * matching event, and that the concurrent-HARD limit is applied on both routes into a running HARD
+ * upgrade — activating one, and promoting an already-active one.
+ */
 class UpgradeServiceTest {
 
     @Mock UpgradeRepositoryPort repository;

--- a/backend/src/test/java/com/healthupgrades/upgrade/domain/model/HealthUpgradeTest.java
+++ b/backend/src/test/java/com/healthupgrades/upgrade/domain/model/HealthUpgradeTest.java
@@ -8,6 +8,13 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
 
+/**
+ * Covers the aggregate's state machine and construction invariants: which transitions are legal from
+ * each state, and which are refused.
+ *
+ * <p>This is the executable form of the lifecycle the guides describe, so a transition changed here
+ * without changing the documentation shows up as a failure.
+ */
 class HealthUpgradeTest {
 
     /** A fixed day to judge date-dependent rules against; the aggregate never reads the clock itself. */

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -1,0 +1,359 @@
+# Architecture
+
+The system as it actually is, at the time of writing. This record describes **what** is built and
+**how the pieces fit**; it does not argue for any of it. The reasoning, the alternatives that were
+rejected, and the conditions that would make us revisit a choice live in [`docs/ADRs/`](../ADRs/).
+
+---
+
+## Architecture overview
+
+HealthUpgrades is a three-process web application: a React single-page app, a Spring Boot HTTP API,
+and a PostgreSQL database. There is no message broker, no cache, no third-party service and no second
+backend — every piece of state lives in the one database, and every side effect the API performs is
+either a write to it or a message pushed to a connected browser.
+
+The browser talks to the API over HTTP for everything it reads and writes, and holds an additional
+WebSocket connection that the API uses to push notifications as they are raised. Both travel to the
+same origin: a proxy in front of the SPA forwards `/api` and `/ws` to the API, so the browser makes no
+cross-origin request in the default setup.
+
+Inside the API, the code is organised as nine bounded contexts over a ports-and-adapters core. The
+domain and application layers know nothing about HTTP, JPA or Spring's event bus; each of those
+arrives through an adapter. The boundaries are not a convention — they are checked on every build by
+an ArchUnit suite, which is the authority on what the layering permits.
+
+```mermaid
+flowchart LR
+    subgraph browser["Browser"]
+        spa["React SPA"]
+    end
+
+    subgraph edge["Frontend container"]
+        nginx["nginx<br/>static files + proxy"]
+    end
+
+    subgraph api["Backend container"]
+        rest["REST controllers"]
+        stomp["STOMP endpoint /ws"]
+        jobs["Scheduled jobs"]
+        core["Domain + application core"]
+    end
+
+    db[("PostgreSQL")]
+
+    spa -->|"HTTPS /api/**"| nginx
+    spa -->|"WebSocket /ws"| nginx
+    nginx -->|"proxy_pass"| rest
+    nginx -->|"proxy_pass, upgraded"| stomp
+    rest --> core
+    jobs --> core
+    core --> stomp
+    core -->|"JDBC"| db
+```
+
+---
+
+## Components
+
+### Runtime processes
+
+| Component | What it is | Responsible for |
+|---|---|---|
+| **Frontend** | nginx serving a Vite production build (container port 80, published on 3000) | Serving the SPA, and proxying `/api` and `/ws` to the backend so the browser stays same-origin |
+| **Backend** | Spring Boot 3.2 on Java 21, executable jar (port 8080) | The whole domain: authentication, the upgrade lifecycle, tracking, reflections, reminders, the dashboard read model, notifications, and the scheduled jobs |
+| **Database** | PostgreSQL 15 (port 5432, volume `postgres_data`) | Every piece of persistent state. Schema owned by Flyway |
+
+In development the nginx container is not involved: the Vite dev server serves the SPA on 3000 and
+performs the same `/api` and `/ws` proxying itself, so the app behaves identically on both sides.
+
+### Backend bounded contexts
+
+Nine contexts, each owning its own vocabulary, plus a cross-cutting `common`.
+
+| Context | Owns | Shape |
+|---|---|---|
+| `upgrade` | `HealthUpgrade` — the core aggregate and its state machine | Full: domain, application, adapters |
+| `tracking` | `TrackingConfig`, `ProgressEntry`, streak and success evaluation | Full |
+| `reflection` | `Reflection` — periodic written reviews | Full |
+| `reminder` | `Reminder` and its day-of-week schedule | Full |
+| `notification` | `Notification` — the inbox and the real-time push | Full, and the only context with a messaging adapter |
+| `healtharea` | `HealthArea` — the groupings upgrades are filed under | Full |
+| `user` | `User` — identity and the stored password hash | Full |
+| `auth` | Registration, login, and issuing tokens | Two-layer: orchestrates over `user`, owns no aggregate |
+| `dashboard` | The composed dashboard read model | Two-layer: reads through other contexts' ports, persists nothing |
+| `common` | Cross-cutting: the `DomainEvent` marker, shared exceptions, the event-publisher port, the global exception handler, JWT security and the WebSocket configuration | Not a context; a shared kernel plus cross-cutting adapters |
+
+`auth` and `dashboard` being two-layer is deliberate, not drift — see ADR-002.
+
+### Frontend modules
+
+| Module | Responsible for |
+|---|---|
+| `src/api/` | One axios instance and a thin function per endpoint. The instance attaches the JWT and turns a 401 into a logout; every call goes through it |
+| `src/contexts/` | `AuthProvider` owns the session; `NotificationProvider` owns the notification list, the STOMP connection and the toasts |
+| `src/hooks/` | `useAuth` and `useNotifications` — typed context readers that fail loudly outside their provider |
+| `src/router/` | The route table, and `ProtectedRoute`, which gates every authenticated page |
+| `src/pages/` | One component per route |
+| `src/components/` | `ui/` primitives, `upgrade/` cards and badges, `notifications/` bell, dropdown, items and toasts, `layout/` navbar and sidebar |
+| `src/types/` | Hand-written mirrors of the backend's response shapes and enums |
+
+---
+
+## Communication
+
+Five distinct mechanisms, each used for one thing:
+
+**1. HTTP, browser to API.** Every read and write. JSON in and out, JWT bearer token in the
+`Authorization` header. Same-origin through the proxy, so no CORS preflight in the default setup; the
+`CORS_ALLOWED_ORIGINS` policy exists only for deployments that split the origins.
+
+**2. STOMP over WebSocket, API to browser.** One-way in practice: the browser connects and subscribes,
+the API pushes. The handshake itself is unauthenticated — a browser cannot set headers on it — so the
+JWT travels in the STOMP `CONNECT` frame and is validated by a channel interceptor, which attaches a
+principal named by user id. Messages are routed to `/user/queue/notifications`, which the broker
+resolves per session using that principal.
+
+The broker is Spring's in-memory simple broker. There is no external broker, so a push reaches only
+clients connected to *this* instance — see "Known constraints" below.
+
+**3. In-process domain events, context to context.** A context that changes state publishes a record
+implementing `DomainEvent` through the `DomainEventPublisher` port. The adapter behind it delegates to
+Spring's `ApplicationEventPublisher`, so consumers can bind to the transaction:
+`@TransactionalEventListener(AFTER_COMMIT)` means a notification is never raised for a write that then
+rolls back. Events raised outside a transaction — by the scheduled sweeps — use a plain `@EventListener`,
+because there is no commit for a transactional listener to wait for.
+
+Events are asynchronous only in the sense of being decoupled; they are delivered in the same process,
+and nothing is queued or persisted between publisher and consumer.
+
+**4. Direct calls through inbound ports, context to context.** Where a context needs to *read* another,
+it calls that context's `application/port/in` interface and receives domain objects — never a
+repository, never a web DTO. `TrackingService` confirms upgrade ownership this way before recording
+progress.
+
+**5. Scheduled invocation.** Three cron-driven jobs drive the core with no request behind them: the
+overdue sweep, the daily check-in nudge, and the per-minute reminder dispatch.
+
+### Which contexts depend on which
+
+Derived from the imports, not from intent:
+
+```mermaid
+flowchart TD
+    auth --> user
+    tracking --> upgrade
+    reflection --> upgrade
+    reminder --> upgrade
+    dashboard --> upgrade
+    dashboard --> tracking
+    dashboard --> healtharea
+    notification --> upgrade
+    notification --> tracking
+    notification --> reflection
+    notification --> reminder
+```
+
+`upgrade`, `user` and `healtharea` depend on no other context. The graph is acyclic, and ArchUnit
+fails the build if that stops being true.
+
+The one edge that is not obvious is the absent one. An upgrade's response carries its tracking
+configuration, which would mean `upgrade → tracking` — and `tracking → upgrade` already exists for
+ownership checks. Instead `upgrade` declares `UpgradeTrackingSummaryPort` describing what it needs, in
+a record it owns, and `tracking` supplies it through a composition adapter. Both arrows run the same
+way. ADR-002 records why.
+
+---
+
+## Data flow
+
+### A write, end to end
+
+Recording a day's progress, which touches most of the machinery:
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant N as nginx
+    participant F as JWT filter
+    participant C as ProgressController
+    participant S as TrackingService
+    participant U as UpgradeQuery (upgrade)
+    participant R as Repository port
+    participant DB as PostgreSQL
+    participant L as NotificationEventListener
+    participant W as STOMP adapter
+
+    B->>N: POST /api/upgrades/{id}/progress
+    N->>F: proxied
+    F->>F: validate JWT, load user, set security context
+    F->>C: request
+    C->>C: map request record to use-case input
+    C->>S: recordProgress(userId, upgradeId, details)
+    S->>U: getOwnedUpgrade(userId, upgradeId)
+    U->>DB: SELECT ... WHERE id = ? AND user_id = ?
+    S->>R: existsByUpgradeIdAndDate → duplicate guard
+    S->>S: evaluate entry against tracking config
+    S->>R: save(entry)
+    R->>DB: INSERT
+    S-->>L: ProgressEntryRecorded, StreakAchieved (on milestone)
+    Note over L: AFTER_COMMIT — nothing fires if the transaction rolls back
+    L->>DB: INSERT notification
+    L->>W: push
+    W-->>B: STOMP frame on /user/queue/notifications
+    C-->>B: 201 with the stored entry
+```
+
+Three things in that flow are easy to miss:
+
+- **Ownership is checked by the query, not by a guard.** Every repository lookup is scoped by user id,
+  so a row belonging to someone else is indistinguishable from one that does not exist and surfaces as
+  404. There is no role model and no per-resource authorization layer.
+- **The server decides completion.** The `completed` flag the client sends is advisory; when the
+  upgrade has a tracking configuration the entry is re-evaluated against the target, so streaks and
+  rates cannot be inflated by a client.
+- **The push happens after commit, and the notification is stored either way.** A browser that was
+  offline sees it on its next fetch.
+
+### A read, end to end
+
+`GET /api/dashboard` is the widest read. `DashboardAggregationService` calls four inbound ports —
+upgrades, progress entries, streaks, health areas — buckets the upgrades by status and date, computes
+the weekly rate, and returns a `DashboardView` of domain objects. The web mapper then turns it into the
+response, reusing the upgrade context's own mapper so the embedded upgrades are identical to what
+`/api/upgrades` returns, and mapping each distinct upgrade once so a single batched query resolves
+every tracking configuration rather than one per upgrade.
+
+### The record's lifetime
+
+A `HealthUpgrade` is created as an `IDEA` and moves only through methods on the aggregate, each of
+which guards its transition:
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDEA: create
+    IDEA --> PLANNED: plan
+    PLANNED --> ACTIVE: activate
+    ACTIVE --> PAUSED: pause
+    PAUSED --> ACTIVE: activate
+    ACTIVE --> COMPLETED: complete
+    IDEA --> ABANDONED: abandon
+    PLANNED --> ABANDONED: abandon
+    ACTIVE --> ABANDONED: abandon
+    PAUSED --> ABANDONED: abandon
+    ABANDONED --> PLANNED: reschedule
+    COMPLETED --> [*]
+```
+
+`COMPLETED` is terminal. `ABANDONED` is not — rescheduling revives it. An upgrade occupies one of the
+three concurrent HARD slots only while `ACTIVE`, which is why the limit is checked both when activating
+one and when promoting a running one to HARD.
+
+### Time-driven flows
+
+| Job | Default schedule | What it does |
+|---|---|---|
+| `UpgradeOverdueScheduler` | daily 08:00 | Publishes `UpgradeOverdueDetected` for every active upgrade past its target date. The notification listener creates at most one notification per upgrade, so the repeated detection does not repeat the alert |
+| `NotificationScheduler.notifyDailyCheckin` | daily 18:00 | Nudges users who have active upgrades and have logged nothing today, at most once a day |
+| `NotificationScheduler.dispatchReminders` | every minute | Fires the reminders due this minute. Due-ness is decided by the `Reminder` aggregate; the upgrades behind the due ones are loaded in one batch |
+
+All three read the clock through an injected `java.time.Clock`, which is what makes them testable
+without waiting.
+
+---
+
+## External dependencies and integration points
+
+**There are no third-party APIs.** Nothing leaves the deployment: no payment provider, no email or
+push service, no analytics, no AI service.
+
+| Dependency | Used for | How it is reached |
+|---|---|---|
+| **PostgreSQL 15** | All persistent state | JDBC from the backend only. Credentials from `DB_URL` / `DB_USERNAME` / `DB_PASSWORD` |
+| **Flyway** | Schema ownership and migration on startup | Embedded in the backend. `V1` schema, `V2` demo seed, `V3` demo password fix, `V4` notifications |
+| **Browser WebSocket** | Real-time notification delivery | The `/ws` STOMP endpoint, proxied by nginx (or Vite in development) |
+| **Browser Notification API** | Desktop notifications when the tab is backgrounded | Optional, permission-gated, and skipped entirely where the API is unavailable |
+
+Integration points a maintainer will need:
+
+- **`/actuator/health`** — the backend's health endpoint, unauthenticated, and what the compose
+  health-check polls.
+- **Environment variables** — `DB_URL`, `DB_USERNAME`, `DB_PASSWORD`, `JWT_SECRET` are required in any
+  real deployment; `CORS_ALLOWED_ORIGINS` and `VITE_API_URL` only matter when frontend and API are on
+  different origins. The cron expressions are overridable per environment. `.env.example` lists them
+  all with safe values.
+- **CI** — GitHub Actions on every push and PR to `main` and `dev`: the backend runs `mvn verify`
+  against a PostgreSQL service container, the frontend lints, audits its shipped dependencies and
+  builds.
+
+---
+
+## Structural decisions not visible from the file layout
+
+**The dependency arrow always points inward.** `adapter → application → domain`, never the reverse.
+No class in `application` imports anything from `adapter`, in either direction. This is what allows the
+whole core to be unit-tested without Spring, and it is checked rather than trusted.
+
+**The domain is framework-free, with one deliberate exception.** Domain classes import no Spring, no
+Jackson, no servlet, no bean validation. They do carry JPA mapping annotations, because the entities
+*are* the persistence model — there is no separate POJO-plus-mapper layer. That trade-off is ADR-001's,
+and ADR-002 reaffirms it.
+
+**Pure domain services carry no stereotype annotation.** `StreakCalculator`,
+`ProgressEvaluationService` and `UpgradeSchedulingService` are plain classes, hand-registered as beans
+by `*BeansConfig` classes in the application layer. A dropped `@Bean` there is invisible to unit tests,
+which is why `ApplicationContextIT` exists.
+
+**Business invariants live on the aggregate, not in services.** `HealthUpgrade` has no setters: status
+moves only through its transition methods, descriptive fields only through `updateDetails`, difficulty
+only through `changeDifficulty`, and instances are created through a validating factory. A service
+orchestrates — load, call the domain method, save, publish — and does not decide.
+
+The one invariant that cannot live there is the max-concurrent-HARD rule, because it needs a count
+across the user's *other* upgrades, which one aggregate cannot see. It is a pure domain service that
+receives the count as a parameter, and the application layer performs the counting query.
+
+**Spring Data is confined to the persistence adapters, and its interfaces are package-private.**
+Everything else depends on a repository port. Swapping the store would mean rewriting one package per
+context and nothing else.
+
+**Every request record and response DTO belongs to the web adapter.** Application services take command
+records from `application/port/in` and return domain objects; a `*WebMapper` per context translates in
+both directions. A wire-format change therefore cannot reach a use-case signature. `UpgradeTrackingConfigDto`
+duplicating `TrackingConfigDto` field for field is the visible cost, and is intentional.
+
+**Optimistic locking is on one aggregate.** Only `HealthUpgrade` carries `@Version`; a concurrent edit
+returns 409. Nothing else is version-checked, because nothing else is edited from two places at once.
+
+**Exception to HTTP status is decided in exactly one class.** Controllers and services throw domain
+exceptions and never build a status by hand. The mapping is pinned by a test.
+
+**The frontend's types are hand-written, not generated.** `src/types/index.ts` mirrors the backend's
+DTOs and enums by hand, so nothing detects drift between them. Two divergences exist today and are
+recorded in that file.
+
+### Known constraints
+
+Stated because they are load-bearing, not because they are problems yet:
+
+- **A single backend instance.** The STOMP broker is in-memory, so a notification pushed by one
+  instance reaches only the clients connected to that instance. Notifications are persisted, so a
+  client on another instance sees them on its next fetch rather than instantly. Running more than one
+  instance needs a real broker relay first.
+- **`mvn test` needs no database; `mvn verify` does.** The integration tests boot the application
+  against a real PostgreSQL. Keeping the unit suite database-free is a constraint worth preserving.
+- **The backend has no dependency vulnerability audit.** OWASP dependency-check cannot populate its
+  database without an `NVD_API_KEY`. ADR-002 records why a check that always fails, or one that cannot
+  fail, was judged worse than none.
+
+---
+
+## Where the reasoning lives
+
+| Question | Record |
+|---|---|
+| Why DDD + hexagonal at all, and why JPA entities as the domain model? | [ADR-001](../ADRs/ADR-001-ddd-hexagonal-architecture.md) |
+| Why the `upgrade`/`tracking` dependency is inverted; why events moved out of `common`; what the ten ArchUnit rules cover; what was rejected and when to revisit | [ADR-002](../ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md) |
+| Day-to-day conventions when changing backend code | [`backend/CLAUDE.md`](../../backend/CLAUDE.md) |
+| Day-to-day conventions when changing frontend code | [`frontend/CLAUDE.md`](../../frontend/CLAUDE.md) |
+| How to run, test and deploy it | [`README.md`](../../README.md) |

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,5 +1,9 @@
 # Frontend conventions
 
+`../docs/architecture/architecture.md` describes how the SPA fits into the wider system — the proxy,
+the two transports, and what the backend guarantees. This file covers the conventions to follow inside
+`frontend/`.
+
 `npm run dev` serves on :3000 and proxies `/api` → `http://localhost:8080` (see `vite.config.ts`).
 
 - **`src/api/client.ts`** is the single axios instance. Its `baseURL` is relative by default so every

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
 import AppRouter from './router';
 
+/**
+ * Server-state cache shared by the whole application.
+ *
+ * A single retry, because a failed call here is usually a 4xx that will fail identically; and a 30
+ * second staleness window, which keeps navigation between pages from refetching data that was just
+ * shown while still picking up changes made in another tab reasonably soon.
+ */
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -12,6 +19,12 @@ const queryClient = new QueryClient({
   },
 });
 
+/**
+ * Application root: installs the query cache and the auth provider around the router.
+ *
+ * The order matters — auth reads through the query client, and everything the router renders needs
+ * both.
+ */
 const App: React.FC = () => (
   <QueryClientProvider client={queryClient}>
     <AuthProvider>

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,16 +1,19 @@
 import client from './client';
 import type { AuthResponse, User } from '../types';
 
+/** Exchanges credentials for a token and profile. Rejects with a 401 when they do not match. */
 export const loginApi = async (email: string, password: string): Promise<AuthResponse> => {
   const { data } = await client.post<AuthResponse>('/api/auth/login', { email, password });
   return data;
 };
 
+/** Creates an account and returns a token for it. Rejects with a 422 if the email is taken. */
 export const registerApi = async (name: string, email: string, password: string): Promise<AuthResponse> => {
   const { data } = await client.post<AuthResponse>('/api/auth/register', { name, email, password });
   return data;
 };
 
+/** Fetches the current user from the stored token — how a session is restored on a page load. */
 export const getMe = async (): Promise<User> => {
   const { data } = await client.get<User>('/api/auth/me');
   return data;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,3 +1,10 @@
+/**
+ * The single axios instance every API module calls through.
+ *
+ * Two interceptors give it the app's auth behaviour: outgoing requests carry the stored JWT, and a 401
+ * response clears the token and sends the user to the login page. Adding a second axios instance
+ * elsewhere would bypass both.
+ */
 import axios from 'axios';
 
 // Default to a relative base URL so every `/api/...` call is same-origin and flows through the
@@ -7,6 +14,7 @@ const client = axios.create({
   baseURL: import.meta.env.VITE_API_URL || '',
 });
 
+/** Attaches the stored JWT to every outgoing request; anonymous when there is none. */
 client.interceptors.request.use((config) => {
   const token = localStorage.getItem('jwt_token');
   if (token) {
@@ -15,6 +23,12 @@ client.interceptors.request.use((config) => {
   return config;
 });
 
+/**
+ * Turns a 401 into a logout: the token is gone or expired, so clear it and go to the login page.
+ *
+ * A hard `location.href` assignment rather than a router navigation, deliberately — this runs outside
+ * React, and replacing the document also drops any cached server state belonging to the old session.
+ */
 client.interceptors.response.use(
   (r) => r,
   (err) => {

--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -1,6 +1,7 @@
 import client from './client';
 import type { DashboardDto } from '../types';
 
+/** Fetches the whole dashboard in one request; every section is computed server-side. */
 export const getDashboard = async (): Promise<DashboardDto> => {
   const { data } = await client.get<DashboardDto>('/api/dashboard');
   return data;

--- a/frontend/src/api/healthAreas.ts
+++ b/frontend/src/api/healthAreas.ts
@@ -1,21 +1,25 @@
 import client from './client';
 import type { HealthArea, CreateHealthAreaRequest } from '../types';
 
+/** Lists the caller's health areas. */
 export const getHealthAreas = async (): Promise<HealthArea[]> => {
   const { data } = await client.get<HealthArea[]>('/api/health-areas');
   return data;
 };
 
+/** Creates a health area. */
 export const createHealthArea = async (req: CreateHealthAreaRequest): Promise<HealthArea> => {
   const { data } = await client.post<HealthArea>('/api/health-areas', req);
   return data;
 };
 
+/** Replaces a health area's attributes; omitted fields are cleared, not preserved. */
 export const updateHealthArea = async (id: string, req: Partial<CreateHealthAreaRequest>): Promise<HealthArea> => {
   const { data } = await client.put<HealthArea>(`/api/health-areas/${id}`, req);
   return data;
 };
 
+/** Deletes a health area. Upgrades filed under it keep the now-dangling area id. */
 export const deleteHealthArea = async (id: string): Promise<void> => {
   await client.delete(`/api/health-areas/${id}`);
 };

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -1,21 +1,29 @@
 import client from './client';
 import type { AppNotification } from '../types';
 
+/** Fetches the fifty most recent notifications, newest first. Not paginated. */
 export const getNotifications = async (): Promise<AppNotification[]> => {
   const { data } = await client.get<AppNotification[]>('/api/notifications');
   return data;
 };
 
+/**
+ * Fetches the unread count, unwrapping the `{ count }` envelope the API returns.
+ *
+ * Counts every unread notification, so it can exceed what {@link getNotifications} returns.
+ */
 export const getUnreadCount = async (): Promise<number> => {
   const { data } = await client.get<{ count: number }>('/api/notifications/unread-count');
   return data.count;
 };
 
+/** Marks one notification as read and returns it. */
 export const markNotificationRead = async (id: string): Promise<AppNotification> => {
   const { data } = await client.post<AppNotification>(`/api/notifications/${id}/read`);
   return data;
 };
 
+/** Marks every unread notification as read in one call. */
 export const markAllNotificationsRead = async (): Promise<void> => {
   await client.post('/api/notifications/read-all');
 };

--- a/frontend/src/api/progress.ts
+++ b/frontend/src/api/progress.ts
@@ -1,21 +1,30 @@
 import client from './client';
 import type { ProgressEntry, CreateProgressRequest, StreakSummary } from '../types';
 
+/** Fetches one upgrade's progress history, newest first. */
 export const getProgressByUpgrade = async (upgradeId: string): Promise<ProgressEntry[]> => {
   const { data } = await client.get<ProgressEntry[]>(`/api/upgrades/${upgradeId}/progress`);
   return data;
 };
 
+/** Fetches the caller's entries for the last seven days, across all upgrades. */
 export const getWeekProgress = async (): Promise<ProgressEntry[]> => {
   const { data } = await client.get<ProgressEntry[]>('/api/progress/week');
   return data;
 };
 
+/** Fetches today's entries across all upgrades — what tells the check-in page what is already logged. */
 export const getTodayProgress = async (): Promise<ProgressEntry[]> => {
   const { data } = await client.get<ProgressEntry[]>('/api/progress/today');
   return data;
 };
 
+/**
+ * Logs a day's progress.
+ *
+ * `upgradeId` selects the endpoint and is deliberately not sent in the body. A second entry for the
+ * same upgrade and date is rejected with a 409 rather than replacing the first.
+ */
 export const createProgress = async (req: CreateProgressRequest): Promise<ProgressEntry> => {
   const { upgradeId, date, completed, numericValue, unit, rating, note } = req;
   const { data } = await client.post<ProgressEntry>(`/api/upgrades/${upgradeId}/progress`, {
@@ -29,6 +38,7 @@ export const createProgress = async (req: CreateProgressRequest): Promise<Progre
   return data;
 };
 
+/** Fetches an upgrade's current and longest streaks, both computed server-side. */
 export const getStreak = async (upgradeId: string): Promise<StreakSummary> => {
   const { data } = await client.get<StreakSummary>(`/api/upgrades/${upgradeId}/streak`);
   return data;

--- a/frontend/src/api/reflections.ts
+++ b/frontend/src/api/reflections.ts
@@ -1,11 +1,13 @@
 import client from './client';
 import type { Reflection, CreateReflectionRequest } from '../types';
 
+/** Fetches an upgrade's reflections, newest first. */
 export const getReflectionsByUpgrade = async (upgradeId: string): Promise<Reflection[]> => {
   const { data } = await client.get<Reflection[]>(`/api/upgrades/${upgradeId}/reflections`);
   return data;
 };
 
+/** Writes a reflection about an upgrade. There is no edit or delete counterpart. */
 export const createReflection = async (
   upgradeId: string,
   req: Omit<CreateReflectionRequest, 'upgradeId'>,

--- a/frontend/src/api/reminders.ts
+++ b/frontend/src/api/reminders.ts
@@ -1,21 +1,30 @@
 import client from './client';
 import type { Reminder, CreateReminderRequest } from '../types';
 
+/** Fetches an upgrade's reminders, enabled or not. */
 export const getReminders = async (upgradeId: string): Promise<Reminder[]> => {
   const { data } = await client.get<Reminder[]>(`/api/upgrades/${upgradeId}/reminders`);
   return data;
 };
 
+/** Adds a reminder to an upgrade; an upgrade may have several. */
 export const createReminder = async (upgradeId: string, req: CreateReminderRequest): Promise<Reminder> => {
   const { data } = await client.post<Reminder>(`/api/upgrades/${upgradeId}/reminders`, req);
   return data;
 };
 
+/**
+ * Reschedules a reminder, addressed by its own id rather than through its upgrade.
+ *
+ * Omitting `enabled` leaves the current state alone, so rescheduling a disabled reminder does not
+ * switch it back on.
+ */
 export const updateReminder = async (id: string, req: CreateReminderRequest): Promise<Reminder> => {
   const { data } = await client.put<Reminder>(`/api/reminders/${id}`, req);
   return data;
 };
 
+/** Deletes a reminder. */
 export const deleteReminder = async (id: string): Promise<void> => {
   await client.delete(`/api/reminders/${id}`);
 };

--- a/frontend/src/api/trackingConfig.ts
+++ b/frontend/src/api/trackingConfig.ts
@@ -1,6 +1,12 @@
 import client from './client';
 import type { TrackingConfig, TrackingType, Frequency } from '../types';
 
+/**
+ * Body for saving an upgrade's tracking configuration.
+ *
+ * `trackingType` decides which of the other fields are meaningful; the numeric target applies to
+ * `NUMERIC` tracking only.
+ */
 export interface SaveTrackingConfigRequest {
   trackingType: TrackingType;
   frequency?: Frequency;
@@ -9,11 +15,18 @@ export interface SaveTrackingConfigRequest {
   requiredDaily?: boolean;
 }
 
+/** Fetches an upgrade's tracking configuration. Rejects with a 404 when none is set up. */
 export const getTrackingConfig = async (upgradeId: string): Promise<TrackingConfig> => {
   const { data } = await client.get<TrackingConfig>(`/api/upgrades/${upgradeId}/tracking-config`);
   return data;
 };
 
+/**
+ * Creates or replaces an upgrade's tracking configuration.
+ *
+ * Idempotent, and never rescores entries already logged — a past day keeps the verdict it was given
+ * under the rule in force at the time.
+ */
 export const saveTrackingConfig = async (
   upgradeId: string,
   req: SaveTrackingConfigRequest,

--- a/frontend/src/api/upgrades.ts
+++ b/frontend/src/api/upgrades.ts
@@ -1,22 +1,31 @@
 import client from './client';
 import type { HealthUpgrade, CreateUpgradeRequest, UpgradeStatus } from '../types';
 
+/** Lists the caller's upgrades, optionally narrowed to one status. */
 export const getUpgrades = async (status?: UpgradeStatus): Promise<HealthUpgrade[]> => {
   const params = status ? { status } : {};
   const { data } = await client.get<HealthUpgrade[]>('/api/upgrades', { params });
   return data;
 };
 
+/** Fetches one upgrade, including its tracking configuration. */
 export const getUpgradeById = async (id: string): Promise<HealthUpgrade> => {
   const { data } = await client.get<HealthUpgrade>(`/api/upgrades/${id}`);
   return data;
 };
 
+/** Creates an upgrade. It always starts as an `IDEA`, whatever else is sent. */
 export const createUpgrade = async (req: CreateUpgradeRequest): Promise<HealthUpgrade> => {
   const { data } = await client.post<HealthUpgrade>('/api/upgrades', req);
   return data;
 };
 
+/**
+ * Replaces an upgrade's editable fields.
+ *
+ * A full replacement server-side despite the `Partial` type here: a field left out is stored as null,
+ * not left at its previous value.
+ */
 export const updateUpgrade = async (id: string, req: Partial<CreateUpgradeRequest>): Promise<HealthUpgrade> => {
   const { data } = await client.put<HealthUpgrade>(`/api/upgrades/${id}`, req);
   return data;
@@ -42,11 +51,16 @@ export const performUpgradeAction = async (id: string, status: UpgradeStatus): P
   return data;
 };
 
+/**
+ * Moves an upgrade's planned start date. Also the only way back from `ABANDONED`, which this returns
+ * to `PLANNED`.
+ */
 export const rescheduleUpgrade = async (id: string, newDate: string): Promise<HealthUpgrade> => {
   const { data } = await client.post<HealthUpgrade>(`/api/upgrades/${id}/reschedule`, { newDate });
   return data;
 };
 
+/** Deletes an upgrade permanently. Its progress entries and reflections are not cascaded. */
 export const deleteUpgrade = async (id: string): Promise<void> => {
   await client.delete(`/api/upgrades/${id}`);
 };

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -2,10 +2,16 @@ import React from 'react';
 import Navbar from './Navbar';
 import Sidebar from './Sidebar';
 
+/** @param children the page to render in the content area */
 interface LayoutProps {
   children: React.ReactNode;
 }
 
+/**
+ * The frame every signed-in page renders inside: fixed navbar, sidebar, and a scrolling content area.
+ *
+ * Applied by the router rather than by each page, so no authenticated page can be added without it.
+ */
 const Layout: React.FC<LayoutProps> = ({ children }) => (
   <div className="min-h-screen bg-gray-50 flex flex-col">
     <Navbar />

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../../hooks/useAuth';
 import Button from '../ui/Button';
 import NotificationBell from '../notifications/NotificationBell';
 
+/** Top bar: brand link home, the notification bell, the signed-in user's name, and logout. */
 const Navbar: React.FC = () => {
   const { user, logout } = useAuth();
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 
+/** One sidebar entry: where it goes, what it is called, and the emoji standing in for an icon. */
 interface NavItem {
   to: string;
   label: string;
   icon: string;
 }
 
+/**
+ * The primary navigation, in the order the app is meant to be used: plan, then run, then review.
+ *
+ * This list is the sidebar's whole content — adding a page here is what puts it in the navigation, and
+ * the route itself still has to be registered in the router.
+ */
 const navItems: NavItem[] = [
   { to: '/dashboard', label: 'Dashboard', icon: '🏠' },
   { to: '/health-areas', label: 'Health Areas', icon: '🎯' },
@@ -18,6 +25,12 @@ const navItems: NavItem[] = [
   { to: '/notifications', label: 'Notifications', icon: '🔔' },
 ];
 
+/**
+ * Primary navigation rail, with the current route highlighted.
+ *
+ * Hidden below the medium breakpoint — on a phone the navbar is the only chrome, and the pages are
+ * reachable from the dashboard.
+ */
 const Sidebar: React.FC = () => (
   <aside className="w-60 bg-gray-50 border-r border-gray-200 min-h-full flex-shrink-0 hidden md:block">
     <nav className="py-4">

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -2,12 +2,20 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useNotifications } from '../../hooks/useNotifications';
 import NotificationDropdown from './NotificationDropdown';
 
+/**
+ * Navbar bell with an unread badge, opening the notification dropdown.
+ *
+ * The count is capped at "9+" so the badge cannot grow wide enough to disturb the navbar, and the
+ * button carries the count in its accessible name — a screen reader would otherwise announce only
+ * "Notifications", losing the very thing the badge conveys.
+ */
 const NotificationBell: React.FC = () => {
   const { unreadCount } = useNotifications();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Close on outside click.
+  // Close on outside click. Bound only while open, and on mousedown rather than click so the dropdown
+  // is gone before a click lands on whatever is underneath it.
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {

--- a/frontend/src/components/notifications/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown.tsx
@@ -4,10 +4,18 @@ import { useNotifications } from '../../hooks/useNotifications';
 import NotificationItem from './NotificationItem';
 import type { AppNotification } from '../../types';
 
+/** @param onClose called after selecting a notification, and by the bell's outside-click handler */
 interface Props {
   onClose: () => void;
 }
 
+/**
+ * Panel under the bell: the eight most recent notifications, mark-all-read, and a link to the full page.
+ *
+ * Selecting one marks it read and navigates to the upgrade it concerns; ones with no related upgrade
+ * (the daily check-in nudge) just close the panel. The desktop-permission prompt appears only while the
+ * browser's answer is still `default`, so a user who has decided either way is not asked again.
+ */
 const NotificationDropdown: React.FC<Props> = ({ onClose }) => {
   const { notifications, unreadCount, markRead, markAllRead, desktopPermission, requestDesktopPermission } =
     useNotifications();

--- a/frontend/src/components/notifications/NotificationItem.tsx
+++ b/frontend/src/components/notifications/NotificationItem.tsx
@@ -2,11 +2,22 @@ import React from 'react';
 import type { AppNotification } from '../../types';
 import { categoryMeta, relativeTime } from './notificationMeta';
 
+/**
+ * @param notification the notification to render
+ * @param onSelect     called with it when pressed; the parent decides what selecting means
+ */
 interface Props {
   notification: AppNotification;
   onSelect: (notification: AppNotification) => void;
 }
 
+/**
+ * One row in the notification list: category icon, title, message and relative time.
+ *
+ * A real button rather than a clickable div, so it is reachable by keyboard and announced as
+ * actionable. Unread rows are tinted and carry a dot with an accessible label, since colour alone
+ * would not convey the state.
+ */
 const NotificationItem: React.FC<Props> = ({ notification, onSelect }) => {
   const meta = categoryMeta[notification.category];
   return (

--- a/frontend/src/components/notifications/ToastContainer.tsx
+++ b/frontend/src/components/notifications/ToastContainer.tsx
@@ -3,16 +3,31 @@ import { useNavigate } from 'react-router-dom';
 import type { AppNotification } from '../../types';
 import { categoryMeta } from './notificationMeta';
 
+/**
+ * The subset of a notification a toast needs.
+ *
+ * Derived from `AppNotification` with `Pick`, so a field renamed there fails to compile here instead of
+ * silently rendering nothing.
+ */
 export interface ToastData extends Pick<AppNotification, 'category' | 'title' | 'message' | 'relatedUpgradeId'> {
   id: string;
 }
 
+/**
+ * @param toasts    the toasts to show, newest first; capped by the provider that owns them
+ * @param onDismiss called on the close button, on selection, and by the auto-dismiss timer
+ */
 interface Props {
   toasts: ToastData[];
   onDismiss: (id: string) => void;
 }
 
-/** Transient real-time toasts, stacked top-right above everything. */
+/**
+ * Transient real-time toasts, stacked top-right above everything.
+ *
+ * Rendered by the notification provider rather than by any page, so a toast survives navigation. Each
+ * is a polite live region: announced when it appears, without interrupting whatever is being read.
+ */
 const ToastContainer: React.FC<Props> = ({ toasts, onDismiss }) => {
   const navigate = useNavigate();
   if (toasts.length === 0) return null;

--- a/frontend/src/components/notifications/notificationMeta.ts
+++ b/frontend/src/components/notifications/notificationMeta.ts
@@ -8,7 +8,13 @@ export const categoryMeta: Record<NotificationCategory, { icon: string; bg: stri
   REMINDER: { icon: '⏰', bg: 'bg-orange-50', ring: 'border-orange-200', text: 'text-orange-700' },
 };
 
-/** "5m ago" style relative time for an ISO timestamp. */
+/**
+ * Formats an ISO timestamp as "just now", "5m ago", "3h ago" or "2d ago", falling back to a locale date
+ * beyond a week.
+ *
+ * Coarse on purpose: a notification list is scanned, not read closely, and a rounded figure is quicker
+ * to take in than an exact one.
+ */
 export const relativeTime = (iso: string): string => {
   const diffMs = Date.now() - new Date(iso).getTime();
   const sec = Math.round(diffMs / 1000);

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 
+/**
+ * @param variant colour scheme; the palette is fixed so badges stay consistent across the app
+ * @param children the label
+ * @param className extra classes appended after the variant's, so they win on conflict
+ */
 interface BadgeProps {
   variant?: 'green' | 'yellow' | 'blue' | 'red' | 'gray' | 'purple';
   children: React.ReactNode;
@@ -15,6 +20,7 @@ const variantClasses: Record<string, string> = {
   purple: 'bg-purple-100 text-purple-800',
 };
 
+/** Small rounded label used for statuses, types and difficulties. */
 const Badge: React.FC<BadgeProps> = ({ variant = 'gray', children, className = '' }) => (
   <span
     className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${variantClasses[variant]} ${className}`}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import LoadingSpinner from './LoadingSpinner';
 
+/**
+ * Extends the native button attributes, so `type`, `onClick`, `aria-*` and the rest pass straight
+ * through.
+ *
+ * @param variant visual weight: primary for the main action, danger for destructive ones
+ * @param size    padding and text scale
+ * @param loading shows a spinner and disables the button, so a slow request cannot be double-submitted
+ */
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
   size?: 'sm' | 'md' | 'lg';
@@ -21,6 +29,7 @@ const sizeClasses: Record<string, string> = {
   lg: 'px-6 py-3 text-base',
 };
 
+/** The app's button. Disabled while `loading`, which is what prevents duplicate submissions. */
 const Button: React.FC<ButtonProps> = ({
   variant = 'primary',
   size = 'md',

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 
+/**
+ * @param children the card body
+ * @param header   optional heading row, separated by a rule; omitted entirely when not given
+ */
 interface CardProps {
   children: React.ReactNode;
   header?: React.ReactNode;
   className?: string;
 }
 
+/** White panel with an optional header. The standard container for a section of a page. */
 const Card: React.FC<CardProps> = ({ children, header, className = '' }) => (
   <div className={`bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden ${className}`}>
     {header && (

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
 
+/**
+ * @param icon        emoji shown above the title
+ * @param title       what is empty, said plainly
+ * @param description optional line explaining how to fill it
+ * @param action      optional button, usually the one that creates the first item
+ */
 interface EmptyStateProps {
   icon?: string;
   title: string;
@@ -7,6 +13,12 @@ interface EmptyStateProps {
   action?: React.ReactNode;
 }
 
+/**
+ * Placeholder for a list with nothing in it.
+ *
+ * Used instead of rendering nothing, so an empty page reads as "there is nothing here yet" rather than
+ * as a page that failed to load.
+ */
 const EmptyState: React.FC<EmptyStateProps> = ({ icon = '📭', title, description, action }) => (
   <div className="flex flex-col items-center justify-center py-16 text-center">
     <div className="text-5xl mb-4">{icon}</div>

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,10 +1,24 @@
 import React from 'react';
 
+/**
+ * Extends the native input attributes, so `type`, `value`, `onChange` and validation attributes pass
+ * through unchanged.
+ *
+ * @param label optional caption, also used to derive an id when none is given
+ * @param error message shown below the field, which also switches it to its error colours
+ */
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
 }
 
+/**
+ * Labelled text input with inline error display.
+ *
+ * When no `id` is supplied one is derived from the label, which is what keeps the `htmlFor` association
+ * intact — without it, clicking the label would not focus the field and screen readers would not
+ * announce it.
+ */
 const Input: React.FC<InputProps> = ({ label, error, id, className = '', ...rest }) => {
   const inputId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
   return (

--- a/frontend/src/components/ui/LoadingSpinner.tsx
+++ b/frontend/src/components/ui/LoadingSpinner.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
+/** @param size sm inside a button, md inline, lg for a full-page wait */
 interface LoadingSpinnerProps {
   size?: 'sm' | 'md' | 'lg';
 }
 
 const sizeMap = { sm: 'h-4 w-4', md: 'h-8 w-8', lg: 'h-12 w-12' };
 
+/** Indeterminate spinner shown while something is in flight. */
 const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ size = 'md' }) => (
   <div className="flex items-center justify-center">
     <div

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect } from 'react';
 
+/**
+ * @param isOpen   whether the dialog is shown; when false the component renders nothing at all
+ * @param onClose  called by the close button, the backdrop and the Escape key alike
+ * @param title    heading text
+ * @param children the dialog body, usually a form
+ */
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -7,6 +13,13 @@ interface ModalProps {
   children: React.ReactNode;
 }
 
+/**
+ * Centred dialog over a dimmed backdrop.
+ *
+ * Closes on Escape as well as on the button and the backdrop; the key listener is bound only while
+ * open, so a closed modal costs nothing and several on one page cannot fight over the key. Nothing is
+ * rendered when closed, which means the body is unmounted and its form state resets between openings.
+ */
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 
+/**
+ * @param title    the page's heading, rendered as the single h1
+ * @param subtitle optional line of context below it
+ * @param action   optional button aligned to the right, usually the page's primary action
+ */
 interface PageHeaderProps {
   title: string;
   subtitle?: string;
   action?: React.ReactNode;
 }
 
+/** Standard page heading: title, optional subtitle, optional right-aligned action. */
 const PageHeader: React.FC<PageHeaderProps> = ({ title, subtitle, action }) => (
   <div className="flex items-start justify-between mb-6">
     <div>

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -1,16 +1,25 @@
 import React from 'react';
 
+/** One choice: the value submitted, and the text shown for it. */
 interface SelectOption {
   value: string;
   label: string;
 }
 
+/**
+ * Extends the native select attributes, so `value`, `onChange` and `required` pass through.
+ *
+ * @param label   optional caption, also used to derive an id when none is given
+ * @param options the choices, rendered in the order given
+ * @param error   message shown below the field, which also switches it to its error colours
+ */
 interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   label?: string;
   options: SelectOption[];
   error?: string;
 }
 
+/** Labelled dropdown with inline error display, matching {@link Input}. */
 const Select: React.FC<SelectProps> = ({ label, options, error, id, className = '', ...rest }) => {
   const selectId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
   return (

--- a/frontend/src/components/upgrade/UpgradeCard.tsx
+++ b/frontend/src/components/upgrade/UpgradeCard.tsx
@@ -6,18 +6,32 @@ import UpgradeTypeBadge from './UpgradeTypeBadge';
 import Badge from '../ui/Badge';
 import Button from '../ui/Button';
 
+/**
+ * @param upgrade        the upgrade to show
+ * @param onStatusChange called with the target status when a transition button is pressed; the card
+ *                       does not perform the transition itself, so the page decides how to refresh
+ * @param showActions    hide the transition buttons where the card is read-only
+ */
 interface Props {
   upgrade: HealthUpgrade;
   onStatusChange?: (id: string, status: HealthUpgrade['status']) => void;
   showActions?: boolean;
 }
 
+/** Difficulty to badge colour: green through red, so HARD reads as the demanding one. */
 const difficultyVariant: Record<string, 'green' | 'yellow' | 'red'> = {
   EASY: 'green',
   MEDIUM: 'yellow',
   HARD: 'red',
 };
 
+/**
+ * Summary card for one upgrade, with the transitions that are legal from its current status.
+ *
+ * The buttons shown mirror the server's state machine — plan an idea, activate a planned one, pause or
+ * complete a running one, resume a paused one. Offering only the legal moves is what keeps a user from
+ * meeting a 422 they could not have predicted.
+ */
 const UpgradeCard: React.FC<Props> = ({ upgrade, onStatusChange, showActions = true }) => {
   const navigate = useNavigate();
 

--- a/frontend/src/components/upgrade/UpgradeStatusBadge.tsx
+++ b/frontend/src/components/upgrade/UpgradeStatusBadge.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import Badge from '../ui/Badge';
 import type { UpgradeStatus } from '../../types';
 
+/** @param status the upgrade's lifecycle status */
 interface Props {
   status: UpgradeStatus;
 }
 
+/** Status to colour and label. Green for running, red for abandoned, neutral for an untouched idea. */
 const statusMap: Record<UpgradeStatus, { variant: 'green' | 'yellow' | 'blue' | 'red' | 'gray' | 'purple'; label: string }> = {
   IDEA: { variant: 'gray', label: 'Idea' },
   PLANNED: { variant: 'blue', label: 'Planned' },
@@ -15,6 +17,12 @@ const statusMap: Record<UpgradeStatus, { variant: 'green' | 'yellow' | 'blue' | 
   ABANDONED: { variant: 'red', label: 'Abandoned' },
 };
 
+/**
+ * Coloured badge naming an upgrade's status.
+ *
+ * Falls back to the raw value for a status this build does not know, so a backend that gains one
+ * degrades to showing its name rather than rendering an empty badge.
+ */
 const UpgradeStatusBadge: React.FC<Props> = ({ status }) => {
   const { variant, label } = statusMap[status] ?? { variant: 'gray', label: status };
   return <Badge variant={variant}>{label}</Badge>;

--- a/frontend/src/components/upgrade/UpgradeTypeBadge.tsx
+++ b/frontend/src/components/upgrade/UpgradeTypeBadge.tsx
@@ -2,10 +2,17 @@ import React from 'react';
 import Badge from '../ui/Badge';
 import type { UpgradeType } from '../../types';
 
+/** @param type what kind of change the upgrade is */
 interface Props {
   type: UpgradeType;
 }
 
+/**
+ * Type to colour and label.
+ *
+ * Covers this app's `UpgradeType` union, which is currently wider than the backend enum — see the note
+ * on that type. The five values the API does not accept are unreachable in practice.
+ */
 const typeMap: Record<UpgradeType, { variant: 'green' | 'yellow' | 'blue' | 'red' | 'gray' | 'purple'; label: string }> = {
   HABIT: { variant: 'green', label: 'Habit' },
   ONE_TIME_ACTION: { variant: 'blue', label: 'One-Time' },
@@ -17,6 +24,7 @@ const typeMap: Record<UpgradeType, { variant: 'green' | 'yellow' | 'blue' | 'red
   MEDICAL_PREVENTIVE: { variant: 'red', label: 'Medical' },
 };
 
+/** Coloured badge naming an upgrade's type, falling back to the raw value for an unknown one. */
 const UpgradeTypeBadge: React.FC<Props> = ({ type }) => {
   const { variant, label } = typeMap[type] ?? { variant: 'gray', label: type };
   return <Badge variant={variant}>{label}</Badge>;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -3,6 +3,16 @@ import { loginApi, registerApi, getMe } from '../api/auth';
 import { AuthContext } from './authContextValue';
 import type { User } from '../types';
 
+/**
+ * Owns the session: the signed-in user, the token, and the login, register and logout actions.
+ *
+ * The token and a copy of the user live in `localStorage`, which is what survives a page reload. That
+ * copy is treated as a cache, never as proof: on mount it is shown immediately so the UI has something
+ * to render, and simultaneously checked against `/api/auth/me`. A token the server rejects clears the
+ * session.
+ *
+ * A 401 on any later request is handled elsewhere, by the axios interceptor in `api/client.ts`.
+ */
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
@@ -41,6 +51,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       .finally(() => setIsLoading(false));
   }, []);
 
+  /** Signs in and persists the session. Rejects if the credentials are wrong, leaving state untouched. */
   const login = useCallback(async (email: string, password: string) => {
     const response = await loginApi(email, password);
     localStorage.setItem('jwt_token', response.token);
@@ -49,6 +60,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setUser(response.user);
   }, []);
 
+  /** Creates an account and signs straight in with the token it returns. */
   const register = useCallback(async (name: string, email: string, password: string) => {
     const response = await registerApi(name, email, password);
     localStorage.setItem('jwt_token', response.token);
@@ -57,6 +69,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setUser(response.user);
   }, []);
 
+  /**
+   * Clears the session and reloads onto the login page.
+   *
+   * A full document navigation rather than a router push, deliberately: it also discards the query
+   * cache, so nothing belonging to the previous user can be read by the next one.
+   */
   const logout = useCallback(() => {
     localStorage.removeItem('jwt_token');
     localStorage.removeItem('user');

--- a/frontend/src/contexts/NotificationProvider.tsx
+++ b/frontend/src/contexts/NotificationProvider.tsx
@@ -7,10 +7,16 @@ import { NotificationContext } from './notificationContextValue';
 import ToastContainer, { type ToastData } from '../components/notifications/ToastContainer';
 import type { AppNotification } from '../types';
 
+/** Query key for the cached notification list, shared by the fetch and every live update below. */
 const NOTIF_KEY = ['notifications'];
 
-/** Build the WebSocket URL. Same-origin /ws (via the Vite/nginx proxy) by default; derived from
- * VITE_API_URL when the API is on another origin. */
+/**
+ * Builds the WebSocket URL.
+ *
+ * Same-origin `/ws` through the Vite or nginx proxy by default, so the socket needs no CORS setup;
+ * derived from `VITE_API_URL` only when the API is on another origin. The scheme is upgraded in step
+ * with the page's, since a `ws://` socket on an `https://` page is blocked by the browser.
+ */
 function buildWsUrl(): string {
   const apiUrl = import.meta.env.VITE_API_URL;
   if (apiUrl && /^https?:\/\//.test(apiUrl)) {
@@ -20,6 +26,17 @@ function buildWsUrl(): string {
   return `${proto}//${window.location.host}/ws`;
 }
 
+/**
+ * Owns notification state: the list, the unread count, the live connection and the toasts.
+ *
+ * Notifications arrive by two routes and both write to the same query cache — a REST fetch on mount,
+ * and a STOMP subscription for anything raised while the tab is open. Live arrivals are de-duplicated
+ * by id, so a notification that comes in both ways is shown once.
+ *
+ * Mounted inside the router because a toast can navigate, and inside the auth provider because the
+ * socket authenticates with the token. The connection follows the session: it opens when signed in and
+ * closes on logout or unmount.
+ */
 export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { token, isAuthenticated } = useAuth();
   const queryClient = useQueryClient();
@@ -36,10 +53,15 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
     enabled: isAuthenticated,
   });
 
+  /** Removes one toast, whether it was dismissed by the user or timed out. */
   const dismissToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
+  /**
+   * Shows a notification as a toast: newest first, at most four at once, each auto-dismissed after six
+   * seconds. The cap matters — a burst of notifications would otherwise cover the page.
+   */
   const pushToast = useCallback((n: AppNotification) => {
     setToasts((prev) =>
       [{ id: n.id, category: n.category, title: n.title, message: n.message, relatedUpgradeId: n.relatedUpgradeId }, ...prev].slice(0, 4),
@@ -47,6 +69,13 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
     window.setTimeout(() => dismissToast(n.id), 6000);
   }, [dismissToast]);
 
+  /**
+   * Handles a notification pushed over the socket: writes it into the cache, toasts it, and raises a
+   * desktop notification when the tab is in the background.
+   *
+   * The desktop notification is deliberately conditional on `document.hidden` — the toast already
+   * covers the case where the user is looking at the page, and doing both would notify twice.
+   */
   const handleIncoming = useCallback((n: AppNotification) => {
     // Prepend to the cached list (de-duped) so the bell/badge/list update live.
     queryClient.setQueryData<AppNotification[]>(NOTIF_KEY, (old = []) =>
@@ -65,6 +94,10 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
   }, [queryClient, pushToast]);
 
   // STOMP connection lifecycle — connect while authenticated, disconnect on logout/unmount.
+  // Reconnects every five seconds while the socket is down; nothing is lost meanwhile, since anything
+  // missed is still fetched by the REST query.
+  // handleIncoming is a dependency, so it is memoised: a new identity each render would tear the
+  // socket down and rebuild it on every render.
   useEffect(() => {
     if (!isAuthenticated || !token) return;
 
@@ -78,7 +111,9 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
           try {
             handleIncoming(JSON.parse(message.body) as AppNotification);
           } catch {
-            /* ignore malformed frames */
+            // A frame that will not parse is dropped rather than thrown: an exception here would
+            // propagate into the STOMP client and tear down the subscription, costing every later
+            // notification as well as this one.
           }
         });
       },
@@ -95,6 +130,12 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
     };
   }, [isAuthenticated, token, handleIncoming]);
 
+  /**
+   * Marks one notification read, updating the cache first and calling the API after.
+   *
+   * The optimistic write is what makes the badge respond instantly. If the call fails the cache is
+   * invalidated, so the server's answer replaces the guess rather than the UI keeping a lie.
+   */
   const markRead = useCallback((id: string) => {
     queryClient.setQueryData<AppNotification[]>(NOTIF_KEY, (old = []) =>
       old.map((n) => (n.id === id ? { ...n, read: true } : n)),
@@ -102,11 +143,18 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
     markNotificationRead(id).catch(() => queryClient.invalidateQueries({ queryKey: NOTIF_KEY }));
   }, [queryClient]);
 
+  /** Marks every notification read, optimistically and with the same rollback-by-invalidation. */
   const markAllRead = useCallback(() => {
     queryClient.setQueryData<AppNotification[]>(NOTIF_KEY, (old = []) => old.map((n) => ({ ...n, read: true })));
     markAllNotificationsRead().catch(() => queryClient.invalidateQueries({ queryKey: NOTIF_KEY }));
   }, [queryClient]);
 
+  /**
+   * Asks the browser for desktop-notification permission.
+   *
+   * Guarded because the API is absent in insecure contexts and some embedded browsers, where reading
+   * `Notification` at all would throw.
+   */
   const requestDesktopPermission = useCallback(() => {
     if (typeof Notification === 'undefined') return;
     Notification.requestPermission().then(setDesktopPermission);

--- a/frontend/src/contexts/authContextValue.ts
+++ b/frontend/src/contexts/authContextValue.ts
@@ -1,6 +1,12 @@
 import { createContext } from 'react';
 import type { User } from '../types';
 
+/**
+ * What the auth context exposes: the signed-in user, the raw token, and the session actions.
+ *
+ * `isLoading` is true only while a stored token is being verified on load; `isAuthenticated` is false
+ * during that window, which is why consumers must check the former before acting on the latter.
+ */
 export interface AuthContextType {
   user: User | null;
   token: string | null;
@@ -11,4 +17,8 @@ export interface AuthContextType {
   isAuthenticated: boolean;
 }
 
+/**
+ * The context object itself, kept in its own module so the file holding the provider component exports
+ * only components — which is what lets React Fast Refresh work on it.
+ */
 export const AuthContext = createContext<AuthContextType | null>(null);

--- a/frontend/src/contexts/notificationContextValue.ts
+++ b/frontend/src/contexts/notificationContextValue.ts
@@ -1,6 +1,13 @@
 import { createContext } from 'react';
 import type { AppNotification } from '../types';
 
+/**
+ * What the notification context exposes: the notification list and unread count, whether the real-time
+ * connection is up, and the desktop-notification permission state.
+ *
+ * `connected` reflects the STOMP socket only. A disconnected client still shows notifications — it
+ * fetches them over REST instead — so this is an indicator, not a gate.
+ */
 export interface NotificationContextType {
   notifications: AppNotification[];
   unreadCount: number;
@@ -11,4 +18,5 @@ export interface NotificationContextType {
   requestDesktopPermission: () => void;
 }
 
+/** The context object, split from the provider component for the same Fast Refresh reason as auth. */
 export const NotificationContext = createContext<NotificationContextType | null>(null);

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,6 +1,12 @@
 import { useContext } from 'react';
 import { AuthContext } from '../contexts/authContextValue';
 
+/**
+ * Reads the auth context.
+ *
+ * @throws Error when called outside `AuthProvider` — a null context would otherwise surface much later
+ * as an unexplained "cannot read property of null" inside a component.
+ */
 export const useAuth = () => {
   const ctx = useContext(AuthContext);
   if (!ctx) throw new Error('useAuth must be used within AuthProvider');

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,6 +1,11 @@
 import { useContext } from 'react';
 import { NotificationContext } from '../contexts/notificationContextValue';
 
+/**
+ * Reads the notification context: the current list, the unread count, and the actions that mutate them.
+ *
+ * @throws Error when called outside `NotificationProvider`
+ */
 export const useNotifications = () => {
   const ctx = useContext(NotificationContext);
   if (!ctx) throw new Error('useNotifications must be used within NotificationProvider');

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,9 @@
+/**
+ * Browser entry point: mounts the application into `#root`.
+ *
+ * StrictMode is on, so in development effects run twice on mount — anything that misbehaves under a
+ * double invocation is a real bug, not an artefact.
+ */
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';

--- a/frontend/src/pages/ActiveUpgradesPage.tsx
+++ b/frontend/src/pages/ActiveUpgradesPage.tsx
@@ -9,6 +9,12 @@ import EmptyState from '../components/ui/EmptyState';
 import UpgradeCard from '../components/upgrade/UpgradeCard';
 import type { UpgradeStatus } from '../types';
 
+/**
+ * The upgrades currently running, with the transitions available from `ACTIVE`.
+ *
+ * Invalidates the whole `upgrades` key rather than the active slice, since pausing or completing one
+ * moves it onto a list this page does not show.
+ */
 const ActiveUpgradesPage: React.FC = () => {
   const qc = useQueryClient();
   const navigate = useNavigate();

--- a/frontend/src/pages/DailyCheckinPage.tsx
+++ b/frontend/src/pages/DailyCheckinPage.tsx
@@ -10,16 +10,30 @@ import EmptyState from '../components/ui/EmptyState';
 import { useNavigate } from 'react-router-dom';
 import type { HealthUpgrade, CreateProgressRequest } from '../types';
 
+/** Draft entries being filled in, keyed by upgrade id, until the whole form is submitted. */
 type ProgressMap = Record<string, Partial<CreateProgressRequest>>;
 
+/** Today as `YYYY-MM-DD`, the date format the progress API expects. */
 const today = () => new Date().toISOString().split('T')[0];
 
-// Avoid sending NaN to the API when the numeric field is cleared.
+/**
+ * Parses a numeric field, treating unparseable input as absent.
+ *
+ * Clearing a number input yields an empty string, and `parseFloat('')` is NaN — which serialises to
+ * `null` and would be read as a logged value of nothing rather than as no value at all.
+ */
 const numOrUndef = (v: string): number | undefined => {
   const n = parseFloat(v);
   return Number.isNaN(n) ? undefined : n;
 };
 
+/**
+ * Logs progress for every active upgrade in one pass.
+ *
+ * The entries are gathered locally and submitted together, so the user fills the form once rather than
+ * saving each upgrade separately. Only upgrades with something entered are sent; an untouched one is
+ * left unlogged rather than recorded as missed.
+ */
 const DailyCheckinPage: React.FC = () => {
   const qc = useQueryClient();
   const navigate = useNavigate();
@@ -37,6 +51,7 @@ const DailyCheckinPage: React.FC = () => {
     },
   });
 
+  /** Merges a field change into one upgrade's draft entry, leaving the others untouched. */
   const updateProgress = (id: string, partial: Partial<CreateProgressRequest>) => {
     setProgressMap((prev) => ({ ...prev, [id]: { ...prev[id], ...partial } }));
   };

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -11,6 +11,13 @@ import EmptyState from '../components/ui/EmptyState';
 import { performUpgradeAction } from '../api/upgrades';
 import type { UpgradeStatus } from '../types';
 
+/**
+ * Landing page after sign-in: counts, the weekly rate, streaks, overdue warnings and today's upgrades.
+ *
+ * Everything comes from the single `/api/dashboard` call, so the sections cannot disagree with one
+ * another. A transition performed from a card invalidates that one query, which refreshes the whole
+ * page at once.
+ */
 const DashboardPage: React.FC = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
@@ -20,6 +27,7 @@ const DashboardPage: React.FC = () => {
     queryFn: getDashboard,
   });
 
+  /** Performs a lifecycle transition from a card, then refetches the dashboard it appeared on. */
   const handleStatusChange = async (id: string, status: UpgradeStatus) => {
     await performUpgradeAction(id, status);
     await queryClient.invalidateQueries({ queryKey: ['dashboard'] });

--- a/frontend/src/pages/HealthAreasPage.tsx
+++ b/frontend/src/pages/HealthAreasPage.tsx
@@ -10,6 +10,13 @@ import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import type { CreateHealthAreaRequest, HealthArea } from '../types';
 
+/**
+ * Manages health areas — the folders upgrades are filed under.
+ *
+ * Create, edit and delete all go through modals over the same list, and each mutation invalidates the
+ * area query rather than patching local state, so what is shown is always what was saved. Deleting an
+ * area does not touch the upgrades filed under it.
+ */
 const HealthAreasPage: React.FC = () => {
   const qc = useQueryClient();
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -35,6 +42,7 @@ const HealthAreasPage: React.FC = () => {
     onSuccess: () => { qc.invalidateQueries({ queryKey: ['healthAreas'] }); setDeleteId(null); },
   });
 
+  /** Clears the shared form, so opening create after edit does not inherit the edited values. */
   const resetForm = () => setForm({ name: '', description: '', icon: '', color: '' });
 
   const handleCreate = async (e: React.FormEvent) => {
@@ -50,6 +58,7 @@ const HealthAreasPage: React.FC = () => {
     await updateMutation.mutateAsync({ id: editArea.id, req: form });
   };
 
+  /** Opens the edit modal pre-filled from an area; nullable fields become empty strings for the inputs. */
   const openEdit = (area: HealthArea) => {
     setEditArea(area);
     setForm({ name: area.name, description: area.description ?? '', icon: area.icon ?? '', color: area.color ?? '' });

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,6 +4,15 @@ import { useAuth } from '../hooks/useAuth';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 
+/**
+ * Sign-in page, one of the two routes reachable without a session.
+ *
+ * The error message is deliberately the same whichever half of the credentials was wrong — saying
+ * which would tell an attacker that an email is registered.
+ *
+ * Redirects to the dashboard when already signed in, which is what stops a user with a valid session
+ * from landing here by typing the URL.
+ */
 const LoginPage: React.FC = () => {
   const { login, isAuthenticated } = useAuth();
   const navigate = useNavigate();

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -7,6 +7,12 @@ import EmptyState from '../components/ui/EmptyState';
 import NotificationItem from '../components/notifications/NotificationItem';
 import type { AppNotification } from '../types';
 
+/**
+ * The full notification list, with an all/unread filter.
+ *
+ * Reads from the notification context rather than fetching, so it shows the same list the bell does and
+ * updates live while open. Selecting one marks it read and follows it to the upgrade it concerns.
+ */
 const NotificationsPage: React.FC = () => {
   const { notifications, unreadCount, markRead, markAllRead, desktopPermission, requestDesktopPermission } =
     useNotifications();

--- a/frontend/src/pages/PlannedUpgradesPage.tsx
+++ b/frontend/src/pages/PlannedUpgradesPage.tsx
@@ -9,6 +9,12 @@ import Button from '../components/ui/Button';
 import { useNavigate } from 'react-router-dom';
 import type { UpgradeStatus } from '../types';
 
+/**
+ * Upgrades committed to a start date but not yet running, soonest first.
+ *
+ * Sorted client-side because the API returns them unordered; upgrades with no planned date sort last
+ * rather than first, so an unscheduled one does not head a list meant to read as a timeline.
+ */
 const PlannedUpgradesPage: React.FC = () => {
   const qc = useQueryClient();
   const navigate = useNavigate();

--- a/frontend/src/pages/ProgressHistoryPage.tsx
+++ b/frontend/src/pages/ProgressHistoryPage.tsx
@@ -9,6 +9,13 @@ import EmptyState from '../components/ui/EmptyState';
 import Badge from '../components/ui/Badge';
 import type { ProgressEntry, HealthUpgrade } from '../types';
 
+/**
+ * The last seven days of progress across every upgrade, newest first.
+ *
+ * Two queries rather than one: entries carry an upgrade id but no title, so the upgrades are fetched
+ * alongside and indexed by id. An entry whose upgrade has since been deleted still renders, labelled
+ * as unknown, rather than disappearing or breaking the list.
+ */
 const ProgressHistoryPage: React.FC = () => {
   const { data: progress = [], isLoading: pLoading, error: pError } = useQuery({ queryKey: ['allProgress'], queryFn: getWeekProgress });
   const { data: upgrades = [], isLoading: uLoading, error: uError } = useQuery({ queryKey: ['allUpgrades'], queryFn: () => getUpgrades() });

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -4,6 +4,15 @@ import { useAuth } from '../hooks/useAuth';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 
+/**
+ * Account creation page, and the other route reachable without a session.
+ *
+ * The password rules checked here — matching confirmation, minimum length — are for immediate feedback
+ * only; the API is the authority on whether a registration is accepted. A duplicate email is reported
+ * as a possibility rather than a fact, so this page does not become a way to test which emails exist.
+ *
+ * Signs the new account straight in, since registration returns a token.
+ */
 const RegisterPage: React.FC = () => {
   const { register, isAuthenticated } = useAuth();
   const navigate = useNavigate();

--- a/frontend/src/pages/UpgradeBacklogPage.tsx
+++ b/frontend/src/pages/UpgradeBacklogPage.tsx
@@ -12,6 +12,12 @@ import EmptyState from '../components/ui/EmptyState';
 import UpgradeCard from '../components/upgrade/UpgradeCard';
 import type { CreateUpgradeRequest, UpgradeType, Difficulty, UpgradeStatus } from '../types';
 
+/**
+ * The upgrade types offered when creating one.
+ *
+ * Covers this app's `UpgradeType` union, which is wider than what the API accepts — see the note on
+ * that type in `src/types`.
+ */
 const typeOptions: { value: UpgradeType; label: string }[] = [
   { value: 'HABIT', label: 'Habit' },
   { value: 'ONE_TIME_ACTION', label: 'One-Time Action' },
@@ -23,12 +29,20 @@ const typeOptions: { value: UpgradeType; label: string }[] = [
   { value: 'MEDICAL_PREVENTIVE', label: 'Medical / Preventive' },
 ];
 
+/** Difficulty choices. HARD is capped at three concurrently active, and the API enforces that. */
 const difficultyOptions: { value: Difficulty; label: string }[] = [
   { value: 'EASY', label: 'Easy' },
   { value: 'MEDIUM', label: 'Medium' },
   { value: 'HARD', label: 'Hard' },
 ];
 
+/**
+ * The idea backlog: every upgrade still in `IDEA`, and the form that creates new ones.
+ *
+ * This is where upgrades enter the system — creation is not offered on the planned or active pages,
+ * because a new upgrade always starts as an idea whatever the client asks for. Planning one from here
+ * moves it off this list.
+ */
 const UpgradeBacklogPage: React.FC = () => {
   const qc = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);

--- a/frontend/src/pages/UpgradeDetailsPage.tsx
+++ b/frontend/src/pages/UpgradeDetailsPage.tsx
@@ -17,19 +17,40 @@ import UpgradeTypeBadge from '../components/upgrade/UpgradeTypeBadge';
 import Badge from '../components/ui/Badge';
 import type { CreateProgressRequest, CreateReflectionRequest, TrackingType, Frequency } from '../types';
 
+/** Today as `YYYY-MM-DD`, the date format the progress and reflection APIs expect. */
 const today = () => new Date().toISOString().split('T')[0];
+/**
+ * Day tokens for the reminder day picker, in week order.
+ *
+ * Three-letter and upper case because that is the form the API stores; selecting none means the
+ * reminder fires every day.
+ */
 const DAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
 
-// Parse number inputs without ever sending NaN to the API (e.g. when the field is cleared).
+/**
+ * Parses a decimal field, treating unparseable input as absent.
+ *
+ * A cleared number input yields an empty string, and `parseFloat('')` is NaN — which would serialise
+ * to `null` and be read as a logged value rather than as no value.
+ */
 const numOrUndef = (v: string): number | undefined => {
   const n = parseFloat(v);
   return Number.isNaN(n) ? undefined : n;
 };
+/** Integer counterpart of {@link numOrUndef}, for the rating fields. */
 const intOrUndef = (v: string): number | undefined => {
   const n = parseInt(v, 10);
   return Number.isNaN(n) ? undefined : n;
 };
 
+/**
+ * Everything about one upgrade: its details, progress history, streak, reflections, reminders and
+ * tracking configuration.
+ *
+ * The busiest page in the app, and the only place several of these can be edited at all. Each concern
+ * is its own query and its own mutation, so saving a reflection does not refetch the progress history;
+ * what they share is the upgrade id from the route.
+ */
 const UpgradeDetailsPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();

--- a/frontend/src/router/ProtectedRoute.tsx
+++ b/frontend/src/router/ProtectedRoute.tsx
@@ -3,10 +3,17 @@ import { Navigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 
+/** @param children the page to render once the caller is known to be signed in */
 interface Props {
   children: React.ReactNode;
 }
 
+/**
+ * Gate that renders its children only for a signed-in user.
+ *
+ * The loading state is not cosmetic: a stored token is verified asynchronously on load, and rendering
+ * the redirect during that window would bounce a signed-in user to the login page on every refresh.
+ */
 const ProtectedRoute: React.FC<Props> = ({ children }) => {
   const { isAuthenticated, isLoading } = useAuth();
   if (isLoading) return <div className="min-h-screen flex items-center justify-center"><LoadingSpinner size="lg" /></div>;

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -15,6 +15,13 @@ import DailyCheckinPage from '../pages/DailyCheckinPage';
 import ProgressHistoryPage from '../pages/ProgressHistoryPage';
 import NotificationsPage from '../pages/NotificationsPage';
 
+/**
+ * The route table, and the only place a URL maps to a page.
+ *
+ * Every route but login and register is wrapped in {@link ProtectedRoute} and the shared {@link Layout},
+ * so an authenticated page cannot be added without both. Unknown paths fall through to `/`, which
+ * redirects to the dashboard when signed in and to login otherwise.
+ */
 // NotificationProvider lives inside the Router so toasts/items can navigate, and inside the existing
 // QueryClientProvider + AuthProvider (mounted in App.tsx) for query + auth access.
 const AppRouter: React.FC = () => (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,12 @@
+/**
+ * Shared wire types.
+ *
+ * These mirror the backend's response DTOs and enums. They are hand-written rather than generated, so
+ * a backend change that is not reflected here is invisible until it fails at runtime — see the note on
+ * {@link UpgradeType}.
+ */
+
+/** A user's public profile, as returned by the auth endpoints. */
 export interface User {
   id: string;
   name: string;
@@ -5,11 +14,18 @@ export interface User {
   createdAt: string;
 }
 
+/** What a successful login or registration returns: the token to store, and who it belongs to. */
 export interface AuthResponse {
   token: string;
   user: User;
 }
 
+/**
+ * A user-defined grouping upgrades are filed under.
+ *
+ * `upgradeCount` is not part of the health-area response; it is filled in by the client where a count
+ * is needed, which is why it is optional.
+ */
 export interface HealthArea {
   id: string;
   userId: string;
@@ -22,6 +38,14 @@ export interface HealthArea {
   upgradeCount?: number;
 }
 
+/**
+ * What kind of change an upgrade is.
+ *
+ * NOTE: this union does not currently match the backend enum, which accepts only `HABIT`, `GOAL`,
+ * `EXPERIMENT` and `PROTOCOL`. Five of the values below are rejected by the API with a 400, and
+ * `PROTOCOL` is missing here. Keep the backend enum, this type and the seed data in step when
+ * changing any of them.
+ */
 export type UpgradeType =
   | 'HABIT'
   | 'ONE_TIME_ACTION'
@@ -32,6 +56,12 @@ export type UpgradeType =
   | 'LEARNING_TASK'
   | 'MEDICAL_PREVENTIVE';
 
+/**
+ * Where an upgrade stands in its lifecycle.
+ *
+ * `IDEA` is the initial state — not `DRAFT`. Transitions are driven server-side through the action
+ * endpoints, never by assigning a status.
+ */
 export type UpgradeStatus =
   | 'IDEA'
   | 'PLANNED'
@@ -40,12 +70,20 @@ export type UpgradeStatus =
   | 'COMPLETED'
   | 'ABANDONED';
 
+/** How demanding an upgrade is. `HARD` is rationed: at most three may be active at once. */
 export type Difficulty = 'EASY' | 'MEDIUM' | 'HARD';
 
+/** How progress is measured, which decides which fields of a progress entry are meaningful. */
 export type TrackingType = 'BOOLEAN' | 'NUMERIC' | 'TEXT' | 'RATING';
 
+/**
+ * How often an upgrade is expected to be acted on.
+ *
+ * NOTE: `CUSTOM` has no counterpart in the backend enum and is rejected by the API.
+ */
 export type Frequency = 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'CUSTOM';
 
+/** How one upgrade is tracked. At most one per upgrade; absent when tracking is not set up. */
 export interface TrackingConfig {
   id: string;
   upgradeId: string;
@@ -56,6 +94,12 @@ export interface TrackingConfig {
   requiredDaily?: boolean;
 }
 
+/**
+ * The core domain object: a planned health improvement.
+ *
+ * `overdue` is derived server-side, and `version` is the optimistic-lock counter — send back the one
+ * that was received or the update is rejected with a 409.
+ */
 export interface HealthUpgrade {
   id: string;
   userId: string;
@@ -77,11 +121,18 @@ export interface HealthUpgrade {
   trackingConfig?: TrackingConfig;
 }
 
+/** An upgrade's streak figures, both counted in consecutive completed days. */
 export interface StreakSummary {
   current: number;
   longest: number;
 }
 
+/**
+ * One day's logged progress. At most one entry exists per upgrade per date.
+ *
+ * `completed` is the server's verdict rather than what was submitted: for a configured upgrade it is
+ * recomputed from the target when the entry is recorded.
+ */
 export interface ProgressEntry {
   id: string;
   upgradeId: string;
@@ -95,6 +146,7 @@ export interface ProgressEntry {
   createdAt: string;
 }
 
+/** A written review of how an upgrade is going. Append-only — there is no edit or delete endpoint. */
 export interface Reflection {
   id: string;
   upgradeId: string;
@@ -108,6 +160,13 @@ export interface Reflection {
   createdAt: string;
 }
 
+/**
+ * The whole dashboard in one response.
+ *
+ * The upgrade lists overlap deliberately — one upgrade can be active, due today and overdue at once,
+ * and appears in each list it qualifies for. `streaks` is keyed by upgrade id and covers active
+ * upgrades only.
+ */
 export interface DashboardDto {
   activeUpgrades: HealthUpgrade[];
   plannedUpgrades: HealthUpgrade[];
@@ -119,6 +178,7 @@ export interface DashboardDto {
   areaSummary: AreaSummary[];
 }
 
+/** Upgrade counts for one health area, as shown on the dashboard. */
 export interface AreaSummary {
   areaId: string;
   areaName: string;
@@ -127,6 +187,7 @@ export interface AreaSummary {
   completedCount: number;
 }
 
+/** Body for creating or replacing a health area. Updates are a full replacement, not a patch. */
 export interface CreateHealthAreaRequest {
   name: string;
   description?: string;
@@ -135,6 +196,11 @@ export interface CreateHealthAreaRequest {
   color?: string;
 }
 
+/**
+ * Body for creating or replacing an upgrade.
+ *
+ * Carries no status: an upgrade is created as an `IDEA` and moves only through the action endpoints.
+ */
 export interface CreateUpgradeRequest {
   areaId?: string;
   title: string;
@@ -147,6 +213,12 @@ export interface CreateUpgradeRequest {
   targetEndDate?: string;
 }
 
+/**
+ * Body for logging progress, plus the `upgradeId` that selects the endpoint.
+ *
+ * `upgradeId` is stripped from the payload by `createProgress` — it belongs in the URL. Which of the
+ * value fields matters depends on the upgrade's tracking type.
+ */
 export interface CreateProgressRequest {
   upgradeId: string;
   date: string;
@@ -157,6 +229,7 @@ export interface CreateProgressRequest {
   note?: string;
 }
 
+/** Body for writing a reflection. Every field but the date is optional. */
 export interface CreateReflectionRequest {
   upgradeId: string;
   date: string;
@@ -167,6 +240,7 @@ export interface CreateReflectionRequest {
   nextAdjustment?: string;
 }
 
+/** What a notification is about. Drives the icon and the destination a click leads to. */
 export type NotificationType =
   | 'UPGRADE_CREATED'
   | 'UPGRADE_PLANNED'
@@ -180,8 +254,15 @@ export type NotificationType =
   | 'REMINDER'
   | 'CHECKIN_REMINDER';
 
+/** How a notification should read, which drives its colour and icon. */
 export type NotificationCategory = 'INFO' | 'SUCCESS' | 'WARNING' | 'REMINDER';
 
+/**
+ * A notification as delivered over either transport.
+ *
+ * Named `AppNotification` because `Notification` is a DOM global — shadowing it would make the browser
+ * API unreachable in any module importing this one.
+ */
 export interface AppNotification {
   id: string;
   type: NotificationType;
@@ -193,6 +274,7 @@ export interface AppNotification {
   createdAt: string;
 }
 
+/** A recurring nudge attached to an upgrade. An empty `daysOfWeek` means every day. */
 export interface Reminder {
   id: string;
   upgradeId: string;
@@ -201,6 +283,12 @@ export interface Reminder {
   enabled: boolean;
 }
 
+/**
+ * Body for creating or rescheduling a reminder.
+ *
+ * An unrecognised day token is rejected by the API rather than ignored. Omitting `enabled` creates the
+ * reminder enabled and leaves an existing one's state alone.
+ */
 export interface CreateReminderRequest {
   reminderTime: string;   // "HH:mm"
   daysOfWeek?: string[];


### PR DESCRIPTION
Closes #17

## Problem

The repository-level documentation was in good shape — `README.md`, two ADRs, three module guides —
but the code itself was not, and one required document was missing entirely.

Measured on `dev` before this branch:

- `docs/architecture/architecture.md` was empty (0 bytes). Nothing described the running system.
- **Backend:** 54 of 144 `src/main` Java files had no doc comment at all, and most of the rest
  documented the type without stating what its public methods accept, return or throw.
- **Frontend:** 46 of 50 `src` files had no doc comment at all.

The reasoning behind the non-obvious parts — why activation checks the HARD limit before mutating
anything, why the WebSocket handshake is left unauthenticated, why an unrecognised reminder day is
rejected rather than skipped, why a malformed STOMP frame is dropped rather than thrown — lived only
in the ADRs and in the author's head.

## Approach

Documentation and comments only. No behaviour change, no rename, no refactor: the HTTP contract, the
domain logic and the test suite are untouched.

- **`docs/architecture/architecture.md`** — the system as it actually is: overview, components and
  their responsibilities, the five communication mechanisms and what each is for, the end-to-end path
  of a write and of a read, external dependencies and integration points, and the structural decisions
  that are not visible from the file layout. The context dependency graph is derived from the imports
  rather than from intent. Diagrams are Mermaid, so they live in the repository as code. It states
  what *is* and points at `docs/ADRs/` for *why*, so the two records cannot contradict each other.
- **Backend** — a doc comment on every public type, and on every public method whose contract is not
  self-evident: parameters, return value, exceptions and the HTTP status each maps to, preconditions
  and side effects. Class-level comments on the eleven test classes that had none, saying what each
  pins.
- **Frontend** — a doc comment on every exported component, hook, context, API function and shared
  type, including the side effects a signature does not show: navigation, token handling, cache
  invalidation, socket lifecycle.
- **Cleanup** — deleted the trailing comments that only restated the line they sat on, and added
  comments to the non-obvious settings in `application.yml`.

## Trade-off accepted

Two rules from the standard were deliberately **not** applied here, because both require code changes
and this branch is documentation only:

1. **Test naming.** None of the 133 test methods follow `Given<X>_When<Y>_Then<Z>`. Renaming them is a
   code change and belongs in its own commit.
2. **Magic values.** A few remain (the streak milestone of 7, the rating threshold of 3, the toast
   timings). Each is now explained by a comment rather than extracted to a named constant.

Private style-lookup maps in the frontend (`variantClasses`, `sizeMap`) are left undocumented on
purpose: the standard asks for a comment on a private helper only when the reason it exists is not
self-evident.

## Defects found while documenting

Neither is fixed here — both are behaviour changes, and documenting them honestly was the most this
branch could do. Both are recorded where a maintainer will meet them:

1. **Frontend/backend enum drift.** `UpgradeType` in `src/types/index.ts` offers five values the API
   rejects with a 400 (`ONE_TIME_ACTION`, `PRODUCT_REPLACEMENT`, `ROUTINE`, `LEARNING_TASK`,
   `MEDICAL_PREVENTIVE`) and is missing the backend's `PROTOCOL`. All five are selectable in the
   create-upgrade form. `Frequency` likewise offers a `CUSTOM` the backend does not have.
2. **Weekly completion rate rendered as 100× its value.** The backend returns a percentage already;
   `DashboardPage` multiplies by 100 again.

## How it was verified

- `mvn test` — passes, unchanged (unit + ArchUnit suites).
- `npm run build` — passes (`tsc` type-check + Vite build).
- `npx eslint src --ext .ts,.tsx` — clean.
- Coverage audited mechanically: no public Java type or method, and no exported frontend symbol, is
  left without a doc comment.

## Related

- [ADR-001](docs/ADRs/ADR-001-ddd-hexagonal-architecture.md) and
  [ADR-002](docs/ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md) — the
  decisions the new architecture document points at rather than restating. No new ADR: this branch
  records existing decisions, it does not make any.
