### PR TITLE
fix: align the frontend/backend enum contract and the dashboard completion rate

### DIFF
--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/model/UpgradeType.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/model/UpgradeType.java
@@ -5,11 +5,25 @@ package com.healthupgrades.upgrade.domain.model;
  *
  * <p>The type is descriptive — it drives presentation and filtering, not domain rules. How progress is
  * measured is decided separately by the tracking configuration.
+ *
+ * <p>The first eight values are the kinds the README defines as the product. They and the frontend's
+ * {@code UpgradeType} union must stay identical: the value is bound straight from the request body, so
+ * a name the frontend offers and this enum lacks fails to deserialize. {@code FrontendEnumContractTest}
+ * fails the build when the two drift apart.
  */
 public enum UpgradeType {
 
     /** A recurring behaviour to establish, e.g. drinking two litres of water a day. */
     HABIT,
+
+    /** A single task to get done, e.g. booking a dentist appointment. */
+    ONE_TIME_ACTION,
+
+    /** Swapping something out for a better alternative, e.g. replacing toxic cleaning products. */
+    PRODUCT_REPLACEMENT,
+
+    /** A defined sequence to follow regularly, e.g. a morning meditation and stretch. */
+    ROUTINE,
 
     /** An outcome to reach by a date, e.g. running 10km by summer. */
     GOAL,
@@ -17,6 +31,18 @@ public enum UpgradeType {
     /** A time-boxed trial to learn from, e.g. no caffeine after 2pm for two weeks. */
     EXPERIMENT,
 
-    /** A defined routine or one-off procedure to follow, e.g. a morning stretch sequence. */
+    /** Something to read up on or study, e.g. reading about intermittent fasting. */
+    LEARNING_TASK,
+
+    /** A preventive or medical errand, e.g. getting bloodwork done. */
+    MEDICAL_PREVENTIVE,
+
+    /**
+     * A prescribed protocol to follow.
+     *
+     * <p>Retained rather than offered: it predates the kinds above, appears in no requirement and is not
+     * selectable in the UI, but a deployed database may hold rows carrying it — and Hibernate would fail
+     * to read those back if the constant were removed.
+     */
     PROTOCOL
 }

--- a/backend/src/main/java/com/healthupgrades/upgrade/domain/model/UpgradeType.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/domain/model/UpgradeType.java
@@ -43,6 +43,10 @@ public enum UpgradeType {
      * <p>Retained rather than offered: it predates the kinds above, appears in no requirement and is not
      * selectable in the UI, but a deployed database may hold rows carrying it — and Hibernate would fail
      * to read those back if the constant were removed.
+     *
+     * @deprecated not one of the documented upgrade kinds. Existing rows keep it and still render; new
+     *             code should choose from the eight above. Remove once no stored row carries it.
      */
+    @Deprecated
     PROTOCOL
 }

--- a/backend/src/test/java/com/healthupgrades/contract/FrontendEnumContractTest.java
+++ b/backend/src/test/java/com/healthupgrades/contract/FrontendEnumContractTest.java
@@ -52,6 +52,13 @@ class FrontendEnumContractTest {
     private static final Pattern UNION_MEMBER = Pattern.compile("'([A-Z_]+)'");
 
     /**
+     * Matches a union of screaming-caps string literals, which is how this codebase spells a mirrored
+     * backend enum and nothing else.
+     */
+    private static final Pattern MIRRORED_UNION = Pattern.compile(
+            "export type (\\w+)\\s*=\\s*((?:\\s*\\|?\\s*'[A-Z_]+')+)\\s*;", Pattern.DOTALL);
+
+    /**
      * Every backend enum that the frontend mirrors, paired with the union that mirrors it.
      *
      * <p>A new mirrored enum belongs here; one that is not listed is not checked.
@@ -83,14 +90,43 @@ class FrontendEnumContractTest {
     }
 
     @Test
-    void GivenTheFrontendTypesFile_WhenItIsRead_ThenEveryMirroredUnionIsPresent() {
+    void GivenARegisteredUnion_WhenTheFrontendIsRead_ThenItStillExistsThere() {
         String source = readFrontendTypes();
 
-        assertThat(mirroredEnums().map(args -> (String) args.get()[0]))
+        assertThat(registeredUnions())
                 .allSatisfy(union -> assertThat(source)
                         .describedAs("union '%s' was renamed or removed; this test can no longer check it, "
                                 + "which is worse than it failing", union)
                         .contains("export type " + union + " ="));
+    }
+
+    /**
+     * The registration above is hand-maintained, which is the very failure this class exists to catch —
+     * so it is checked too. A mirrored union the frontend declares and nobody registered would otherwise
+     * be silently unguarded.
+     */
+    @Test
+    void GivenAMirroredUnionInTheFrontend_WhenItIsNotRegisteredHere_ThenTheOmissionFailsTheBuild() {
+        Matcher declarations = MIRRORED_UNION.matcher(readFrontendTypes());
+        Set<String> declared = new LinkedHashSet<>();
+        while (declarations.find()) {
+            declared.add(declarations.group(1));
+        }
+
+        assertThat(declared)
+                .describedAs("every enum-shaped union in %s must be registered in mirroredEnums(), or it is "
+                                + "not checked against the backend at all. Register it, or — if it is a "
+                                + "frontend-only union with no backend enum behind it — say so in a comment "
+                                + "on the declaration and exclude it here deliberately",
+                        FRONTEND_TYPES)
+                .isSubsetOf(registeredUnions());
+    }
+
+    /** The union names this class checks. */
+    private static Set<String> registeredUnions() {
+        return mirroredEnums()
+                .map(args -> (String) args.get()[0])
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /** The values declared by one union in the frontend's shared types. */

--- a/backend/src/test/java/com/healthupgrades/contract/FrontendEnumContractTest.java
+++ b/backend/src/test/java/com/healthupgrades/contract/FrontendEnumContractTest.java
@@ -1,0 +1,138 @@
+package com.healthupgrades.contract;
+
+import com.healthupgrades.notification.domain.model.NotificationCategory;
+import com.healthupgrades.notification.domain.model.NotificationType;
+import com.healthupgrades.tracking.domain.model.Frequency;
+import com.healthupgrades.tracking.domain.model.TrackingType;
+import com.healthupgrades.upgrade.domain.model.Difficulty;
+import com.healthupgrades.upgrade.domain.model.UpgradeStatus;
+import com.healthupgrades.upgrade.domain.model.UpgradeType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins every backend enum against the hand-written union the frontend mirrors it with.
+ *
+ * <p>These pairs are a contract with no compiler behind it. The frontend types are written by hand
+ * rather than generated, so nothing connects the two sides: a value the frontend offers and the
+ * backend lacks is bound straight from the request body and fails to deserialize — which surfaces as a
+ * 500, not a validation error, because an unbindable body is not a bean-validation failure.
+ *
+ * <p>That is not hypothetical. The frontend offered five upgrade types the API had never accepted, and
+ * a {@code CUSTOM} frequency backed by nothing, and both were selectable in the UI for as long as they
+ * existed. This test is what makes the next divergence fail the build instead of reaching a user.
+ *
+ * <p>It reads the frontend source directly, so it is coupled to that file's location. That is
+ * deliberate: any indirection would be another thing to keep in step, which is the problem being
+ * solved.
+ */
+class FrontendEnumContractTest {
+
+    /** The frontend module's shared type declarations, relative to the repository root. */
+    private static final Path FRONTEND_TYPES = Paths.get("frontend", "src", "types", "index.ts");
+
+    /** Matches a value inside a union declaration, e.g. the {@code HABIT} in {@code | 'HABIT'}. */
+    private static final Pattern UNION_MEMBER = Pattern.compile("'([A-Z_]+)'");
+
+    /**
+     * Every backend enum that the frontend mirrors, paired with the union that mirrors it.
+     *
+     * <p>A new mirrored enum belongs here; one that is not listed is not checked.
+     */
+    private static Stream<Arguments> mirroredEnums() {
+        return Stream.of(
+                Arguments.of("UpgradeType", names(UpgradeType.values())),
+                Arguments.of("UpgradeStatus", names(UpgradeStatus.values())),
+                Arguments.of("Difficulty", names(Difficulty.values())),
+                Arguments.of("TrackingType", names(TrackingType.values())),
+                Arguments.of("Frequency", names(Frequency.values())),
+                Arguments.of("NotificationType", names(NotificationType.values())),
+                Arguments.of("NotificationCategory", names(NotificationCategory.values())));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("mirroredEnums")
+    void GivenAMirroredEnum_WhenComparedWithTheFrontendUnion_ThenBothDeclareTheSameValues(
+            String unionName, Set<String> backendValues) {
+
+        Set<String> frontendValues = unionValues(unionName);
+
+        assertThat(frontendValues)
+                .describedAs("frontend union '%s' in %s must declare exactly the values of the backend enum; "
+                                + "a value on only one side is a request the API cannot bind, or a row the UI "
+                                + "cannot render",
+                        unionName, FRONTEND_TYPES)
+                .containsExactlyInAnyOrderElementsOf(backendValues);
+    }
+
+    @Test
+    void GivenTheFrontendTypesFile_WhenItIsRead_ThenEveryMirroredUnionIsPresent() {
+        String source = readFrontendTypes();
+
+        assertThat(mirroredEnums().map(args -> (String) args.get()[0]))
+                .allSatisfy(union -> assertThat(source)
+                        .describedAs("union '%s' was renamed or removed; this test can no longer check it, "
+                                + "which is worse than it failing", union)
+                        .contains("export type " + union + " ="));
+    }
+
+    /** The values declared by one union in the frontend's shared types. */
+    private static Set<String> unionValues(String unionName) {
+        String source = readFrontendTypes();
+        Pattern declaration = Pattern.compile(
+                "export type " + Pattern.quote(unionName) + "\\s*=(.*?);", Pattern.DOTALL);
+
+        Matcher declarationMatch = declaration.matcher(source);
+        assertThat(declarationMatch.find())
+                .describedAs("no 'export type %s' declaration found in %s", unionName, FRONTEND_TYPES)
+                .isTrue();
+
+        Matcher members = UNION_MEMBER.matcher(declarationMatch.group(1));
+        Set<String> values = new LinkedHashSet<>();
+        while (members.find()) {
+            values.add(members.group(1));
+        }
+        return values;
+    }
+
+    /** Reads the frontend types file, searching upward for the repository root. */
+    private static String readFrontendTypes() {
+        Path root = Paths.get("").toAbsolutePath();
+        while (root != null && !Files.exists(root.resolve(FRONTEND_TYPES))) {
+            root = root.getParent();
+        }
+        assertThat(root)
+                .describedAs("could not locate %s from %s — the frontend module is part of this contract "
+                                + "and its absence is a broken checkout, not a reason to skip the check",
+                        FRONTEND_TYPES, Paths.get("").toAbsolutePath())
+                .isNotNull();
+
+        try {
+            return Files.readString(root.resolve(FRONTEND_TYPES));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not read " + root.resolve(FRONTEND_TYPES), e);
+        }
+    }
+
+    /** The constant names of an enum, as a set. */
+    private static Set<String> names(Enum<?>[] values) {
+        return Arrays.stream(values).map(Enum::name).collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+}

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -329,8 +329,10 @@ returns 409. Nothing else is version-checked, because nothing else is edited fro
 exceptions and never build a status by hand. The mapping is pinned by a test.
 
 **The frontend's types are hand-written, not generated.** `src/types/index.ts` mirrors the backend's
-DTOs and enums by hand, so nothing detects drift between them. Two divergences exist today and are
-recorded in that file.
+DTOs and enums by hand. The **enums** are checked: `FrontendEnumContractTest` reads that file and fails
+the build if any mirrored union stops matching its backend enum, which is what stops an unbindable
+value reaching the UI. The **DTO shapes** are not checked — a renamed or retyped field still drifts
+silently, and only a type generated from the API contract would close that gap.
 
 ### Known constraints
 

--- a/frontend/src/components/upgrade/UpgradeTypeBadge.tsx
+++ b/frontend/src/components/upgrade/UpgradeTypeBadge.tsx
@@ -10,8 +10,9 @@ interface Props {
 /**
  * Type to colour and label.
  *
- * Covers this app's `UpgradeType` union, which is currently wider than the backend enum — see the note
- * on that type. The five values the API does not accept are unreachable in practice.
+ * Keyed by `UpgradeType`, so the compiler requires an entry for every value the backend can return —
+ * including the legacy `PROTOCOL`, which is never offered in the create form but must still render on
+ * a row that already carries it.
  */
 const typeMap: Record<UpgradeType, { variant: 'green' | 'yellow' | 'blue' | 'red' | 'gray' | 'purple'; label: string }> = {
   HABIT: { variant: 'green', label: 'Habit' },
@@ -22,6 +23,7 @@ const typeMap: Record<UpgradeType, { variant: 'green' | 'yellow' | 'blue' | 'red
   EXPERIMENT: { variant: 'gray', label: 'Experiment' },
   LEARNING_TASK: { variant: 'purple', label: 'Learning' },
   MEDICAL_PREVENTIVE: { variant: 'red', label: 'Medical' },
+  PROTOCOL: { variant: 'gray', label: 'Protocol' },
 };
 
 /** Coloured badge naming an upgrade's type, falling back to the raw value for an unknown one. */

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -36,7 +36,8 @@ const DashboardPage: React.FC = () => {
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
   if (error) return <p className="text-red-500 text-center py-10">Failed to load dashboard.</p>;
 
-  const completionPct = Math.round((data?.weeklyCompletionRate ?? 0) * 100);
+  // Rounded, not scaled: the API sends a percentage already (see DashboardDto.weeklyCompletionRate).
+  const completionPct = Math.round(data?.weeklyCompletionRate ?? 0);
   const streakEntries = Object.entries(data?.streaks ?? {});
 
   return (

--- a/frontend/src/pages/UpgradeBacklogPage.tsx
+++ b/frontend/src/pages/UpgradeBacklogPage.tsx
@@ -13,10 +13,10 @@ import UpgradeCard from '../components/upgrade/UpgradeCard';
 import type { CreateUpgradeRequest, UpgradeType, Difficulty, UpgradeStatus } from '../types';
 
 /**
- * The upgrade types offered when creating one.
+ * The upgrade types offered when creating one: the eight kinds the product defines.
  *
- * Covers this app's `UpgradeType` union, which is wider than what the API accepts — see the note on
- * that type in `src/types`.
+ * Deliberately not every value of `UpgradeType` — the legacy `PROTOCOL` still renders on rows that
+ * carry it, but is not something to create more of.
  */
 const typeOptions: { value: UpgradeType; label: string }[] = [
   { value: 'HABIT', label: 'Habit' },

--- a/frontend/src/pages/UpgradeDetailsPage.tsx
+++ b/frontend/src/pages/UpgradeDetailsPage.tsx
@@ -366,7 +366,6 @@ const UpgradeDetailsPage: React.FC = () => {
               { value: 'DAILY', label: 'Daily' },
               { value: 'WEEKLY', label: 'Weekly' },
               { value: 'MONTHLY', label: 'Monthly' },
-              { value: 'CUSTOM', label: 'Custom' },
             ]}
           />
           {trackingForm.trackingType === 'NUMERIC' && (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -176,6 +176,7 @@ export interface DashboardDto {
   plannedUpgrades: HealthUpgrade[];
   todayUpgrades: HealthUpgrade[];
   overdueUpgrades: HealthUpgrade[];
+  /** Already a percentage in the range 0–100, not a fraction. Display it as-is. */
   weeklyCompletionRate: number;
   streaks: Record<string, number>;
   recentlyCompleted: HealthUpgrade[];

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -41,10 +41,12 @@ export interface HealthArea {
 /**
  * What kind of change an upgrade is.
  *
- * NOTE: this union does not currently match the backend enum, which accepts only `HABIT`, `GOAL`,
- * `EXPERIMENT` and `PROTOCOL`. Five of the values below are rejected by the API with a 400, and
- * `PROTOCOL` is missing here. Keep the backend enum, this type and the seed data in step when
- * changing any of them.
+ * Must stay identical to the backend `UpgradeType` enum — the value is bound straight from the
+ * request body, so a name offered here and missing there fails to deserialize and surfaces as a 500.
+ * `FrontendEnumContractTest` in the backend fails the build if the two drift apart.
+ *
+ * `PROTOCOL` is legacy: it is accepted and rendered so an existing row displays, but it is not one of
+ * the documented kinds and is deliberately absent from the create form.
  */
 export type UpgradeType =
   | 'HABIT'
@@ -54,7 +56,8 @@ export type UpgradeType =
   | 'GOAL'
   | 'EXPERIMENT'
   | 'LEARNING_TASK'
-  | 'MEDICAL_PREVENTIVE';
+  | 'MEDICAL_PREVENTIVE'
+  | 'PROTOCOL';
 
 /**
  * Where an upgrade stands in its lifecycle.
@@ -79,9 +82,10 @@ export type TrackingType = 'BOOLEAN' | 'NUMERIC' | 'TEXT' | 'RATING';
 /**
  * How often an upgrade is expected to be acted on.
  *
- * NOTE: `CUSTOM` has no counterpart in the backend enum and is rejected by the API.
+ * Must stay identical to the backend `Frequency` enum. A per-day schedule is expressed with a
+ * reminder, not with a frequency, which is why there is no custom option here.
  */
-export type Frequency = 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'CUSTOM';
+export type Frequency = 'DAILY' | 'WEEKLY' | 'MONTHLY';
 
 /** How one upgrade is tracked. At most one per upgrade; absent when tracking is not set up. */
 export interface TrackingConfig {


### PR DESCRIPTION
Closes #19
Closes #20

## Problem

Two contract mismatches between the frontend and the backend, both found while documenting the
project in #18 and both verified before being acted on.

**1. Five of the eight upgrade types the UI offers were rejected (#19).** The backend enum had
`HABIT, GOAL, EXPERIMENT, PROTOCOL`; the frontend offered eight, five of which the API could not
bind. Verified with a standalone MockMvc request:

```
POST /api/upgrades  {"title":"x","type":"ONE_TIME_ACTION"}
→ 500 {"status":500,"message":"Internal server error",...}
```

500, not 400 — Jackson's `HttpMessageNotReadableException` is caught by the catch-all
`@ExceptionHandler(Exception.class)` before Spring's default 400 handling applies. `Frequency` had
the same shape of problem with a `CUSTOM` the backend never had.

**2. The weekly completion rate was rendered 100× too large (#20).** The backend returns a
percentage — `completed / total * 100.0`, pinned at `50.0` by `DashboardAggregationServiceTest` — and
`DashboardPage` multiplied by 100 again. A 50% week displayed as `5000%`, and the progress bar was
rendered with `width: 5000%`, so it sat full for any non-zero rate.

## Approach

**For the enum drift, the backend was the side that was wrong.** The README defines the product as
exactly the eight kinds the frontend offers; `PROTOCOL` appears in no requirement, no seed row and no
screen. So the enum was widened to match the documented product rather than five features being
deleted from the UI.

`PROTOCOL` is kept anyway: a deployed database may hold rows carrying it, and Hibernate would fail to
read those back if the constant disappeared. It renders on such a row but is deliberately absent from
the create form.

`CUSTOM` is the opposite case — nothing on either side implements a custom schedule, and a per-day
schedule is what reminders are for — so the frontend loses it.

**The agreement is now pinned.** `FrontendEnumContractTest` reads `frontend/src/types/index.ts` and
asserts each mirrored union matches its backend enum, across all seven mirrored pairs. It fails on
both of these divergences before the fix and passes after.

**For the rate, only the frontend changed** — the backend's half of the contract was already correct
and already tested. The unit is now stated on the shared type.

## Trade-off accepted

- **The rate fix ships without a test of its own.** The frontend has no test runner — no vitest, no
  jest, nothing in `devDependencies` — so a failing-test-first fix would mean introducing a test
  framework, a new dependency and a CI step, which is a bigger decision than a one-line arithmetic
  fix and deserves its own ADR. The backend half is pinned by the existing test; this half is verified
  by inspection and by the documented unit.
- **`FrontendEnumContractTest` reads across module boundaries**, so it is coupled to the frontend
  file's path. That coupling is deliberate — any indirection would be one more thing to keep in step,
  which is the class of problem being fixed.
- **`PROTOCOL` is retained rather than removed**, accepting a value in the enum that no requirement
  asks for, because removing it would break reads on any database already holding it.

## Not fixed here

An unbindable request body returns **500 rather than 400** — the catch-all handler in
`GlobalExceptionHandler` intercepts `HttpMessageNotReadableException` before Spring's default handling
applies. Aligning the enums removes the way users were hitting it, but malformed JSON still produces
a 500. That is a separate defect and a wire-contract change, so it is not bundled in here.

## How it was verified

- `mvn test` — passes, including the new `FrontendEnumContractTest` (8 tests). Confirmed failing on
  both divergences before the fix.
- `npm run build` — passes (`tsc` + Vite).
- `npx eslint src --ext .ts,.tsx` — clean.
- No migration needed: `health_upgrades.type` and `tracking_configs.frequency` are `VARCHAR(50)` with
  no CHECK constraint.

## Related

`docs/architecture/architecture.md` said the hand-written frontend types had nothing detecting drift.
That is now half true and the entry says so: the enums are checked, the DTO field shapes still are
not. No new ADR — this corrects an implementation to match a documented product, it does not decide
anything.
