### PR TITLE
docs: complete the rename to UpHealther and add the requirements document

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,6 +7,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 A "health upgrade" is the core domain object — a planned health improvement (habit, one-time action,
 experiment, goal, etc.) that moves through a lifecycle.
 
+## Requirements
+
+`docs/requirements/requirements.md` states what the system must do: capabilities, business rules and
+invariants, non-functional requirements, and the non-goals. Each entry names the class or test that
+enforces it, so it can be checked rather than trusted. Read it before proposing work — a change that
+satisfies no requirement, or contradicts one, is a conversation before it is code — and update it in
+the same commit when what the system must do changes.
+
 ## Architecture
 
 `docs/architecture/architecture.md` describes the system as it is: components, communication, data

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-HealthUpgrades — Proprietary Source-Available License
+UpHealther — Proprietary Source-Available License
 Version 1.0
 
 Copyright (c) 2026 Naim Elijah. All rights reserved.
@@ -113,7 +113,7 @@ SUMMARY (not part of the licence terms)
 7. NAME AND ATTRIBUTION
 
     This licence grants no right to use the name of the Author, the name
-    "HealthUpgrades", or any associated branding, whether to identify the origin
+    "UpHealther", or any associated branding, whether to identify the origin
     of a work, to endorse or promote anything, or otherwise.
 
     Authorship of the Software is asserted by the Author and is recorded in the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HealthUpgrades 🌱
+# UpHealther 🌱
 
 A full-stack health upgrade planning and tracking platform. Plan, activate, and track your health improvements — from drinking more water to meditating daily, from better sleep habits to product replacements.
 
@@ -54,10 +54,12 @@ A **Health Upgrade** is more than a habit. It can be:
 
 ## Architecture
 
-[`docs/architecture/architecture.md`](docs/architecture/architecture.md) describes the system as it
-actually is — components, how they communicate, the path a request takes end to end, external
-dependencies, and the structural decisions that are not visible from the file layout. Start there; the
-summary below is the short version.
+[`docs/requirements/requirements.md`](docs/requirements/requirements.md) states **what** the system
+must do — the capabilities, the business rules, and the non-goals — with the enforcing class or test
+named against each. [`docs/architecture/architecture.md`](docs/architecture/architecture.md) describes
+**how** it does it: components, how they communicate, the path a request takes end to end, external
+dependencies, and the structural decisions that are not visible from the file layout. Start with
+either; the summary below is the short version.
 
 ### Backend — Hexagonal (Ports & Adapters) + DDD
 
@@ -193,7 +195,7 @@ Events are published through a `DomainEventPublisher` outbound port (a Spring-ba
 1. **Clone the repository**
    ```bash
    git clone <repo-url>
-   cd Health_Upgrades_Tracker
+   cd UpHealther
    ```
 
 2. **Set up environment**
@@ -304,11 +306,11 @@ npm run build
 
 ## Disclaimer
 
-> HealthUpgrades is a lifestyle planning tool. It is **not** a medical application and does not provide medical advice, diagnosis, or treatment. Always consult a healthcare professional for medical decisions.
+> UpHealther is a lifestyle planning tool. It is **not** a medical application and does not provide medical advice, diagnosis, or treatment. Always consult a healthcare professional for medical decisions.
 
 ## Resume Summary
 
-**HealthUpgrades** is a production-quality full-stack web application built with Java 21 / Spring Boot 3 backend and React / TypeScript frontend. It demonstrates:
+**UpHealther** is a production-quality full-stack web application built with Java 21 / Spring Boot 3 backend and React / TypeScript frontend. It demonstrates:
 - Clean architecture: Domain-Driven Design (DDD) + Hexagonal (Ports & Adapters), enforced with ArchUnit
 - JWT authentication with Spring Security
 - PostgreSQL with Flyway migrations and optimistic locking
@@ -324,7 +326,7 @@ npm run build
 
 **Copyright © 2026 Naim Elijah. All rights reserved.**
 
-HealthUpgrades is **source-available, not open source**. The code is published so it can be read,
+UpHealther is **source-available, not open source**. The code is published so it can be read,
 reviewed and evaluated — by prospective employers, collaborators and anyone technically curious. That
 is the whole of the permission granted.
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,8 +1,9 @@
 # Backend conventions
 
-`../docs/architecture/architecture.md` describes the system as it is — contexts, communication, data
-flow and the structural decisions behind the layout. This file covers the conventions to follow when
-changing it.
+`../docs/requirements/requirements.md` states what the system must do — the capabilities, the business
+rules, and the class or test that enforces each. `../docs/architecture/architecture.md` describes the
+system as it is — contexts, communication, data flow and the structural decisions behind the layout.
+This file covers the conventions to follow when changing it.
 
 Architecture is DDD + Hexagonal. The decision and its rationale are recorded in
 `../docs/ADRs/ADR-001-ddd-hexagonal-architecture.md`, corrected and extended by

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -354,6 +354,7 @@ Stated because they are load-bearing, not because they are problems yet:
 
 | Question | Record |
 |---|---|
+| What is the system supposed to do, and what is it deliberately not doing? | [`docs/requirements/requirements.md`](../requirements/requirements.md) |
 | Why DDD + hexagonal at all, and why JPA entities as the domain model? | [ADR-001](../ADRs/ADR-001-ddd-hexagonal-architecture.md) |
 | Why the `upgrade`/`tracking` dependency is inverted; why events moved out of `common`; what the ten ArchUnit rules cover; what was rejected and when to revisit | [ADR-002](../ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md) |
 | Day-to-day conventions when changing backend code | [`backend/CLAUDE.md`](../../backend/CLAUDE.md) |

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -8,7 +8,7 @@ rejected, and the conditions that would make us revisit a choice live in [`docs/
 
 ## Architecture overview
 
-HealthUpgrades is a three-process web application: a React single-page app, a Spring Boot HTTP API,
+UpHealther is a three-process web application: a React single-page app, a Spring Boot HTTP API,
 and a PostgreSQL database. There is no message broker, no cache, no third-party service and no second
 backend — every piece of state lives in the one database, and every side effect the API performs is
 either a write to it or a message pushed to a connected browser.

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -1,0 +1,177 @@
+# Requirements
+
+What UpHealther must do. This document records the requirements the project **currently meets** —
+each one is implemented, and where it is enforced in code the enforcing class or test is named, so a
+claim here can be checked rather than trusted.
+
+For *how* the system is built, see [`../architecture/architecture.md`](../architecture/architecture.md).
+For *why* a given solution was chosen, see [`../ADRs/`](../ADRs/).
+
+---
+
+## 1. Purpose and scope
+
+UpHealther is a personal planning and tracking tool for health improvements. It exists because a
+"health upgrade" is broader than a habit — it can be a one-off errand, a product swap, a time-boxed
+experiment or a goal with a deadline — and habit trackers model only the recurring case.
+
+**In scope:** capturing intended improvements, committing them to dates, tracking whether they are
+actually being done, and reflecting on what worked.
+
+**Out of scope:** anything clinical. UpHealther is a lifestyle tool, not a medical application (see
+§5.1).
+
+**Users:** one person managing their own upgrades. Every record belongs to exactly one account, and
+nothing is shared between accounts.
+
+---
+
+## 2. Functional requirements
+
+### 2.1 Accounts and access
+
+| ID | Requirement | Enforced by |
+|---|---|---|
+| FR-1 | A visitor can register with a name, email and password, and is signed in immediately | `AuthService.register` |
+| FR-2 | A registered user can sign in with email and password and receive a token | `AuthService.login` |
+| FR-3 | A signed-in user can retrieve their own profile, so a stored token restores a session | `AuthController.me`, `AuthContext` |
+| FR-4 | An email may be registered once | `AuthService.register` → `BusinessRuleException` |
+| FR-5 | Every endpoint except registration, login and health checks requires a valid token | `SecurityConfig` |
+
+### 2.2 Health areas
+
+| ID | Requirement | Enforced by |
+|---|---|---|
+| FR-6 | A user can create, read, update and delete their own health areas | `HealthAreaService` |
+| FR-7 | An area carries a name and optional description, priority, icon and colour | `HealthArea`, `HealthAreaRequest` |
+| FR-8 | Deleting an area leaves upgrades filed under it intact | `HealthAreaService.delete` |
+
+### 2.3 Upgrades
+
+| ID | Requirement | Enforced by |
+|---|---|---|
+| FR-9 | A user can create an upgrade of any of the eight kinds: habit, one-time action, product replacement, routine, goal, experiment, learning task, medical/preventive | `UpgradeType`, `FrontendEnumContractTest` |
+| FR-10 | An upgrade carries a title and type, and optionally an area, description, difficulty, planned start, target end, motivation and success criteria | `HealthUpgrade.create` |
+| FR-11 | A user can list their upgrades, narrowed by status, type, area or difficulty | `UpgradeService.findAll` |
+| FR-12 | A user can move an upgrade through its lifecycle: plan, activate, pause, complete, abandon, reschedule | `HealthUpgrade`, `HealthUpgradeTest` |
+| FR-13 | A user can edit an upgrade's descriptive fields at any point in its lifecycle | `HealthUpgrade.updateDetails` |
+| FR-14 | A user can delete an upgrade | `UpgradeService.delete` |
+| FR-15 | An upgrade's response carries its tracking configuration, so a list view needs no second call | `UpgradeWebMapper`, `UpgradeDtoSerializationTest` |
+
+### 2.4 Tracking and progress
+
+| ID | Requirement | Enforced by |
+|---|---|---|
+| FR-16 | A user can configure how an upgrade is measured: boolean, numeric, rating or free text | `TrackingType` |
+| FR-17 | A numeric configuration can carry a target value and a unit | `TrackingConfig` |
+| FR-18 | A user can log progress for an upgrade on a given day | `TrackingService.recordProgress` |
+| FR-19 | A user can log progress for every active upgrade in one pass | `DailyCheckinPage` |
+| FR-20 | A user can read an upgrade's progress history, newest first | `TrackingService.getProgress` |
+| FR-21 | A user can read today's and the last seven days' progress across all upgrades | `TrackingService.getTodayProgress`, `getWeekProgress` |
+| FR-22 | A user can see an upgrade's current and longest streak | `StreakCalculator`, `StreakCalculatorTest` |
+
+### 2.5 Reflections and reminders
+
+| ID | Requirement | Enforced by |
+|---|---|---|
+| FR-23 | A user can write a reflection about an upgrade — ratings for difficulty and benefit, and notes on what worked, what did not, and what to change | `ReflectionService.create` |
+| FR-24 | A user can read an upgrade's reflections, newest first | `ReflectionService.getForUpgrade` |
+| FR-25 | A user can attach reminders to an upgrade, each with a time and a day-of-week filter | `ReminderService`, `ReminderDays` |
+| FR-26 | A user can reschedule, enable, disable and delete a reminder | `ReminderService` |
+
+### 2.6 Dashboard and notifications
+
+| ID | Requirement | Enforced by |
+|---|---|---|
+| FR-27 | A user can see, in one request, their active, planned, due-today, overdue and recently completed upgrades, their weekly completion rate, their streaks and per-area counts | `DashboardAggregationService`, `DashboardAggregationServiceTest` |
+| FR-28 | A user is notified when an upgrade is created, planned, activated, paused, completed or abandoned, when a reflection is added, and when a streak milestone is reached | `NotificationEventListener`, `NotificationEventListenerTest` |
+| FR-29 | A user is notified when an active upgrade passes its target date | `UpgradeOverdueScheduler` |
+| FR-30 | A user with active upgrades and nothing logged is nudged once a day | `NotificationScheduler.notifyDailyCheckin` |
+| FR-31 | A user's reminders fire at the configured time and day | `NotificationScheduler.dispatchReminders`, `ReminderTest` |
+| FR-32 | Notifications arrive in real time on a connected client, and are readable afterwards regardless | `StompNotificationPushAdapter`, `NotificationService` |
+| FR-33 | A user can read their fifty most recent notifications, see an unread count, and mark one or all as read | `NotificationService` |
+
+---
+
+## 3. Business rules and invariants
+
+| ID | Rule | Enforced by |
+|---|---|---|
+| BR-1 | An upgrade is created in `IDEA` and its status changes only through a named transition — never by assignment | `HealthUpgrade` (no setters), `HealthUpgradeTest` |
+| BR-2 | Legal transitions are: `IDEA → PLANNED → ACTIVE ⇄ PAUSED`; `ACTIVE → COMPLETED`; any non-final state `→ ABANDONED`; `ABANDONED --reschedule--> PLANNED` | `HealthUpgrade`, `HealthUpgradeTest` |
+| BR-3 | `COMPLETED` is terminal — it cannot be reactivated, paused or rescheduled | `HealthUpgrade.activate/pause/reschedule` |
+| BR-4 | An upgrade must always have an owner, a title and a type | `HealthUpgrade.create` |
+| BR-5 | A user may have at most **three** `HARD` upgrades active at once, checked on every route into a running HARD upgrade | `UpgradeSchedulingService`, `UpgradeSchedulingServiceTest` |
+| BR-6 | At most one progress entry exists per upgrade per date; a second is refused as a conflict | `TrackingService`, unique constraint on `progress_entries` |
+| BR-7 | Whether an entry counts as successful is decided by the server from the tracking configuration, not by the client | `ProgressEvaluationService`, `ProgressEvaluationServiceTest` |
+| BR-8 | A numeric entry counts only when its unit agrees with the target's; an unstated unit is read as the configured one | `ProgressEvaluationService.unitsAreComparable` |
+| BR-9 | A streak counts consecutive days; a day not yet logged does not break it | `StreakCalculator`, `StreakCalculatorTest` |
+| BR-10 | A streak milestone is announced every seventh day, not every day | `TrackingService.recordProgress` |
+| BR-11 | An overdue upgrade is announced once, however many times the sweep rediscovers it | `NotificationService.createOncePerUpgrade` |
+| BR-12 | A reminder with no day filter fires every day; an unrecognisable day is rejected, never ignored | `ReminderDays`, `ReminderTest` |
+| BR-13 | Reflections are append-only — there is no edit or delete path | `ReflectionService` |
+| BR-14 | Concurrent edits to an upgrade are refused rather than silently merged | `@Version` on `HealthUpgrade` |
+| BR-15 | A record is visible only to its owner; another user's record is reported as absent, never as forbidden | every repository query is user-scoped; `ResourceNotFoundException` |
+
+---
+
+## 4. Non-functional requirements
+
+| ID | Requirement | Enforced by |
+|---|---|---|
+| NFR-1 | Authentication is stateless: a signed token, no server session | `SecurityConfig` (`SessionCreationPolicy.STATELESS`) |
+| NFR-2 | Passwords are stored only as BCrypt hashes; a raw password never leaves the registration call | `SecurityConfig.passwordEncoder`, `AuthService` |
+| NFR-3 | The signing secret is supplied by configuration and must be at least 256 bits, or the application refuses to start | `JwtTokenProvider` |
+| NFR-4 | A token is valid for 24 hours and is not refreshable | `app.jwt.expiration` |
+| NFR-5 | The user behind a token is re-loaded on every request, so a deleted account stops working immediately | `JwtAuthenticationFilter` |
+| NFR-6 | Personal data is never written to logs; event publication logs the type and timestamp only | `SpringDomainEventPublisher` |
+| NFR-7 | Every failure maps to a defined HTTP status: 404 not found, 422 rule violation, 409 conflict, 400 invalid input, 403 denied | `GlobalExceptionHandler`, `GlobalExceptionHandlerTest` |
+| NFR-8 | The database schema is owned by migrations; the application refuses to start against a schema that does not match its entities | Flyway + `ddl-auto: validate` |
+| NFR-9 | Layering is enforced mechanically, not by convention: the domain stays framework-free, the application depends on no adapter, contexts form an acyclic graph | `HexagonalArchitectureTest` (ten rules) |
+| NFR-10 | The frontend's mirrored enums cannot drift from the backend's | `FrontendEnumContractTest` |
+| NFR-11 | The unit test suite runs without a database | `mvn test` |
+| NFR-12 | Every push and pull request is built, tested, linted, and the shipped frontend dependencies audited | `.github/workflows/ci.yml` |
+| NFR-13 | The whole stack starts with one command | `docker-compose up --build` |
+| NFR-14 | List endpoints resolve related data in batch rather than per row | `UpgradeWebMapper.toDtos`, `TrackingConfigQuery.findByUpgradeIds` |
+| NFR-15 | Time-dependent behaviour reads an injected clock, so it is testable and timezone-explicit | `Clock` bean, scheduler tests |
+
+---
+
+## 5. Non-goals
+
+These are deliberate. Re-proposing one needs a reason that has changed.
+
+- **5.1 — Not a medical application.** UpHealther gives no medical advice, diagnosis or treatment, and
+  no feature may imply otherwise. It is a lifestyle planning tool and says so in the README and in the
+  licence's warranty disclaimer.
+- **5.2 — Not multi-tenant or shared.** There is no sharing, no accountability partner, no team view.
+  Every record belongs to one account.
+- **5.3 — Not horizontally scaled.** Real-time push uses an in-memory broker, so it reaches only
+  clients connected to the instance that raised the notification. Running more than one instance needs
+  a broker relay first — see `architecture.md`, "Known constraints".
+- **5.4 — Not an open platform.** There is no public API, no API keys, no third-party integration, and
+  the code is source-available rather than open source ([ADR-003](../ADRs/ADR-003-proprietary-source-available-licensing.md)).
+
+---
+
+## 6. Open questions
+
+Undecided, and owned by the repository owner.
+
+- **The frontend has no test runner.** No vitest, no jest. Frontend logic is currently verified only by
+  the type checker, the linter and inspection. Introducing one is a dependency decision that deserves
+  an ADR.
+- **The backend has no dependency vulnerability audit.** OWASP dependency-check needs an `NVD_API_KEY`
+  secret; ADR-002 records why a check that cannot fail was judged worse than none.
+- **An unbindable request body returns 500 rather than 400** — tracked as issue #22.
+- **`UpgradeType.PROTOCOL` is deprecated but retained** for rows that may already carry it. Removing it
+  needs confirmation that no stored row uses it.
+- **No governing jurisdiction is named in the licence** — ADR-003 flags this as the first thing to add
+  if the project ever becomes commercially significant.
+- **Requirement priorities and delivery order are not recorded here.** Everything above is already
+  built, so nothing has needed ranking yet.
+
+---
+
+UpHealther is still evolving and expanding, and so are its requirements — this document records what
+the project meets today, not the limit of what it will do.

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -163,7 +163,8 @@ Undecided, and owned by the repository owner.
   an ADR.
 - **The backend has no dependency vulnerability audit.** OWASP dependency-check needs an `NVD_API_KEY`
   secret; ADR-002 records why a check that cannot fail was judged worse than none.
-- **An unbindable request body returns 500 rather than 400** — tracked as issue #22.
+- **An unbindable request body returns 500 rather than 400** — tracked as
+  [issue #22](https://github.com/NaimElijah/UpHealther/issues/22).
 - **`UpgradeType.PROTOCOL` is deprecated but retained** for rows that may already carry it. Removing it
   needs confirmation that no stored row uses it.
 - **No governing jurisdiction is named in the licence** — ADR-003 flags this as the first thing to add

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,8 +1,9 @@
 # Frontend conventions
 
-`../docs/architecture/architecture.md` describes how the SPA fits into the wider system — the proxy,
-the two transports, and what the backend guarantees. This file covers the conventions to follow inside
-`frontend/`.
+`../docs/requirements/requirements.md` states what the system must do, including the rules the UI is
+expected to respect. `../docs/architecture/architecture.md` describes how the SPA fits into the wider
+system — the proxy, the two transports, and what the backend guarantees. This file covers the
+conventions to follow inside `frontend/`.
 
 `npm run dev` serves on :3000 and proxies `/api` → `http://localhost:8080` (see `vite.config.ts`).
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>HealthUpgrades</title>
+    <title>UpHealther</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -12,7 +12,7 @@ const Navbar: React.FC = () => {
     <nav className="bg-white border-b border-gray-200 h-16 flex items-center px-6 justify-between sticky top-0 z-30">
       <Link to="/dashboard" className="flex items-center gap-2">
         <span className="text-2xl">💪</span>
-        <span className="font-bold text-gray-900 text-lg">HealthUpgrades</span>
+        <span className="font-bold text-gray-900 text-lg">UpHealther</span>
       </Link>
       <div className="flex items-center gap-3">
         <NotificationBell />

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -45,7 +45,7 @@ const LoginPage: React.FC = () => {
       <div className="bg-white rounded-2xl shadow-xl p-8 w-full max-w-md">
         <div className="text-center mb-8">
           <div className="text-5xl mb-3">💪</div>
-          <h1 className="text-2xl font-bold text-gray-900">HealthUpgrades</h1>
+          <h1 className="text-2xl font-bold text-gray-900">UpHealther</h1>
           <p className="text-gray-500 mt-1">Sign in to your account</p>
         </div>
         <form onSubmit={handleSubmit} className="space-y-4">


### PR DESCRIPTION
## Problem

Two things, both consequences of the project being renamed and of a directory that was created but
never filled.

**1. The rename to UpHealther was half-finished.** The README heading and the licence title had been
updated; nothing else had. The old name was still on:

- the browser tab title, the navbar brand and the login heading — the three places a user actually
  sees the product named;
- **`LICENSE` §7**, which reserved the name `"HealthUpgrades"`. The trademark clause was protecting a
  name the project no longer uses, and saying nothing about the one it does;
- the README disclaimer, resume summary and licence section, plus a clone instruction pointing at a
  directory called `Health_Upgrades_Tracker`;
- the opening sentence of the architecture document.

**2. `docs/requirements/` held nothing but a `.gitkeep`.** The repository baseline requires a
requirements document, and there was none — so what the system must do existed only as code, tests and
inference.

## Approach

**For the rename, I drew a line between the project's name and identifiers that happen to contain the
old string,** and fixed only the first. Renamed: prose, documentation, and every user-visible surface.
Deliberately not renamed:

| Left alone | Why |
|---|---|
| `com.healthupgrades` Java package (162 files) | A mechanical but repository-wide refactor with no user-visible effect |
| `healthupgrades` database name, user and password | Baked into existing local volumes and `.env` files; changing the default breaks every existing environment |
| `demo@healthupgrades.com` | Seeded by Flyway `V2`, which is immutable — changing it needs a new migration |
| `healthupgrades-db` / `-backend` container names, Maven artifactId, `package.json` name | Build and infrastructure identifiers, not the product name |

None of those is "the project name being wrong". Each is a code or infrastructure change with its own
blast radius, and they belong in their own PR — happy to do it, but not folded into a documentation
change.

**For the requirements document, I recorded what the project meets today**, as asked: 33 functional
requirements, 15 business rules and invariants, 15 non-functional requirements, 4 non-goals and 6 open
questions. Every entry names the class or test that enforces it, so a claim in the document can be
checked rather than trusted — `BR-5` points at `UpgradeSchedulingServiceTest`, `NFR-9` at
`HexagonalArchitectureTest`, and so on.

It states *what*, points at `architecture.md` for *how* and the ADRs for *why*, and closes by saying
the project and its requirements are both still growing.

## Trade-off accepted

The document describes **implemented** behaviour rather than independently-established intent. That is
what was asked for, and it is the honest thing to say about a document derived from a finished
codebase — but it means anything the code gets wrong, the requirements would inherit. The open
questions section names the six things the code cannot answer, including the two known gaps (no
frontend test runner, no backend dependency audit) and the one open defect (#22), rather than
presenting the project as complete.

Priorities and delivery order are not recorded, because everything listed is already built and nothing
has needed ranking.

## How it was verified

- `mvn test` — passes.
- `npm run build` and `npx eslint src` — pass, clean.
- Every factual claim in the requirements document was checked against the code before writing it,
  including the ones easiest to get wrong: the `uq_progress_upgrade_date` unique constraint actually
  exists in `V1` (BR-6), the token lifetime really is 24 hours and non-refreshable (NFR-4), and the
  frontend really does offer exactly eight upgrade kinds (FR-9).
- Confirmed no occurrence of the old name survives in prose or UI; the remaining hits are all the
  identifiers listed above.
