### PR TITLE
docs: add arch-diagrams — seven views of the architecture, three generated from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,19 @@ jobs:
       # its database without an NVD API key and fails outright without one. See the known gaps in
       # ADR-002 for what enabling it requires.
 
+  diagrams:
+    name: Diagrams - Drift check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Three of the diagrams in docs/architecture/arch-diagrams/ are derived from the imports, the
+      # package layout and the migrations. Regenerating here and failing on a difference is what stops
+      # them describing an architecture the code no longer has — the failure ADR-002 was written about.
+      - name: Check the generated diagrams still match the source
+        run: python3 docs/architecture/arch-diagrams/generate.py --check
+
   frontend:
     name: Frontend - Build & Lint
     runs-on: ubuntu-latest

--- a/docs/architecture/arch-diagrams/README.md
+++ b/docs/architecture/arch-diagrams/README.md
@@ -150,8 +150,11 @@ Relations shown are **implements**, **extends**, and *holds a field of this type
 that reveals the wiring. Accessors and framework plumbing are left out on purpose; the interesting
 content is which layer a type sits in and which way its arrows point.
 
-Scoped to this context's own types, so dependencies on `common` and on Spring do not appear —
-`UpgradeService` also holds a `DomainEventPublisher` and a `Clock`, neither of which is drawn here.
+Two things are therefore absent by construction, and neither means what it looks like. Dependencies on
+`common` and on Spring are out of scope — `UpgradeService` also holds a `DomainEventPublisher` and a
+`Clock`. And a type *constructed in a method* rather than held as a field draws no arrow, which is why
+nothing connects `UpgradeBeansConfig` to `UpgradeSchedulingService` even though wiring that bean is the
+only reason the class exists.
 
 <!-- generated:class-diagram -->
 ```mermaid
@@ -208,17 +211,29 @@ classDiagram
         <<outbound port>>
     }
 
-    %% ---- application ----
-    class UpgradeBeansConfig {
-        <<application>>
+    %% ---- port record ----
+    class UpgradeTrackingSummary {
+        <<port record>>
     }
+
+    %% ---- application ----
     class UpgradeService {
         <<application>>
+    }
+
+    %% ---- bean wiring ----
+    class UpgradeBeansConfig {
+        <<bean wiring>>
     }
 
     %% ---- inbound port ----
     class UpgradeQuery {
         <<inbound port>>
+    }
+
+    %% ---- use-case record ----
+    class UpgradeDetails {
+        <<use-case record>>
     }
 
     %% ---- web adapter ----
@@ -258,16 +273,6 @@ classDiagram
     }
     class UpgradeRepositoryAdapter {
         <<persistence adapter>>
-    }
-
-    %% ---- port record ----
-    class UpgradeTrackingSummary {
-        <<port record>>
-    }
-
-    %% ---- use-case record ----
-    class UpgradeDetails {
-        <<use-case record>>
     }
 
     %% ---- relations: implements, extends, and fields typed by another type ----

--- a/docs/architecture/arch-diagrams/README.md
+++ b/docs/architecture/arch-diagrams/README.md
@@ -1,0 +1,506 @@
+# Architecture diagrams
+
+Seven views of UpHealther, ordered from the outside in: what the moving parts are, how the backend
+is divided, how one division is shaped, what one of them contains, how its core object moves through
+its life, how a request travels, and what is stored.
+
+Read them in order and you have the system. For the prose that goes with them see
+[`../architecture.md`](../architecture.md); for why any of it is shaped this way, see
+[`../../ADRs/`](../../ADRs/).
+
+> **Three of these are generated, not drawn.** The context map, the class diagram and the ER diagram
+> are derived from the imports, the package layout and the Flyway migrations respectively, by
+> [`generate.py`](generate.py). CI fails if the committed output stops matching the source, so a
+> diagram here cannot quietly go out of date. The other three describe intent rather than structure,
+> do not rot, and are written by hand.
+
+---
+
+## 1. System context
+
+Three processes and a browser. There is no message broker, no cache and no third-party service —
+every piece of state is in the one database, and every side effect is either a write to it or a
+message pushed to a connected browser.
+
+```mermaid
+flowchart LR
+    user(["User's browser"])
+
+    subgraph frontend["Frontend container · nginx :80 → :3000"]
+        spa["React SPA<br/>static bundle"]
+        proxy["reverse proxy<br/>/api · /ws"]
+    end
+
+    subgraph backend["Backend container · Spring Boot :8080"]
+        rest["REST controllers"]
+        stomp["STOMP endpoint /ws"]
+        jobs["Scheduled jobs<br/>overdue · check-in · reminders"]
+        core["Domain + application core"]
+    end
+
+    db[("PostgreSQL 15<br/>schema owned by Flyway")]
+
+    user -->|"HTTP"| spa
+    user -->|"/api/**"| proxy
+    user -->|"WebSocket /ws"| proxy
+    proxy -->|"proxy_pass"| rest
+    proxy -->|"proxy_pass, upgraded"| stomp
+    rest --> core
+    jobs --> core
+    core -->|"push"| stomp
+    core -->|"JDBC"| db
+```
+
+Same-origin by design: the browser only ever talks to the frontend's origin, and the proxy forwards
+`/api` and `/ws` onward. In development the Vite dev server does the same job, so both sides behave
+identically.
+
+---
+
+## 2. Bounded-context map
+
+The backend is nine bounded contexts over a shared kernel. This graph is read off the `import`
+statements — it is what the code does, not what anyone intended.
+
+<!-- generated:context-map -->
+```mermaid
+flowchart TD
+    auth["auth"]
+    user["user"]
+    healtharea["healtharea"]
+    upgrade["upgrade"]
+    tracking["tracking"]
+    reflection["reflection"]
+    reminder["reminder"]
+    dashboard["dashboard"]
+    notification["notification"]
+
+    auth --> user
+    tracking --> upgrade
+    reflection --> upgrade
+    reminder --> upgrade
+    dashboard --> healtharea
+    dashboard --> tracking
+    dashboard --> upgrade
+    notification --> reflection
+    notification --> reminder
+    notification --> tracking
+    notification --> upgrade
+
+    %% depends on nothing: healtharea, upgrade, user — the graph is acyclic,
+    %% which HexagonalArchitectureTest fails the build over if it stops being true.
+```
+<!-- /generated:context-map -->
+
+`common` is excluded: every context depends on it by definition, so drawing it would add ten edges
+that say nothing. The absent edge is the interesting one — `upgrade` points at nothing, even though
+an upgrade's response carries its tracking configuration. That inversion is
+[ADR-002](../../ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md).
+
+---
+
+## 3. How to read a context
+
+Every context is the same shape, so learning it once is enough. Arrows run **inward**: adapters
+depend on the core, and the core depends on nothing outside itself. The driven side is inverted —
+persistence and messaging *implement* ports the core declares, rather than the core calling them.
+
+```mermaid
+flowchart LR
+    subgraph driving["driving side — what starts work"]
+        web["adapter/in/web<br/>controllers · DTOs · mappers"]
+        sched["adapter/in/scheduling<br/>cron jobs"]
+        evt["adapter/in/event<br/>event listeners"]
+    end
+
+    subgraph core["the core — no Spring, no JPA queries, no HTTP"]
+        portIn["application/port/in<br/>inbound ports · command records"]
+        app["application<br/>transactional services"]
+        domain["domain/model · domain/service<br/>aggregates · invariants"]
+        portOut["domain/port/out<br/>outbound ports"]
+    end
+
+    subgraph driven["driven side — what work reaches out to"]
+        persistence["adapter/out/persistence<br/>JPA repositories"]
+        messaging["adapter/out/messaging<br/>STOMP push"]
+    end
+
+    web --> portIn
+    sched --> portIn
+    evt --> portIn
+    portIn --> app
+    app --> domain
+    app --> portOut
+    persistence -. implements .-> portOut
+    messaging -. implements .-> portOut
+```
+
+This is not a convention anyone has to remember — `HexagonalArchitectureTest` fails the build on
+every arrow that runs the wrong way. Two contexts are deliberately smaller than this: `auth`
+orchestrates over `user` and owns no aggregate, and `dashboard` is a read model with no driven side.
+
+---
+
+## 4. Inside one context — `upgrade`
+
+The core context, and the one worth reading in full: it owns `HealthUpgrade`, the aggregate whose
+state machine the whole product is built around. Every other context follows the shape from §3.
+
+Relations shown are **implements**, **extends**, and *holds a field of this type* — the composition
+that reveals the wiring. Accessors and framework plumbing are left out on purpose; the interesting
+content is which layer a type sits in and which way its arrows point.
+
+Scoped to this context's own types, so dependencies on `common` and on Spring do not appear —
+`UpgradeService` also holds a `DomainEventPublisher` and a `Clock`, neither of which is drawn here.
+
+<!-- generated:class-diagram -->
+```mermaid
+classDiagram
+    direction LR
+
+    %% ---- domain model ----
+    class Difficulty {
+        <<domain model · enum>>
+    }
+    class HealthUpgrade {
+        <<domain model>>
+    }
+    class UpgradeStatus {
+        <<domain model · enum>>
+    }
+    class UpgradeType {
+        <<domain model · enum>>
+    }
+
+    %% ---- domain event ----
+    class HealthUpgradeAbandoned {
+        <<domain event>>
+    }
+    class HealthUpgradeActivated {
+        <<domain event>>
+    }
+    class HealthUpgradeCompleted {
+        <<domain event>>
+    }
+    class HealthUpgradeCreated {
+        <<domain event>>
+    }
+    class HealthUpgradePaused {
+        <<domain event>>
+    }
+    class HealthUpgradePlanned {
+        <<domain event>>
+    }
+    class UpgradeOverdueDetected {
+        <<domain event>>
+    }
+
+    %% ---- domain service ----
+    class UpgradeSchedulingService {
+        <<domain service>>
+    }
+
+    %% ---- outbound port ----
+    class UpgradeRepositoryPort {
+        <<outbound port>>
+    }
+    class UpgradeTrackingSummaryPort {
+        <<outbound port>>
+    }
+
+    %% ---- application ----
+    class UpgradeBeansConfig {
+        <<application>>
+    }
+    class UpgradeService {
+        <<application>>
+    }
+
+    %% ---- inbound port ----
+    class UpgradeQuery {
+        <<inbound port>>
+    }
+
+    %% ---- web adapter ----
+    class ActivateRequest {
+        <<web adapter>>
+    }
+    class PlanRequest {
+        <<web adapter>>
+    }
+    class RescheduleRequest {
+        <<web adapter>>
+    }
+    class UpgradeController {
+        <<web adapter>>
+    }
+    class UpgradeDto {
+        <<web adapter>>
+    }
+    class UpgradeRequest {
+        <<web adapter>>
+    }
+    class UpgradeTrackingConfigDto {
+        <<web adapter>>
+    }
+    class UpgradeWebMapper {
+        <<web adapter>>
+    }
+
+    %% ---- scheduling adapter ----
+    class UpgradeOverdueScheduler {
+        <<scheduling adapter>>
+    }
+
+    %% ---- persistence adapter ----
+    class UpgradeJpaRepository {
+        <<persistence adapter>>
+    }
+    class UpgradeRepositoryAdapter {
+        <<persistence adapter>>
+    }
+
+    %% ---- port record ----
+    class UpgradeTrackingSummary {
+        <<port record>>
+    }
+
+    %% ---- use-case record ----
+    class UpgradeDetails {
+        <<use-case record>>
+    }
+
+    %% ---- relations: implements, extends, and fields typed by another type ----
+    HealthUpgrade --> Difficulty
+    HealthUpgrade --> UpgradeStatus
+    HealthUpgrade --> UpgradeType
+    UpgradeController --> UpgradeService
+    UpgradeController --> UpgradeWebMapper
+    UpgradeDetails --> Difficulty
+    UpgradeDetails --> UpgradeType
+    UpgradeDto --> Difficulty
+    UpgradeDto --> UpgradeStatus
+    UpgradeDto --> UpgradeTrackingConfigDto
+    UpgradeDto --> UpgradeType
+    UpgradeOverdueScheduler --> UpgradeQuery
+    UpgradeRepositoryAdapter --> UpgradeJpaRepository
+    UpgradeRepositoryAdapter ..|> UpgradeRepositoryPort : implements
+    UpgradeRequest --> Difficulty
+    UpgradeRequest --> UpgradeType
+    UpgradeService --> UpgradeRepositoryPort
+    UpgradeService --> UpgradeSchedulingService
+    UpgradeService ..|> UpgradeQuery : implements
+    UpgradeWebMapper --> UpgradeTrackingSummaryPort
+```
+<!-- /generated:class-diagram -->
+
+Read the stereotypes as layers. Note that `UpgradeService` holds `UpgradeRepositoryPort` — an
+interface in the domain — and never the adapter that implements it, which is the whole point.
+
+---
+
+## 5. The upgrade lifecycle
+
+The state machine `HealthUpgrade` owns. Status changes only through these named transitions — the
+aggregate has no setter for it — and each one guards itself, so an illegal move is a 422 with a reason
+rather than a silently accepted write.
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDEA: create
+    IDEA --> PLANNED: plan
+    PLANNED --> ACTIVE: activate
+    ACTIVE --> PAUSED: pause
+    PAUSED --> ACTIVE: activate
+    ACTIVE --> COMPLETED: complete
+    IDEA --> ABANDONED: abandon
+    PLANNED --> ABANDONED: abandon
+    ACTIVE --> ABANDONED: abandon
+    PAUSED --> ABANDONED: abandon
+    ABANDONED --> PLANNED: reschedule
+    COMPLETED --> [*]
+```
+
+`COMPLETED` is terminal; `ABANDONED` is not — rescheduling revives it, which is the one transition not
+named after its destination. An upgrade occupies one of the three concurrent `HARD` slots only while
+`ACTIVE`, which is why that limit is checked both when activating one and when promoting a running one
+to `HARD`. Every transition here is pinned by `HealthUpgradeTest`.
+
+---
+
+## 6. Request lifecycle
+
+Logging a day's progress, end to end. Chosen because it touches almost everything: authentication,
+cross-context ownership checks, a domain invariant, an event, and both delivery transports.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant N as nginx
+    participant F as JwtAuthenticationFilter
+    participant C as ProgressController
+    participant S as TrackingService
+    participant U as UpgradeQuery
+    participant R as ProgressEntryRepositoryPort
+    participant DB as PostgreSQL
+    participant L as NotificationEventListener
+    participant W as StompNotificationPushAdapter
+
+    B->>N: POST /api/upgrades/{id}/progress
+    N->>F: proxied
+    F->>F: validate JWT, load user, set security context
+    F->>C: request
+    C->>S: recordProgress(userId, upgradeId, details)
+    S->>U: getOwnedUpgrade(userId, upgradeId)
+    U->>DB: SELECT … WHERE id = ? AND user_id = ?
+    S->>R: existsByUpgradeIdAndDate — duplicate guard
+    S->>S: score the entry against the tracking config
+    S->>R: save(entry)
+    R->>DB: INSERT
+    S-->>L: ProgressEntryRecorded · StreakAchieved
+    Note over L: AFTER_COMMIT — nothing fires if the transaction rolls back
+    L->>DB: INSERT notification
+    L->>W: push
+    W-->>B: STOMP frame on /user/queue/notifications
+    C-->>B: 201 with the stored entry
+```
+
+Three things worth noticing: ownership is enforced by the *query* being user-scoped rather than by a
+guard, so a foreign row is indistinguishable from a missing one; the server scores the entry rather
+than trusting the client's `completed` flag; and the push happens only after commit, while the
+notification is persisted either way so an offline client still sees it.
+
+---
+
+## 7. Data model
+
+Tables, keys and foreign keys, read from the Flyway migrations. The schema is owned by Flyway and
+Hibernate runs with `ddl-auto: validate`, so this is authoritative — the application refuses to start
+against a schema that does not match it.
+
+<!-- generated:er-diagram -->
+```mermaid
+erDiagram
+    health_areas |o--o{ health_upgrades : ""
+    health_upgrades |o--o{ notifications : ""
+    health_upgrades ||--o{ progress_entries : ""
+    health_upgrades ||--o{ reflections : ""
+    health_upgrades ||--o{ reminders : ""
+    health_upgrades ||--o{ tracking_configs : ""
+    users ||--o{ health_areas : ""
+    users ||--o{ health_upgrades : ""
+    users ||--o{ notifications : ""
+    users ||--o{ progress_entries : ""
+    users ||--o{ reflections : ""
+
+    users {
+        uuid id PK
+        varchar name
+        varchar email UK
+        varchar password_hash
+        timestamp created_at
+        timestamp updated_at
+    }
+    health_areas {
+        uuid id PK
+        uuid user_id
+        varchar name
+        text description
+        integer priority
+        varchar icon
+        varchar color
+        timestamp created_at
+        timestamp updated_at
+    }
+    health_upgrades {
+        uuid id PK
+        uuid user_id
+        uuid area_id
+        varchar title
+        text description
+        varchar type
+        varchar status
+        varchar difficulty
+        date planned_start_date
+        date actual_start_date
+        date target_end_date
+        text motivation
+        text success_criteria
+        bigint version
+        timestamp created_at
+        timestamp updated_at
+    }
+    tracking_configs {
+        uuid id PK
+        uuid upgrade_id UK
+        varchar tracking_type
+        varchar frequency
+        double target_numeric_value
+        varchar target_unit
+        boolean required_daily
+    }
+    progress_entries {
+        uuid id PK
+        uuid upgrade_id
+        uuid user_id
+        date date
+        boolean completed
+        double numeric_value
+        varchar unit
+        integer rating
+        text note
+        timestamp created_at
+        timestamp updated_at
+    }
+    reminders {
+        uuid id PK
+        uuid upgrade_id
+        time reminder_time
+        varchar days_of_week
+        boolean enabled
+        timestamp created_at
+        timestamp updated_at
+    }
+    reflections {
+        uuid id PK
+        uuid upgrade_id
+        uuid user_id
+        date date
+        integer difficulty_rating
+        integer benefit_rating
+        text what_worked
+        text what_did_not_work
+        text next_adjustment
+        timestamp created_at
+        timestamp updated_at
+    }
+    notifications {
+        uuid id PK
+        uuid user_id
+        varchar type
+        varchar category
+        varchar title
+        text message
+        uuid related_upgrade_id
+        boolean is_read
+        timestamp created_at
+    }
+```
+<!-- /generated:er-diagram -->
+
+The two constraints doing real work: `progress_entries` is unique on `(upgrade_id, date)`, which is
+what makes "one entry per upgrade per day" survive a race the application-level check would miss; and
+`tracking_configs.upgrade_id` is unique, so an upgrade has at most one configuration.
+
+---
+
+## Regenerating
+
+```bash
+python docs/architecture/arch-diagrams/generate.py           # rewrite the generated diagrams
+python docs/architecture/arch-diagrams/generate.py --check   # fail if they are out of date (CI runs this)
+```
+
+Editing a generated region by hand is pointless — the next run overwrites it, and CI will fail before
+then. Change the code, then regenerate.

--- a/docs/architecture/arch-diagrams/generate.py
+++ b/docs/architecture/arch-diagrams/generate.py
@@ -85,11 +85,13 @@ def code_only(source: str) -> str:
     return STRING_LITERAL.sub('""', LINE_COMMENT.sub("", BLOCK_COMMENT.sub("", source)))
 
 
-def stereotype_for(relative_package: str, kind: str) -> str:
-    """The layer and role to stamp on a type, from where it sits and what kind of type it is.
+def stereotype_for(relative_package: str, kind: str, name: str) -> str:
+    """The layer and role to stamp on a type, from where it sits, what kind it is, and what it is called.
 
-    A port package holds two different things — the port interface and the records passed across it —
-    and calling both "port" would hide the distinction the hexagonal layering exists to make.
+    Two distinctions the package path alone would flatten, both of which the hexagonal layering exists
+    to make visible: a port package holds the port interface *and* the records passed across it, and
+    the application package holds use cases *and* the configuration that hand-wires the domain
+    services — which carry no stereotype annotation precisely so the domain stays framework-free.
     """
     best, label = "", "type"
     for prefix, candidate in STEREOTYPES:
@@ -98,6 +100,8 @@ def stereotype_for(relative_package: str, kind: str) -> str:
 
     if label in ("inbound port", "outbound port") and kind != "interface":
         return "use-case record" if "port/in" in relative_package else "port record"
+    if label == "application" and name.endswith("Config"):
+        return "bean wiring"
     return label
 
 
@@ -123,7 +127,7 @@ def discover_types() -> dict:
             "context": context,
             "package": package,
             "kind": kind,
-            "stereotype": stereotype_for(package, kind),
+            "stereotype": stereotype_for(package, kind, name),
             "body": body,
             "source": source,
         }
@@ -231,9 +235,10 @@ def class_diagram(types: dict, context: str) -> str:
     for name, meta in sorted(members.items()):
         by_stereotype.setdefault(meta["stereotype"], []).append((name, meta))
 
-    layer_order = ["domain model", "domain event", "domain service", "outbound port",
-                   "application", "inbound port", "web adapter", "scheduling adapter",
-                   "persistence adapter", "composition adapter", "messaging adapter", "event adapter"]
+    layer_order = ["domain model", "domain event", "domain service", "outbound port", "port record",
+                   "application", "bean wiring", "inbound port", "use-case record",
+                   "web adapter", "scheduling adapter", "persistence adapter",
+                   "composition adapter", "messaging adapter", "event adapter"]
     ordered = sorted(by_stereotype, key=lambda s: (layer_order.index(s) if s in layer_order else 99, s))
 
     for stereotype in ordered:

--- a/docs/architecture/arch-diagrams/generate.py
+++ b/docs/architecture/arch-diagrams/generate.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Regenerates the mechanical diagrams in this folder's README from the source they describe.
+
+Three of the six diagrams are derived rather than drawn, because they restate something the code
+already states and would otherwise drift the moment anyone adds an import, a field or a column:
+
+    context-map    the cross-context dependency graph, from the import statements
+    class-diagram  one bounded context's types and their relations, from the package layout
+    er-diagram     the database schema, from the Flyway migrations
+
+The other three are conceptual, do not rot, and are written by hand in the README.
+
+Usage:
+    python generate.py            rewrite the generated regions of README.md
+    python generate.py --check    exit 1 if the committed README is out of date
+
+The generated regions are delimited by <!-- generated:NAME --> ... <!-- /generated:NAME --> markers;
+everything outside them is left untouched.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# The context whose internals the class diagram shows. `upgrade` owns the core aggregate and its
+# state machine, so it is the one worth reading in full; every other context follows the same shape.
+CLASS_DIAGRAM_CONTEXT = "upgrade"
+
+CONTEXTS = [
+    "auth", "user", "healtharea", "upgrade", "tracking",
+    "reflection", "reminder", "dashboard", "notification",
+]
+
+# Package path (relative to a context root) → the layer and role shown as a Mermaid stereotype.
+# Longest match wins, so `domain/port/out` beats `domain`.
+STEREOTYPES = [
+    ("adapter/in/web", "web adapter"),
+    ("adapter/in/scheduling", "scheduling adapter"),
+    ("adapter/in/composition", "composition adapter"),
+    ("adapter/in/event", "event adapter"),
+    ("adapter/out/persistence", "persistence adapter"),
+    ("adapter/out/messaging", "messaging adapter"),
+    ("application/port/in", "inbound port"),
+    ("application/port/out", "outbound port"),
+    ("application", "application"),
+    ("domain/model", "domain model"),
+    ("domain/event", "domain event"),
+    ("domain/port/out", "outbound port"),
+    ("domain/service", "domain service"),
+]
+
+SQL_TYPE_TOKENS = {
+    "UUID": "uuid", "TEXT": "text", "DATE": "date", "BOOLEAN": "boolean",
+    "INTEGER": "integer", "BIGINT": "bigint", "TIMESTAMP": "timestamp",
+    "DOUBLE": "double", "VARCHAR": "varchar", "NUMERIC": "numeric",
+}
+
+
+# --------------------------------------------------------------------------- source discovery
+
+def repo_root() -> Path:
+    for candidate in [Path(__file__).resolve()] + list(Path(__file__).resolve().parents):
+        if (candidate / ".git").exists():
+            return candidate
+    raise SystemExit("could not locate the repository root (no .git found above this file)")
+
+
+ROOT = repo_root()
+JAVA_ROOT = ROOT / "backend" / "src" / "main" / "java" / "com" / "healthupgrades"
+MIGRATIONS = ROOT / "backend" / "src" / "main" / "resources" / "db" / "migration"
+README = Path(__file__).resolve().parent / "README.md"
+
+BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+LINE_COMMENT = re.compile(r"//[^\n]*")
+STRING_LITERAL = re.compile(r'"(?:\\.|[^"\\])*"')
+
+
+def code_only(source: str) -> str:
+    """Strips comments and string literals, so documentation references are not read as dependencies.
+
+    This matters here: the codebase is heavily javadoc'd and nearly every class names several others
+    in prose. Scanning the raw text would report those mentions as relations.
+    """
+    return STRING_LITERAL.sub('""', LINE_COMMENT.sub("", BLOCK_COMMENT.sub("", source)))
+
+
+def stereotype_for(relative_package: str, kind: str) -> str:
+    """The layer and role to stamp on a type, from where it sits and what kind of type it is.
+
+    A port package holds two different things — the port interface and the records passed across it —
+    and calling both "port" would hide the distinction the hexagonal layering exists to make.
+    """
+    best, label = "", "type"
+    for prefix, candidate in STEREOTYPES:
+        if relative_package.startswith(prefix) and len(prefix) > len(best):
+            best, label = prefix, candidate
+
+    if label in ("inbound port", "outbound port") and kind != "interface":
+        return "use-case record" if "port/in" in relative_package else "port record"
+    return label
+
+
+def discover_types() -> dict:
+    """Every type in the backend's main sources, keyed by simple name."""
+    types = {}
+    for path in sorted(JAVA_ROOT.rglob("*.java")):
+        relative = path.relative_to(JAVA_ROOT)
+        parts = relative.parts
+        context = parts[0]
+        package = "/".join(parts[1:-1])
+        name = path.stem
+        source = path.read_text(encoding="utf-8")
+        body = code_only(source)
+
+        kind = "class"
+        for candidate in ("interface", "record", "enum"):
+            if re.search(r"\b%s\s+%s\b" % (candidate, re.escape(name)), body):
+                kind = candidate
+                break
+
+        types[name] = {
+            "context": context,
+            "package": package,
+            "kind": kind,
+            "stereotype": stereotype_for(package, kind),
+            "body": body,
+            "source": source,
+        }
+    return types
+
+
+# --------------------------------------------------------------------------- 1. context map
+
+def context_map() -> str:
+    """The cross-context dependency graph, read off the imports rather than off intent."""
+    edges = {}
+    for path in sorted(JAVA_ROOT.rglob("*.java")):
+        source_context = path.relative_to(JAVA_ROOT).parts[0]
+        if source_context not in CONTEXTS:
+            continue
+        for match in re.finditer(r"^import\s+(?:static\s+)?com\.healthupgrades\.(\w+)\.",
+                                 path.read_text(encoding="utf-8"), re.MULTILINE):
+            target = match.group(1)
+            if target in CONTEXTS and target != source_context:
+                edges.setdefault(source_context, set()).add(target)
+
+    depended_on = {t for targets in edges.values() for t in targets}
+    lines = ["flowchart TD"]
+    for context in CONTEXTS:
+        if context in edges or context in depended_on:
+            shape = f'    {context}["{context}"]'
+            lines.append(shape)
+    lines.append("")
+    for source in CONTEXTS:
+        for target in sorted(edges.get(source, ())):
+            lines.append(f"    {source} --> {target}")
+    lines.append("")
+    sinks = sorted(c for c in depended_on if c not in edges)
+    lines.append(f"    %% depends on nothing: {', '.join(sinks)} — the graph is acyclic,")
+    lines.append("    %% which HexagonalArchitectureTest fails the build over if it stops being true.")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- 2. class diagram
+
+FIELD = re.compile(
+    r"^\s*(?:private|protected|public)\s+(?:static\s+|final\s+|transient\s+|volatile\s+)*"
+    r"([A-Za-z_][\w.]*(?:\s*<[^;=]*?>)?)\s+([a-z]\w*)\s*[;=]",
+    re.MULTILINE,
+)
+IMPLEMENTS = re.compile(r"\b(?:class|record|enum)\s+\w+[^{]*?\bimplements\s+([\w\s,<>.]+?)\s*\{", re.DOTALL)
+EXTENDS = re.compile(r"\b(?:class|interface)\s+\w+[^{]*?\bextends\s+([\w\s,<>.]+?)(?:\s+implements|\s*\{)", re.DOTALL)
+
+
+def record_components(body: str, name: str) -> str:
+    """The parameter list of a record declaration, or an empty string for anything else."""
+    start = body.find(f"record {name}")
+    if start == -1:
+        return ""
+    open_paren = body.find("(", start)
+    if open_paren == -1:
+        return ""
+    depth, index = 0, open_paren
+    while index < len(body):
+        if body[index] == "(":
+            depth += 1
+        elif body[index] == ")":
+            depth -= 1
+            if depth == 0:
+                return body[open_paren + 1:index]
+        index += 1
+    return ""
+
+
+def referenced_types(text: str, known: set, exclude: str) -> set:
+    """Project types named in a fragment of code — generic arguments included."""
+    return {token for token in re.findall(r"\b([A-Z]\w+)\b", text) if token in known and token != exclude}
+
+
+def supertype_names(clause: str, known: set, exclude: str) -> set:
+    """The base types in an extends/implements clause, ignoring their type arguments.
+
+    `extends JpaRepository<HealthUpgrade, UUID>` names one supertype, not two: reading the type
+    argument as a supertype would draw an inheritance arrow that does not exist.
+    """
+    parts, depth, current = [], 0, ""
+    for character in clause:
+        if character == "<":
+            depth += 1
+        elif character == ">":
+            depth -= 1
+        if character == "," and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += character
+    parts.append(current)
+
+    names = {part.split("<")[0].strip().split(".")[-1] for part in parts}
+    return {name for name in names if name in known and name != exclude}
+
+
+def class_diagram(types: dict, context: str) -> str:
+    members = {name: meta for name, meta in types.items() if meta["context"] == context}
+    known = set(members)
+
+    lines = ["classDiagram", "    direction LR", ""]
+
+    by_stereotype = {}
+    for name, meta in sorted(members.items()):
+        by_stereotype.setdefault(meta["stereotype"], []).append((name, meta))
+
+    layer_order = ["domain model", "domain event", "domain service", "outbound port",
+                   "application", "inbound port", "web adapter", "scheduling adapter",
+                   "persistence adapter", "composition adapter", "messaging adapter", "event adapter"]
+    ordered = sorted(by_stereotype, key=lambda s: (layer_order.index(s) if s in layer_order else 99, s))
+
+    for stereotype in ordered:
+        lines.append(f"    %% ---- {stereotype} ----")
+        for name, meta in by_stereotype[stereotype]:
+            label = meta["stereotype"] if meta["kind"] != "enum" else f"{meta['stereotype']} · enum"
+            lines.append(f"    class {name} {{")
+            lines.append(f"        <<{label}>>")
+            lines.append("    }")
+        lines.append("")
+
+    relations = []
+    for name, meta in sorted(members.items()):
+        body = meta["body"]
+
+        for match in IMPLEMENTS.finditer(body):
+            for target in supertype_names(match.group(1), known, name):
+                relations.append(f"    {name} ..|> {target} : implements")
+        for match in EXTENDS.finditer(body):
+            for target in supertype_names(match.group(1), known, name):
+                relations.append(f"    {name} --|> {target} : extends")
+
+        holds = set()
+        for match in FIELD.finditer(body):
+            holds |= referenced_types(match.group(1), known, name)
+        holds |= referenced_types(record_components(body, name), known, name)
+        for target in sorted(holds):
+            relations.append(f"    {name} --> {target}")
+
+    lines.append("    %% ---- relations: implements, extends, and fields typed by another type ----")
+    lines.extend(sorted(set(relations)))
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- 3. ER diagram
+
+CREATE_TABLE = re.compile(r"CREATE TABLE (\w+)\s*\((.*?)\n\);", re.DOTALL | re.IGNORECASE)
+
+
+def sql_type_token(column_definition: str) -> str:
+    head = column_definition.strip().split()
+    if len(head) < 2:
+        return "unknown"
+    raw = head[1].upper().split("(")[0]
+    return SQL_TYPE_TOKENS.get(raw, raw.lower())
+
+
+def er_diagram() -> str:
+    tables, relations = {}, []
+    for migration in sorted(MIGRATIONS.glob("V*.sql")):
+        sql = migration.read_text(encoding="utf-8")
+        for table, block in CREATE_TABLE.findall(sql):
+            columns = []
+            for line in block.splitlines():
+                line = line.strip().rstrip(",")
+                if not line or line.upper().startswith("CONSTRAINT"):
+                    # A single-column UNIQUE is a property of that column and is marked on it. A
+                    # composite one is a property of the pair, and Mermaid has no notation for that —
+                    # marking each column UK would claim each is independently unique, which is false.
+                    # Composite constraints are described in the prose beside the diagram instead.
+                    inner = re.search(r"UNIQUE\s*\(([^)]*)\)", line, re.IGNORECASE)
+                    if inner and "," not in inner.group(1):
+                        columns.append((inner.group(1).strip(), None, "UK"))
+                    continue
+                name = line.split()[0]
+                if name.upper() in ("PRIMARY", "FOREIGN", "UNIQUE", "CHECK"):
+                    continue
+                key = "PK" if "PRIMARY KEY" in line.upper() else ("UK" if " UNIQUE" in line.upper() else "")
+                columns.append((name, sql_type_token(line), key))
+
+                reference = re.search(r"REFERENCES\s+(\w+)", line, re.IGNORECASE)
+                if reference:
+                    optional = "NOT NULL" not in line.upper()
+                    cardinality = "||--o{" if not optional else "|o--o{"
+                    relations.append(f"    {reference.group(1)} {cardinality} {table} : \"\"")
+
+            merged = {}
+            for name, type_token, key in columns:
+                if name in merged:
+                    existing_type, existing_key = merged[name]
+                    merged[name] = (existing_type or type_token, existing_key or key)
+                else:
+                    merged[name] = (type_token, key)
+            tables[table] = merged
+
+    lines = ["erDiagram"]
+    lines.extend(sorted(set(relations)))
+    lines.append("")
+    for table, columns in tables.items():
+        lines.append(f"    {table} {{")
+        for name, (type_token, key) in columns.items():
+            lines.append(f"        {type_token or 'unknown'} {name}{(' ' + key) if key else ''}")
+        lines.append("    }")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- rendering
+
+def replace_region(text: str, marker: str, body: str) -> str:
+    """Replaces the content between a pair of markers, which may be empty on a first run."""
+    open_marker = f"<!-- generated:{marker} -->"
+    close_marker = f"<!-- /generated:{marker} -->"
+    pattern = re.compile(
+        "%s.*?%s" % (re.escape(open_marker), re.escape(close_marker)), re.DOTALL,
+    )
+    if not pattern.search(text):
+        raise SystemExit(f"marker {open_marker} not found in {README}")
+    replacement = f"{open_marker}\n```mermaid\n{body}\n```\n{close_marker}"
+    return pattern.sub(lambda _: replacement, text)
+
+
+def render(existing: str, types: dict) -> str:
+    updated = replace_region(existing, "context-map", context_map())
+    updated = replace_region(updated, "class-diagram", class_diagram(types, CLASS_DIAGRAM_CONTEXT))
+    return replace_region(updated, "er-diagram", er_diagram())
+
+
+def main() -> int:
+    check_only = "--check" in sys.argv
+    existing = README.read_text(encoding="utf-8")
+    updated = render(existing, discover_types())
+
+    if updated == existing:
+        print("diagrams are up to date")
+        return 0
+    if check_only:
+        print("ERROR: the generated diagrams in README.md no longer match the source they describe.")
+        print("Run: python docs/architecture/arch-diagrams/generate.py")
+        return 1
+    README.write_text(updated, encoding="utf-8")
+    print(f"regenerated the diagrams in {README.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -23,34 +23,8 @@ domain and application layers know nothing about HTTP, JPA or Spring's event bus
 arrives through an adapter. The boundaries are not a convention — they are checked on every build by
 an ArchUnit suite, which is the authority on what the layering permits.
 
-```mermaid
-flowchart LR
-    subgraph browser["Browser"]
-        spa["React SPA"]
-    end
-
-    subgraph edge["Frontend container"]
-        nginx["nginx<br/>static files + proxy"]
-    end
-
-    subgraph api["Backend container"]
-        rest["REST controllers"]
-        stomp["STOMP endpoint /ws"]
-        jobs["Scheduled jobs"]
-        core["Domain + application core"]
-    end
-
-    db[("PostgreSQL")]
-
-    spa -->|"HTTPS /api/**"| nginx
-    spa -->|"WebSocket /ws"| nginx
-    nginx -->|"proxy_pass"| rest
-    nginx -->|"proxy_pass, upgraded"| stomp
-    rest --> core
-    jobs --> core
-    core --> stomp
-    core -->|"JDBC"| db
-```
+> **Diagram:** [System context](arch-diagrams/README.md#1-system-context) — the three
+> processes, the browser, and what each connection carries.
 
 ---
 
@@ -139,20 +113,8 @@ overdue sweep, the daily check-in nudge, and the per-minute reminder dispatch.
 
 Derived from the imports, not from intent:
 
-```mermaid
-flowchart TD
-    auth --> user
-    tracking --> upgrade
-    reflection --> upgrade
-    reminder --> upgrade
-    dashboard --> upgrade
-    dashboard --> tracking
-    dashboard --> healtharea
-    notification --> upgrade
-    notification --> tracking
-    notification --> reflection
-    notification --> reminder
-```
+> **Diagram:** [Bounded-context map](arch-diagrams/README.md#2-bounded-context-map) —
+> generated from the imports, so it is what the code does rather than what was intended.
 
 `upgrade`, `user` and `healtharea` depend on no other context. The graph is acyclic, and ArchUnit
 fails the build if that stops being true.
@@ -171,38 +133,8 @@ way. ADR-002 records why.
 
 Recording a day's progress, which touches most of the machinery:
 
-```mermaid
-sequenceDiagram
-    participant B as Browser
-    participant N as nginx
-    participant F as JWT filter
-    participant C as ProgressController
-    participant S as TrackingService
-    participant U as UpgradeQuery (upgrade)
-    participant R as Repository port
-    participant DB as PostgreSQL
-    participant L as NotificationEventListener
-    participant W as STOMP adapter
-
-    B->>N: POST /api/upgrades/{id}/progress
-    N->>F: proxied
-    F->>F: validate JWT, load user, set security context
-    F->>C: request
-    C->>C: map request record to use-case input
-    C->>S: recordProgress(userId, upgradeId, details)
-    S->>U: getOwnedUpgrade(userId, upgradeId)
-    U->>DB: SELECT ... WHERE id = ? AND user_id = ?
-    S->>R: existsByUpgradeIdAndDate → duplicate guard
-    S->>S: evaluate entry against tracking config
-    S->>R: save(entry)
-    R->>DB: INSERT
-    S-->>L: ProgressEntryRecorded, StreakAchieved (on milestone)
-    Note over L: AFTER_COMMIT — nothing fires if the transaction rolls back
-    L->>DB: INSERT notification
-    L->>W: push
-    W-->>B: STOMP frame on /user/queue/notifications
-    C-->>B: 201 with the stored entry
-```
+> **Diagram:** [Request lifecycle](arch-diagrams/README.md#6-request-lifecycle) —
+> logging progress, from the browser through to the pushed notification.
 
 Three things in that flow are easy to miss:
 
@@ -229,21 +161,8 @@ every tracking configuration rather than one per upgrade.
 A `HealthUpgrade` is created as an `IDEA` and moves only through methods on the aggregate, each of
 which guards its transition:
 
-```mermaid
-stateDiagram-v2
-    [*] --> IDEA: create
-    IDEA --> PLANNED: plan
-    PLANNED --> ACTIVE: activate
-    ACTIVE --> PAUSED: pause
-    PAUSED --> ACTIVE: activate
-    ACTIVE --> COMPLETED: complete
-    IDEA --> ABANDONED: abandon
-    PLANNED --> ABANDONED: abandon
-    ACTIVE --> ABANDONED: abandon
-    PAUSED --> ABANDONED: abandon
-    ABANDONED --> PLANNED: reschedule
-    COMPLETED --> [*]
-```
+> **Diagram:** [The upgrade lifecycle](arch-diagrams/README.md#5-the-upgrade-lifecycle) —
+> every legal transition of the aggregate's state machine.
 
 `COMPLETED` is terminal. `ABANDONED` is not — rescheduling revives it. An upgrade occupies one of the
 three concurrent HARD slots only while `ACTIVE`, which is why the limit is checked both when activating
@@ -354,6 +273,7 @@ Stated because they are load-bearing, not because they are problems yet:
 
 | Question | Record |
 |---|---|
+| What does all of this look like? | [`arch-diagrams/`](arch-diagrams/README.md) — seven diagrams, outside in |
 | What is the system supposed to do, and what is it deliberately not doing? | [`docs/requirements/requirements.md`](../requirements/requirements.md) |
 | Why DDD + hexagonal at all, and why JPA entities as the domain model? | [ADR-001](../ADRs/ADR-001-ddd-hexagonal-architecture.md) |
 | Why the `upgrade`/`tracking` dependency is inverted; why events moved out of `common`; what the ten ArchUnit rules cover; what was rejected and when to revisit | [ADR-002](../ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md) |


### PR DESCRIPTION
## Problem

`architecture.md` described the system in prose with four diagrams scattered through it. There was no
single place to go and *see* the shape — and the context map in it was hand-drawn, so it recorded what
someone believed the dependency graph to be rather than what it was.

## Approach

`docs/architecture/arch-diagrams/README.md` is the page GitHub renders when you open the folder, so
landing there shows the whole architecture rendered rather than a list of filenames to click through.
That is the reason it is one page and not seven files.

Seven diagrams, ordered outside in:

| # | Diagram | Source |
|---|---|---|
| 1 | System context | Hand-written |
| 2 | Bounded-context map | **Generated** from the imports |
| 3 | How to read a context — the hexagon key | Hand-written |
| 4 | Inside `upgrade` — class diagram | **Generated** from the package layout |
| 5 | The upgrade lifecycle — state machine | Hand-written |
| 6 | Request lifecycle — sequence | Hand-written |
| 7 | Data model — ER | **Generated** from the Flyway migrations |

**The split is not arbitrary.** Three of these restate something the code already states, and would be
wrong on the next import, field or column — those are generated by `generate.py` into marked regions,
and CI fails when the committed output stops matching the source. The other three encode intent, which
no generator can derive and which does not rot.

Diagram 7 did not exist anywhere before: the schema had no picture at all.

## Trade-off accepted

**The four diagrams moved out of `architecture.md` rather than being copied,** so there is exactly one
source for each and the document links to them at the point each used to sit. The cost is that
`architecture.md` is now prose-only and a reader has to follow a link to see a picture. Copying was
the worse option: the context map in the folder is generated and the copy left behind would not be, so
they would diverge — which is the failure this whole change exists to prevent.

**The class diagram covers `upgrade` only, not all ten contexts.** One worked example plus the "how to
read a context" key teaches the shape well enough to read the other nine from the source. Ten
near-identical diagrams is scrolling, not understanding. If they turn out to be wanted, they belong in
a `per-context/` subfolder, linked but out of the reader's way.

**`generate.py` parses Java with regular expressions rather than a real parser.** That is adequate for
this codebase, which is uniform, and it keeps the tool dependency-free — but it is not a general Java
parser and would need care if the source got more exotic. Two bugs of exactly that kind were found and
fixed while building it, both listed below.

## How it was verified

- **The drift check can actually fail.** Adding a class to the `upgrade` context turns `--check` red;
  removing it turns it green. A guard that cannot fail is worse than no guard, so this was checked
  rather than assumed.
- Two generator bugs found by reading the output against the source, not by trusting it:
  - `UpgradeJpaRepository --|> HealthUpgrade : extends` — false. It extends
    `JpaRepository<HealthUpgrade, UUID>`; the type *argument* was being read as a supertype.
  - `progress_entries` showed `upgrade_id UK` and `date UK` as separate unique columns. The constraint
    is composite — `UNIQUE (upgrade_id, date)` — and claiming each is independently unique is a
    different, false statement. Mermaid has no composite notation, so single-column uniques are marked
    and composite ones are described in the prose beside the diagram.
  - Port packages were stamped `<<outbound port>>` for both the interface and the records passed across
    it; they are now distinguished as `<<outbound port>>`, `<<port record>>` and `<<use-case record>>`.
- `mvn test` passes; no production code changed.

## Note on what I could not verify

I have **not seen these rendered**. Mermaid syntax here is deliberately conservative and auto-laid-out,
so the risk is low, but if any block fails to parse it will show as an error box on GitHub rather than
a diagram. Worth a glance at the Files tab before merging — that is the one check I cannot do from
here.
