### PR TITLE
docs: license the repository as proprietary source-available

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,175 @@
+HealthUpgrades — Proprietary Source-Available License
+Version 1.0
+
+Copyright (c) 2026 Naim Elijah. All rights reserved.
+
+
+SUMMARY (not part of the licence terms)
+
+    This source code is published so that it can be read, reviewed and evaluated.
+    It is not open source. You may look at it. You may not use it, copy it,
+    modify it, run it, or publish it — in whole or in part — without written
+    permission from the copyright holder.
+
+
+1. DEFINITIONS
+
+    1.1 "The Software" means the source code, documentation, configuration,
+        database migrations, diagrams, and any other original material contained
+        in this repository, together with any part of it.
+
+    1.2 "The Author" means Naim Elijah, the copyright holder and sole author of
+        the Software.
+
+    1.3 "You" means any individual or legal entity accessing the Software.
+
+    1.4 "Third-Party Components" means software that the Software depends on,
+        references, or is built with, but that was not authored by the Author.
+
+
+2. RESERVATION OF RIGHTS
+
+    The Software is the exclusive property of the Author and is protected by
+    copyright law and international copyright treaties. All rights are reserved.
+
+    Publishing the Software where it can be viewed does not place it in the
+    public domain, does not make it open source, and does not grant any licence
+    beyond the limited permission expressly stated in Section 3.
+
+    Any right not expressly granted in this licence is withheld.
+
+
+3. LIMITED PERMISSION GRANTED
+
+    Subject to your compliance with this licence, the Author grants you a
+    personal, non-exclusive, non-transferable, revocable permission to:
+
+    3.1 view and read the Software;
+
+    3.2 retain a local copy obtained through the hosting platform's own
+        mechanisms, solely for the purpose of reading and evaluating it; and
+
+    3.3 quote short excerpts for the purpose of commentary, review, teaching or
+        news reporting, provided the Author and this repository are clearly
+        credited.
+
+    This permission exists so that the Software can be assessed — by prospective
+    employers, collaborators, reviewers and the technically curious. It is not
+    permission to use the Software.
+
+
+4. RESTRICTIONS
+
+    Except with the prior written permission of the Author, you may NOT:
+
+    4.1 use the Software, or any part of it, in any project, product, service or
+        system, whether commercial or non-commercial;
+
+    4.2 copy, reproduce or republish the Software, in whole or in substantial
+        part, other than as permitted by Section 3;
+
+    4.3 modify the Software, or create derivative works based on it;
+
+    4.4 distribute, sublicense, sell, rent, lease or otherwise transfer the
+        Software or any rights in it;
+
+    4.5 deploy, host, execute or operate the Software, including as part of a
+        hosted or network-accessible service;
+
+    4.6 remove, obscure or alter any copyright notice, authorship attribution or
+        licence text contained in the Software;
+
+    4.7 present the Software, or any substantial part of it, as your own work,
+        including in a portfolio, a curriculum vitae, an academic submission, a
+        technical assessment or a competition entry; or
+
+    4.8 use the Software as training data for, or otherwise incorporate it into,
+        any machine learning model, dataset or generative system.
+
+
+5. THIRD-PARTY COMPONENTS
+
+    The Software depends on Third-Party Components that are neither owned by the
+    Author nor licensed under this licence. Those components remain governed by
+    the terms their own authors apply to them, and nothing in this licence
+    restricts, extends or otherwise affects your rights in them.
+
+    This licence applies only to the original material authored by the Author.
+
+
+6. CONTRIBUTIONS
+
+    The Author does not solicit contributions to the Software.
+
+    If you nonetheless submit a contribution — including a pull request, a patch
+    or a code suggestion — you assign to the Author all right, title and interest
+    in that contribution, or, where such assignment is not permitted by law, you
+    grant the Author a perpetual, worldwide, irrevocable, royalty-free licence to
+    use it without restriction. You confirm that you are entitled to do so.
+
+    This exists so that the Software remains under single, unambiguous ownership.
+
+
+7. NAME AND ATTRIBUTION
+
+    This licence grants no right to use the name of the Author, the name
+    "HealthUpgrades", or any associated branding, whether to identify the origin
+    of a work, to endorse or promote anything, or otherwise.
+
+    Authorship of the Software is asserted by the Author and is recorded in the
+    version-control history of this repository.
+
+
+8. REQUESTING PERMISSION
+
+    Permission beyond Section 3 may be granted, and is granted only in writing.
+    Requests should be directed to the Author through the repository's hosting
+    platform, at: https://github.com/NaimElijah
+
+    Silence is not permission. An unanswered request is a refused request.
+
+
+9. TERMINATION
+
+    The permission granted in Section 3 terminates automatically and immediately
+    if you breach any term of this licence.
+
+    On termination you must cease all use of the Software and destroy any copy in
+    your possession. Sections 2, 4, 5, 6, 7, 10, 11 and 12 survive termination.
+
+    Termination of your permission does not limit any other remedy available to
+    the Author.
+
+
+10. NO WARRANTY
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT.
+
+    THE SOFTWARE IS A PERSONAL PROJECT AND A LIFESTYLE PLANNING TOOL. IT IS NOT A
+    MEDICAL DEVICE, IT IS NOT CERTIFIED FOR ANY PURPOSE, AND IT MUST NOT BE RELIED
+    UPON FOR MEDICAL, CLINICAL OR SAFETY-CRITICAL DECISIONS.
+
+
+11. LIMITATION OF LIABILITY
+
+    TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE AUTHOR SHALL NOT BE
+    LIABLE FOR ANY CLAIM, DAMAGE, LOSS OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+    CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OF, OR OTHER DEALINGS IN, THE SOFTWARE.
+
+
+12. GENERAL
+
+    12.1 If any provision of this licence is held unenforceable, that provision
+         shall be limited or severed to the minimum extent necessary, and the
+         remaining provisions remain in full force.
+
+    12.2 A failure by the Author to enforce any provision is not a waiver of it.
+
+    12.3 This licence is the entire agreement concerning the Software and
+         supersedes any prior understanding regarding it.
+
+
+END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -319,3 +319,29 @@ npm run build
 - Docker Compose for one-command deployment
 - GitHub Actions CI pipeline
 - Comprehensive unit tests for domain logic
+
+## License
+
+**Copyright © 2026 Naim Elijah. All rights reserved.**
+
+HealthUpgrades is **source-available, not open source**. The code is published so it can be read,
+reviewed and evaluated — by prospective employers, collaborators and anyone technically curious. That
+is the whole of the permission granted.
+
+| You may | You may not |
+|---|---|
+| Read and review the source | Use it in any project, product or service |
+| Keep a local copy to evaluate it | Copy, modify or build on it |
+| Quote short excerpts, with credit | Deploy, host or run it |
+| | Redistribute or sell it |
+| | Present it as your own work |
+| | Use it to train a machine learning model |
+
+Anything beyond reading requires **written permission** from the author. Requests go through
+[github.com/NaimElijah](https://github.com/NaimElijah) — an unanswered request is a refused one.
+
+The full terms are in [`LICENSE`](LICENSE), and they are what govern; the table above is a summary.
+
+Third-party dependencies (Spring Boot, React, PostgreSQL and the rest) are **not** covered by this
+licence and remain under the terms their own authors set. This licence applies only to the original
+work in this repository.

--- a/docs/ADRs/ADR-003-proprietary-source-available-licensing.md
+++ b/docs/ADRs/ADR-003-proprietary-source-available-licensing.md
@@ -1,0 +1,118 @@
+# ADR-003: Publish source-available under a proprietary licence, not open source
+
+- **Status:** Accepted
+- **Date:** 2026-08-18
+- **Scope:** The repository as a whole. No effect on the architecture, the build or the runtime.
+
+## Context
+
+The repository is being made public. Until now it was private and carried no `LICENSE` file at all,
+which the repository baseline requires.
+
+The absence was not neutral. Under copyright law, code published with no licence is "all rights
+reserved" by default — nobody may lawfully use it — but readers routinely assume a public repository is
+free to take. The gap between the legal position and the common assumption is exactly where a dispute
+would sit.
+
+The author's goal in publishing is **evaluation, not adoption**: the repository is a portfolio piece,
+meant to be read by prospective employers, collaborators and the technically curious. There is no
+intent to build a user community, accept contributions, or have the code adopted as a dependency. The
+concern that prompted this decision was that someone would present the work as their own.
+
+Two facts shaped the choice:
+
+1. **No licence prevents copying.** A licence is a legal instrument, not a technical control. Its value
+   is that it makes the terms unambiguous and gives the author standing to act.
+2. **The best evidence of authorship is already in place.** The repository has a full commit history
+   attributed to the author, dated, and now public alongside the code. That is stronger day-to-day
+   protection against a plagiarism claim than any licence text.
+
+## Decision
+
+Publish under a **proprietary source-available licence**, written for this repository and recorded in
+`LICENSE`, rather than under an open-source licence.
+
+The licence grants exactly one thing: permission to read, retain a local copy for evaluation, and quote
+short excerpts with credit. It withholds everything else — use, modification, redistribution,
+deployment, and presenting the work as one's own — pending written permission.
+
+Three clauses exist for reasons worth stating:
+
+- **Third-party components are carved out** (§5). The repository depends on Spring Boot, React,
+  PostgreSQL and others under their own terms. A licence that appeared to claim rights over them would
+  be both wrong and unenforceable.
+- **Contributions are assigned to the author** (§6). Contributions are not solicited, but an
+  unsolicited pull request that the author merged would otherwise leave a fragment of the repository
+  owned by somebody else — which is the single-ownership property this licence exists to preserve.
+- **Warranty and liability are disclaimed** (§10, §11). Publishing code creates exposure regardless of
+  whether anyone is permitted to use it, and this repository models health behaviour, where a reader
+  acting on it could come to harm.
+
+The README carries a plain-English summary and points at `LICENSE` as the governing text.
+
+## Consequences
+
+**What this makes easy**
+
+- The legal position is stated rather than inferred. A reader who copies the work cannot claim the
+  repository looked like an invitation.
+- Authorship is asserted in the licence, in the README, and in the commit history — three independent
+  records that agree.
+- The repository can be shown to anyone without implicitly offering them anything.
+- The repository baseline is satisfied: `LICENSE` exists.
+
+**What this makes hard**
+
+- **It is not open source, and GitHub will not display a licence badge for it.** Automated tooling that
+  classifies licences will report this repository as unlicensed or "other". Some readers will read that
+  as carelessness rather than as a decision — which is part of why this record exists.
+- **Forking cannot be prevented on GitHub.** Making a repository public means accepting GitHub's terms,
+  under which other users may view and fork it through the platform. The licence governs what a forker
+  may then lawfully *do*, not whether the fork button works.
+- **Nobody can contribute or reuse the work without an individual grant.** That is the intent, but it
+  forecloses the incidental benefits of open source: bug reports from users, adoption as a dependency,
+  and the signal that permissive licensing sends to some employers.
+- **Enforcement is the author's problem.** The licence creates standing; acting on it costs time and,
+  potentially, money. Realistically its function is deterrence and clarity.
+
+**Neutral**
+
+- No code, build, dependency or runtime behaviour changes.
+- The licence can be relaxed later. It cannot be tightened retroactively for a version already
+  published under looser terms — which is the asymmetry behind starting restrictive.
+
+## Alternatives considered
+
+- **Apache-2.0.** The professional default for "use it, but credit me": redistribution must retain the
+  copyright notice, state modifications, and it withholds trademark rights. Rejected because it permits
+  exactly what the author did not want to permit — anyone building on the work, commercially and
+  closed-source, with attribution buried in a notices file. **Revisit if** the goal changes from being
+  read to being used, or if the repository ever needs to be consumed as a dependency by another
+  project.
+
+- **MIT.** Simplest and most recognised. Rejected for the same reason as Apache-2.0, and it is weaker
+  still: no patent grant, no trademark clause, no requirement to state modifications. **Revisit if**
+  the project is ever released for general use and minimising friction matters more than control.
+
+- **AGPL-3.0.** Would prevent anyone building a closed-source product on the work, since network use
+  triggers the obligation to publish source. Rejected because it still grants full use and modification
+  rights, which is more than intended, and because many organisations ban AGPL code outright — reducing
+  the readership this repository is published for. **Revisit if** the project gains real users and the
+  concern shifts from attribution to commercial appropriation.
+
+- **No licence at all.** Legally close to the chosen outcome, since the default is already all rights
+  reserved. Rejected because it communicates nothing: it reads as an oversight, leaves readers guessing,
+  and fails the repository baseline. Saying "all rights reserved" deliberately is different from having
+  said nothing.
+
+- **A dual licence** — source-available by default, with a permissive licence for a defined subset.
+  Rejected as premature: there is no subset anyone has asked for, and maintaining two licences over one
+  codebase is a real cost with no current benefit. **Revisit when** somebody actually asks to use a
+  specific part.
+
+## Note
+
+This licence was drafted for the specific goal recorded above; it has not been reviewed by a lawyer.
+It is enforceable as written in the ordinary case — the terms are clear and the restrictions
+conventional — but it names no governing jurisdiction, which is the first thing to add if the
+repository ever becomes commercially significant.


### PR DESCRIPTION
## Problem

The repository is about to be made public and has no `LICENSE` file, which the repository baseline
requires.

The absence is not neutral. Code published without a licence is "all rights reserved" by default —
nobody may lawfully use it — but readers routinely assume a public repository is free to take. That
gap between the legal position and the common assumption is exactly where a dispute would sit.

## Approach

Publish **source-available, not open source**. The goal in making this repository public is
evaluation, not adoption: it is a portfolio piece meant to be read by prospective employers and
collaborators, not a project seeking users, contributors or downstream dependents.

The licence grants exactly one thing — permission to read, keep a local copy to evaluate, and quote
short excerpts with credit — and withholds everything else pending written permission: use,
modification, redistribution, deployment, presenting the work as one's own, and use as machine
learning training data.

Three clauses are worth calling out:

- **Third-party components are carved out (§5).** Spring Boot, React and PostgreSQL are governed by
  their own authors' terms. A licence appearing to claim rights over them would be wrong and
  unenforceable.
- **Contributions are assigned to the author (§6).** Contributions are not solicited, but a merged
  unsolicited pull request would otherwise leave a fragment of the repository owned by someone else,
  defeating the single-ownership property the licence exists to preserve.
- **Warranty and liability are disclaimed (§10, §11).** Publishing code creates exposure regardless of
  who may use it, and this repository models health behaviour.

## Trade-off accepted

Recorded in full in [ADR-003](docs/ADRs/ADR-003-proprietary-source-available-licensing.md), with the
trigger that would make each alternative worth revisiting. The two costs worth stating here:

1. **It is not open source, so GitHub will show no licence badge.** Tooling that classifies licences
   will report this repository as unlicensed or "other", and some readers will read that as
   carelessness rather than as a decision. ADR-003 exists partly so that reading is available to
   anyone who looks.
2. **Forking cannot be prevented.** Making a repository public means accepting GitHub's terms, under
   which other users may view and fork it. The licence governs what a forker may lawfully *do* with
   the code — not whether the fork button works.

Apache-2.0, MIT, AGPL-3.0 and publishing with no licence at all were each considered and rejected;
ADR-003 records why, and what would change the answer.

## How it was verified

- No code, build, dependency or runtime change — `LICENSE` and `ADR-003` are new files, and the README
  gains a section at the bottom.
- The README summary is explicitly labelled a summary, with `LICENSE` named as the governing text, so
  the two cannot be read as competing terms.
- Copyright holder, year and contact route confirmed with the repository owner before drafting.

## Note

The licence was drafted for the goal recorded in ADR-003 and has not been reviewed by a lawyer. It
names no governing jurisdiction — the first thing to add if this repository ever becomes commercially
significant.
