### PR TITLE
feat(frontend): dark mode via semantic colour tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,11 @@ jobs:
       - name: Lint frontend
         run: cd frontend && npm run lint
 
+      # Tailwind emits nothing for an unknown class and raises no error, so a mistyped or missed colour
+      # renders as no colour at all rather than failing. This is the only check that catches it.
+      - name: Check no palette colours bypass the theme tokens
+        run: cd frontend && npm run check:colours
+
       # After the lint, so a failure here is a behaviour failure rather than a style one. `npm run test`
       # is `vitest run` and not the watcher — a bare `vitest` would hold the runner until the job times
       # out. See ADR-004 for why the frontend has a test harness at all.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,12 @@ jobs:
       - name: Lint frontend
         run: cd frontend && npm run lint
 
+      # After the lint, so a failure here is a behaviour failure rather than a style one. `npm run test`
+      # is `vitest run` and not the watcher — a bare `vitest` would hold the runner until the job times
+      # out. See ADR-004 for why the frontend has a test harness at all.
+      - name: Test frontend
+        run: cd frontend && npm run test
+
       # Scoped to what ships. Auditing the dev tree here would redden every unrelated PR whenever an
       # advisory lands against the Vite or ESLint toolchain, none of which reaches a user's browser.
       - name: Audit shipped frontend dependencies for known vulnerabilities

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ backend/.mvn/wrapper/maven-wrapper.jar
 frontend/node_modules/
 frontend/dist/
 frontend/.vite/
+# Vitest and npx write a cache here when a command is run from the repo root by mistake.
+node_modules/
 
 # Environment
 .env

--- a/README.md
+++ b/README.md
@@ -269,11 +269,19 @@ mvn verify    # the above plus integration tests — needs a running PostgreSQL
 bean graph or a missing Flyway migration — neither of which a unit test can see. Start a database first
 with `docker-compose up -d postgres`.
 
-### Frontend Build (includes type check)
+### Frontend Tests
 ```bash
 cd frontend
-npm run build
+npm run test           # Vitest + jsdom + Testing Library
+npm run build          # type check and production build
+npm run lint           # ESLint, zero warnings tolerated
+npm run check:colours  # fails on any Tailwind palette colour used outside the theme tokens
 ```
+
+`npm run test` covers the theme provider — that an explicit choice beats the operating system, that
+`system` follows it live, that the media-query listener is cleaned up under `React.StrictMode`, and that
+a browser with storage blocked still boots. See
+[ADR-004](docs/ADRs/ADR-004-frontend-test-harness.md) for why the harness exists and what it cannot do.
 
 ## Environment Variables
 
@@ -297,7 +305,7 @@ npm run build
 - [ ] Gamification: achievements, badges, levels
 - [ ] Integration with wearables (steps, sleep data)
 - [ ] Weekly/monthly progress email reports
-- [ ] Dark mode
+- [x] Dark mode
 - [ ] Internationalization (i18n)
 
 ## Screenshots

--- a/docs/ADRs/ADR-004-frontend-test-harness.md
+++ b/docs/ADRs/ADR-004-frontend-test-harness.md
@@ -1,0 +1,134 @@
+# ADR-004: Test the frontend with Vitest, jsdom and Testing Library
+
+- **Status:** Accepted
+- **Date:** 2026-08-19
+- **Scope:** `frontend/` only. No effect on the backend, the runtime, or anything that ships to a
+  browser — every package added here is a development dependency.
+
+## Context
+
+[ADR-002](ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md) built a floor under
+the backend: an integration test that boots the application against a real PostgreSQL, ArchUnit rules
+that fail on a layering violation, and tests for the two services that had none. It left the frontend
+without an equivalent, and `docs/requirements/requirements.md` §6 has recorded that gap as an open
+question ever since:
+
+> **The frontend has no test runner.** No vitest, no jest. Frontend logic is currently verified only by
+> the type checker, the linter and inspection. Introducing one is a dependency decision that deserves
+> an ADR.
+
+This is that record.
+
+Until now the gap was tolerable because the frontend held almost no logic worth testing. Its
+components render server state that TanStack Query fetches, and the one piece of real behaviour —
+that the mirrored enums cannot drift from the backend's — is already enforced from the backend by
+`FrontendEnumContractTest`. Type checking and a zero-warning lint genuinely covered the rest.
+
+Dark mode changes that. `ThemeProvider` holds branching logic that no type can express and no reviewer
+can reliably eyeball:
+
+- an explicit choice must beat the operating system's preference, but only when it is explicit;
+- `system` must follow the OS **while the tab is open**, which means a `matchMedia` subscription with a
+  cleanup that `React.StrictMode` will exercise twice on every mount;
+- reading `localStorage` throws outright where site data is blocked, and there is no error boundary
+  above this provider, so an unguarded read blanks the whole application.
+
+Each of those is a small, pure, deterministic assertion. Each is also the kind of defect that ships
+green and surfaces months later on somebody else's machine.
+
+## Decision
+
+Add **Vitest** with **jsdom** and **Testing Library** as development dependencies, and run them in CI
+between the lint and the audit.
+
+Four packages, all `devDependencies`: `vitest`, `jsdom`, `@testing-library/react`,
+`@testing-library/dom`. Nothing reaches a user's browser, so `npm audit --omit=dev` — the audit scope
+ADR-002 chose deliberately — is unaffected.
+
+Four choices inside that decision are worth stating, because each has a failure mode:
+
+- **Vitest is pinned to `^3.2.7`, not `^4`.** Vitest 4 declares a peer dependency on Vite `^6 || ^7 ||
+  ^8`; this project is on Vite 5. Taking Vitest 4 would mean a Vite major upgrade riding along inside a
+  styling change. Vitest 3 depends on Vite `^5.0.0 || ^6.0.0 || ^7.0.0-0` and needs nothing moved.
+- **Configuration lives in `vitest.config.ts`, merged over `vite.config.ts` with `mergeConfig`.** A
+  `test` key inside `vite.config.ts` would make the production build configuration type-depend on a
+  development-only package. Keeping them separate without the merge is worse: Vitest reads
+  `vitest.config.ts` *instead of* `vite.config.ts` when both exist, so the React plugin and the dev
+  proxy would silently stop applying to tests. The merge is what keeps one source of truth.
+- **No globals.** `describe`, `it` and `expect` are imported in each test file rather than injected
+  ambiently. This leaves `tsconfig.json`'s `types` array — and therefore the production type check —
+  untouched, at the cost of one import line per file.
+- **Tests are colocated under `src/`, not in a separate tree.** `tsconfig.json` includes `src`, so
+  `tsc` type-checks the tests as part of `npm run build`. A test that no longer compiles is a broken
+  test and should redden the build.
+
+## Consequences
+
+**What this makes easy**
+
+- Frontend behaviour can be asserted rather than inspected. `requirements.md` entries covering the SPA
+  can now name a real test in their "Enforced by" column instead of naming a component and asking the
+  reader to trust it.
+- The provider's failure paths — blocked storage, absent `matchMedia`, an unrecognised stored value —
+  are exercised. None of them are reachable by clicking through the application.
+- StrictMode double-invocation is caught by a test that counts live media-query listeners, which is the
+  only practical way to notice a dropped effect cleanup.
+- The open question in `requirements.md` §6 closes.
+
+**What this makes hard**
+
+- **CI gains a step that can fail, and a slow one relative to the others.** That is the point, but the
+  frontend job is no longer "lint and build" and a flaky test would now block merges. There are none
+  today; keeping it that way is a standing obligation.
+- **Four more development dependencies to keep current**, and Vitest moves quickly. The pin to `^3`
+  will eventually need revisiting — see below.
+- **Type errors in test files redden the production build**, because `tsc` sees `src/**`. This is
+  deliberate, but it means a broken test cannot be left in the tree over a weekend.
+- **jsdom is not a browser.** It has no layout engine and no real rendering, so it cannot verify that a
+  colour meets a contrast ratio, that a focus ring is visible, or that anything is positioned where it
+  should be. Everything visual in this project still rests on inspection.
+
+**Neutral**
+
+- Nothing ships to the browser and no runtime behaviour changes.
+- `npm run build` is unchanged; the test run is a separate script and a separate CI step.
+
+## Alternatives considered
+
+- **No test runner — keep relying on `tsc`, ESLint and inspection.** The status quo, and defensible
+  right up until the frontend held logic. It does not survive `ThemeProvider`: no type expresses "an
+  explicit choice beats the OS preference", and no linter notices a missing `removeEventListener`.
+  **Revisit if** the frontend is ever reduced back to pure presentation, which is not a plausible
+  direction.
+
+- **Jest.** The most widely used option, and the one most contributors would recognise. Rejected
+  because it needs its own transform pipeline — `babel-jest` or `ts-jest` plus a module-resolution
+  configuration — duplicating what Vite already does, and that duplicate can drift from the real build
+  until a test passes against code that would not ship. Vitest reuses the project's actual Vite
+  configuration, so there is exactly one transform. **Revisit if** Vitest is abandoned upstream or the
+  project leaves Vite.
+
+- **Playwright, or any real-browser end-to-end runner.** Would catch what jsdom cannot: real rendering,
+  real `prefers-color-scheme` emulation, and therefore real contrast and focus-ring verification. Not
+  a substitute — it tests a different level, needs the backend and a database running, and is far too
+  slow to gate every push. **Revisit when** there is a user-visible regression that a unit test could
+  not have caught, or when the manual pass before each release becomes the bottleneck. At that point it
+  is an addition to this decision, not a replacement for it.
+
+- **Vitest browser mode** (`@vitest/browser` driving a real Chromium). Removes the jsdom caveat above
+  while keeping one runner. Rejected as premature: it needs a browser binary in CI, is materially
+  slower, and buys nothing for the pure-logic assertions this harness exists to make. **Revisit when**
+  a test genuinely needs layout or computed styles — the contrast checks are the obvious candidate.
+
+- **`@testing-library/jest-dom` for its matchers** (`toHaveClass`, `toBeInTheDocument`). Convenient and
+  near-universal. Rejected to keep the dependency count honest: the assertions this harness makes are
+  about `classList` and `localStorage`, which plain `expect` states just as clearly. **Revisit if**
+  component tests grow to the point where the matchers measurably improve their readability.
+
+## Note
+
+There is no accessibility or visual-regression gate in CI, and this ADR does not add one. Contrast
+ratios in the theme were computed by hand and are recorded in the pull request that introduced them;
+nothing re-checks them when a colour changes. That is a known gap, and the honest reason it stays open
+is that the tooling to close it (a real browser in CI) is the same tooling the browser-mode alternative
+above defers.

--- a/docs/ADRs/ADR-004-frontend-test-harness.md
+++ b/docs/ADRs/ADR-004-frontend-test-harness.md
@@ -50,6 +50,18 @@ Four choices inside that decision are worth stating, because each has a failure 
 - **Vitest is pinned to `^3.2.7`, not `^4`.** Vitest 4 declares a peer dependency on Vite `^6 || ^7 ||
   ^8`; this project is on Vite 5. Taking Vitest 4 would mean a Vite major upgrade riding along inside a
   styling change. Vitest 3 depends on Vite `^5.0.0 || ^6.0.0 || ^7.0.0-0` and needs nothing moved.
+- **jsdom is pinned to `^29`, not `^30`.** jsdom 30 declares `engines: ^22.22.2 || ^24.15.0 || >=26.0.0`
+  and pulls `undici@8`, which needs Node `>=22.19.0`. CI and the frontend Dockerfile both run Node 20,
+  so jsdom 30 installs with an `EBADENGINE` warning and then dies at import with
+  `webidl.util.markAsUncloneable is not a function` — an error that names nothing in this project and
+  appears only on the CI runner, never on a developer machine running a newer Node. jsdom 29 accepts
+  `^20.19.0 || ^22.13.0 || >=24.0.0`, which covers both. Same principle as the Vitest pin: the harness
+  bends to the project's runtime, not the other way round.
+
+  This one bit before it was understood — the CI test step was added and merged without ever running,
+  so the mismatch stayed invisible until the first pull request. **Node 20 reached end of life in April
+  2026**, so the real resolution is to move the whole toolchain, including `frontend/Dockerfile`, off
+  it; that is a deployment change and belongs in its own ADR rather than riding along here.
 - **Configuration lives in `vitest.config.ts`, merged over `vite.config.ts` with `mergeConfig`.** A
   `test` key inside `vite.config.ts` would make the production build configuration type-depend on a
   development-only package. Keeping them separate without the merge is worse: Vitest reads

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -202,8 +202,8 @@ Integration points a maintainer will need:
   different origins. The cron expressions are overridable per environment. `.env.example` lists them
   all with safe values.
 - **CI** — GitHub Actions on every push and PR to `main` and `dev`: the backend runs `mvn verify`
-  against a PostgreSQL service container, the frontend lints, audits its shipped dependencies and
-  builds.
+  against a PostgreSQL service container, the frontend lints, tests, audits its shipped dependencies
+  and builds.
 
 ---
 
@@ -277,6 +277,7 @@ Stated because they are load-bearing, not because they are problems yet:
 | What is the system supposed to do, and what is it deliberately not doing? | [`docs/requirements/requirements.md`](../requirements/requirements.md) |
 | Why DDD + hexagonal at all, and why JPA entities as the domain model? | [ADR-001](../ADRs/ADR-001-ddd-hexagonal-architecture.md) |
 | Why the `upgrade`/`tracking` dependency is inverted; why events moved out of `common`; what the ten ArchUnit rules cover; what was rejected and when to revisit | [ADR-002](../ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md) |
+| Why the frontend tests with Vitest rather than Jest; why Vitest is pinned to 3; why there is still no accessibility gate | [ADR-004](../ADRs/ADR-004-frontend-test-harness.md) |
 | Day-to-day conventions when changing backend code | [`backend/CLAUDE.md`](../../backend/CLAUDE.md) |
 | Day-to-day conventions when changing frontend code | [`frontend/CLAUDE.md`](../../frontend/CLAUDE.md) |
 | How to run, test and deploy it | [`README.md`](../../README.md) |

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -65,8 +65,8 @@ Nine contexts, each owning its own vocabulary, plus a cross-cutting `common`.
 | Module | Responsible for |
 |---|---|
 | `src/api/` | One axios instance and a thin function per endpoint. The instance attaches the JWT and turns a 401 into a logout; every call goes through it |
-| `src/contexts/` | `AuthProvider` owns the session; `NotificationProvider` owns the notification list, the STOMP connection and the toasts |
-| `src/hooks/` | `useAuth` and `useNotifications` — typed context readers that fail loudly outside their provider |
+| `src/contexts/` | `AuthProvider` owns the session; `NotificationProvider` owns the notification list, the STOMP connection and the toasts; `ThemeProvider` owns the light/dark/system choice and the `dark` class on `<html>` |
+| `src/hooks/` | `useAuth`, `useNotifications` and `useTheme` — typed context readers that fail loudly outside their provider |
 | `src/router/` | The route table, and `ProtectedRoute`, which gates every authenticated page |
 | `src/pages/` | One component per route |
 | `src/components/` | `ui/` primitives, `upgrade/` cards and badges, `notifications/` bell, dropdown, items and toasts, `layout/` navbar and sidebar |
@@ -246,6 +246,21 @@ returns 409. Nothing else is version-checked, because nothing else is edited fro
 
 **Exception to HTTP status is decided in exactly one class.** Controllers and services throw domain
 exceptions and never build a status by hand. The mapping is pinned by a test.
+
+**No component names a colour.** Every colour in the SPA is a semantic token — `bg-surface`,
+`text-fg-subtle`, `border-line-strong` — declared in `frontend/tailwind.config.js` and given its two
+values, once per theme, in `frontend/src/index.css`. Components name the *role*; the theme decides the
+value. The indirection is not decoration: Tailwind emits nothing for a class it does not recognise and
+raises no error, so a component that reached for a palette shade would render correctly in one theme
+and be invisible in the other, silently. `npm run check:colours` fails the build on any direct palette
+use, and is the only thing that catches it.
+
+Two consequences a maintainer would otherwise have to rediscover. Tokens hold **space-separated RGB
+channels**, not hex, because Tailwind's opacity modifier (`bg-overlay/50`) can only compose an alpha
+onto a variable in that form. And the `dark` class on `<html>` is set **twice** — once by a classic
+inline script in `index.html` that runs before the first paint, and thereafter by `ThemeProvider`. The
+two must agree on the storage key and the resolution rule; changing one alone reintroduces the flash
+the script exists to prevent.
 
 **The frontend's types are hand-written, not generated.** `src/types/index.ts` mirrors the backend's
 DTOs and enums by hand. The **enums** are checked: `FrontendEnumContractTest` reads that file and fails

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -91,6 +91,15 @@ nothing is shared between accounts.
 | FR-32 | Notifications arrive in real time on a connected client, and are readable afterwards regardless | `StompNotificationPushAdapter`, `NotificationService` |
 | FR-33 | A user can read their fifty most recent notifications, see an unread count, and mark one or all as read | `NotificationService` |
 
+### 2.7 Appearance
+
+| ID | Requirement | Enforced by |
+|---|---|---|
+| FR-34 | A user can set the interface to a light theme, a dark theme, or to follow the operating system | `ThemeToggle`, `ThemeToggle.test.tsx` |
+| FR-35 | A user who is following the operating system sees the interface change when that preference changes, without reloading | `ThemeProvider`, `ThemeProvider.test.tsx` |
+| FR-36 | A user's explicit choice overrides the operating system's preference until they change it | `ThemeProvider`, `ThemeProvider.test.tsx` |
+| FR-37 | The theme control is reachable before signing in | `LoginPage`, `RegisterPage` |
+
 ---
 
 ## 3. Business rules and invariants
@@ -134,6 +143,10 @@ nothing is shared between accounts.
 | NFR-13 | The whole stack starts with one command | `docker-compose up --build` |
 | NFR-14 | List endpoints resolve related data in batch rather than per row | `UpgradeWebMapper.toDtos`, `TrackingConfigQuery.findByUpgradeIds` |
 | NFR-15 | Time-dependent behaviour reads an injected clock, so it is testable and timezone-explicit | `Clock` bean, scheduler tests |
+| NFR-16 | A user's theme choice survives a reload and is applied before the first paint, so the page never flashes the wrong theme | the boot script in `frontend/index.html`, `ThemeProvider` |
+| NFR-17 | The interface remains usable where browser storage is blocked or `matchMedia` is unavailable | `ThemeProvider`, `ThemeProvider.test.tsx` |
+| NFR-18 | Every colour in the interface is a semantic token, so no component can hard-code one that survives a theme change | `frontend/scripts/check-colours.mjs`, `.github/workflows/ci.yml` |
+| NFR-19 | Text meets a 4.5:1 contrast ratio and control boundaries 3:1, in both themes | the token values in `frontend/src/index.css` — computed, not automatically re-checked; see §6 |
 
 ---
 

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -158,9 +158,10 @@ These are deliberate. Re-proposing one needs a reason that has changed.
 
 Undecided, and owned by the repository owner.
 
-- **The frontend has no test runner.** No vitest, no jest. Frontend logic is currently verified only by
-  the type checker, the linter and inspection. Introducing one is a dependency decision that deserves
-  an ADR.
+- **The frontend has no accessibility or visual-regression gate.** Contrast ratios in the theme were
+  computed by hand; nothing re-checks them when a colour changes, and jsdom cannot — it has no layout
+  engine. Closing this needs a real browser in CI; [ADR-004](../ADRs/ADR-004-frontend-test-harness.md)
+  records why that was deferred.
 - **The backend has no dependency vulnerability audit.** OWASP dependency-check needs an `NVD_API_KEY`
   secret; ADR-002 records why a check that cannot fail was judged worse than none.
 - **An unbindable request body returns 500 rather than 400** — tracked as

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -27,11 +27,16 @@ conventions to follow inside `frontend/`.
   `text-fg-subtle`, not `text-gray-500`. The tokens are declared in `tailwind.config.js` and given
   their light and dark values in `src/index.css`. `npm run check:colours` fails on any direct palette
   use and runs in CI — Tailwind itself emits nothing and reports nothing for an unrecognised class, so
-  a mistyped token renders as *no colour at all* rather than as an error.
+  a mistyped token renders as *no colour at all* rather than as an error. It covers everything in
+  Tailwind's `content` glob, `index.html` included, and matches named utilities only: an arbitrary
+  value like `bg-[#fff]` slips past it.
   - Adding a colour means adding a **role**, with both values, not reaching for a shade. If no existing
     role fits, the role is what is missing.
   - Check contrast when you add one: 4.5:1 for text, 3:1 for control boundaries, in both themes.
     Nothing re-checks this automatically.
   - The `dark` class on `<html>` is set by the inline boot script in `index.html` *and* by
     `ThemeProvider`. They must agree on the storage key (`theme`) and the resolution rule; changing one
-    alone brings back the flash of wrong theme on load.
+    alone brings back the flash of wrong theme on load. `src/contexts/bootScript.test.tsx` enforces
+    that agreement — it runs the shipped script verbatim and compares it against the provider across
+    every combination of stored choice and system preference, so drift fails the build instead of
+    shipping. Change the rule in both places, and the test will tell you if you missed one.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -16,5 +16,22 @@ conventions to follow inside `frontend/`.
   local React state.
 - **Auth** flows through `contexts/AuthContext.tsx` (the context object lives in `contexts/authContextValue.ts`)
   + `hooks/useAuth.ts`; routes are gated by `router/ProtectedRoute.tsx`. Routing is React Router 6.
+- **Theme** flows through `contexts/ThemeProvider.tsx` (context object in `contexts/themeContextValue.ts`)
+  + `hooks/useTheme.ts`, mounted outermost in `App.tsx` so the auth pages get it too. That split of the
+  `createContext` call into its own module is not stylistic: `react-refresh/only-export-components`
+  warns when a `.tsx` file exports a non-component value, and `npm run lint` runs `--max-warnings 0` in
+  CI. Follow it for any new context.
 - Shared TypeScript types (mirroring backend DTOs/enums, e.g. `UpgradeStatus`) live in `src/types/index.ts`.
 - Styling is Tailwind CSS; reusable primitives are in `src/components/ui/`.
+- **Colours are semantic tokens, never palette shades.** Write `bg-surface`, not `bg-white`;
+  `text-fg-subtle`, not `text-gray-500`. The tokens are declared in `tailwind.config.js` and given
+  their light and dark values in `src/index.css`. `npm run check:colours` fails on any direct palette
+  use and runs in CI — Tailwind itself emits nothing and reports nothing for an unrecognised class, so
+  a mistyped token renders as *no colour at all* rather than as an error.
+  - Adding a colour means adding a **role**, with both values, not reaching for a shade. If no existing
+    role fits, the role is what is missing.
+  - Check contrast when you add one: 4.5:1 for text, 3:1 for control boundaries, in both themes.
+    Nothing re-checks this automatically.
+  - The `dark` class on `<html>` is set by the inline boot script in `index.html` *and* by
+    `ThemeProvider`. They must agree on the storage key (`theme`) and the resolution rule; changing one
+    alone brings back the flash of wrong theme on load.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,31 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UpHealther</title>
+    <!--
+      Applies the saved theme before the first paint.
+
+      Deliberately a classic (non-module) inline script: Vite leaves it alone and the browser runs it
+      synchronously while parsing the head, so the `dark` class is on <html> before any pixel is drawn.
+      A type="module" script would be bundled and deferred until after parsing, and the page would
+      flash light before React could correct it.
+
+      Kept in step with ThemeProvider: same storage key, same three states, same resolution rule.
+    -->
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('theme');
+          var dark =
+            stored === 'dark' ||
+            (stored !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          document.documentElement.classList.toggle('dark', dark);
+        } catch (e) {
+          // Reading localStorage throws outright where storage is blocked, and matchMedia is absent in
+          // a few embedded webviews. Either way the page boots light and ThemeProvider applies the
+          // system preference on mount, one frame later — a flash, not a failure.
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,7 @@
         "eslint": "^8.55.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
-        "jsdom": "^30.0.1",
+        "jsdom": "^29.1.1",
         "postcss": "^8.4.32",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.2.2",
@@ -49,57 +49,55 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
-      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.3.0",
-        "@csstools/css-color-parser": "^4.1.10",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.5.2"
+        "@csstools/css-tokenizer": "^4.0.0"
       },
       "engines": {
-        "node": "^22.13.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
-      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.5.2"
+        "is-potential-custom-element-name": "^1.0.1"
       },
       "engines": {
-        "node": "^22.13.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -2720,21 +2718,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3834,39 +3817,39 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
-      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^6.0.5",
-        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
-        "@exodus/bytes": "^1.15.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.5.2",
+        "lru-cache": "^11.3.5",
         "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.2",
-        "undici": "^8.9.0",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^17.1.0",
+        "whatwg-url": "^16.0.1",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "canvas": "^3.2.3"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -5353,13 +5336,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -5613,18 +5596,18 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
-      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.15.1",
+        "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
         "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": "^22.14.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,8 @@
         "react-router-dom": "^6.22.0"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -25,10 +27,12 @@
         "eslint": "^8.55.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
+        "jsdom": "^30.0.1",
         "postcss": "^8.4.32",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.2.2",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0",
+        "vitest": "^3.2.7"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -42,6 +46,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -298,6 +355,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -344,6 +411,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -822,6 +1042,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1411,6 +1649,61 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1455,6 +1748,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1731,6 +2042,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1844,6 +2270,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1852,6 +2288,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -1929,6 +2375,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1999,6 +2455,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2053,6 +2519,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2068,6 +2551,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2179,6 +2672,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2199,6 +2706,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2216,6 +2752,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2230,6 +2783,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/didyoumean": {
@@ -2272,6 +2835,13 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2293,6 +2863,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2310,6 +2893,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -2588,6 +3178,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2596,6 +3196,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3016,6 +3626,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -3157,6 +3780,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3201,6 +3831,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3329,6 +4010,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3339,6 +4027,26 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3347,6 +4055,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3563,6 +4278,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3608,6 +4336,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3823,6 +4568,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -3888,6 +4661,13 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3951,6 +4731,16 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -4082,6 +4872,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -4127,6 +4930,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4146,6 +4956,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -4172,6 +4996,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -4221,6 +5065,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -4290,6 +5141,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -4338,6 +5203,56 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4349,6 +5264,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4409,6 +5350,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4519,6 +5470,163 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4533,6 +5641,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -4551,6 +5676,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "eslint": "^8.55.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "jsdom": "^30.0.1",
+    "jsdom": "^29.1.1",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,17 +6,21 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
+    "@stomp/stompjs": "^7.0.0",
+    "@tanstack/react-query": "^5.17.0",
+    "axios": "^1.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.0",
-    "@tanstack/react-query": "^5.17.0",
-    "@stomp/stompjs": "^7.0.0",
-    "axios": "^1.6.0"
+    "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -26,9 +30,11 @@
     "eslint": "^8.55.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "jsdom": "^30.0.1",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^3.2.7"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "check:colours": "node scripts/check-colours.mjs"
   },
   "dependencies": {
     "@stomp/stompjs": "^7.0.0",

--- a/frontend/scripts/check-colours.mjs
+++ b/frontend/scripts/check-colours.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Fails if any Tailwind palette colour is used directly in `src/`.
+ *
+ * Tailwind fails silently: `bg-surfce` emits no CSS and raises no error, so the element renders with no
+ * background at all — which on a dark canvas reads as a deliberate transparent panel rather than a
+ * mistake. There is no compiler for class names. This is the substitute.
+ *
+ * It catches the opposite mistake too: a literal `bg-white` reintroduced by a copy-paste would render
+ * correctly in light and be invisible against dark text. Colours belong in `src/index.css`, once per
+ * theme, and are reached through the semantic tokens declared in `tailwind.config.js`.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC = join(fileURLToPath(new URL('.', import.meta.url)), '..', 'src');
+
+const PALETTE = [
+  'slate', 'gray', 'zinc', 'neutral', 'stone', 'red', 'orange', 'amber', 'yellow', 'lime', 'green',
+  'emerald', 'teal', 'cyan', 'sky', 'blue', 'indigo', 'violet', 'purple', 'fuchsia', 'pink', 'rose',
+].join('|');
+
+/**
+ * Utility prefixes that take a colour, including the side-suffixed border forms.
+ *
+ * `border-t-blue-600` is in here deliberately: `LoadingSpinner` used exactly that shape, and a pattern
+ * anchored on `border-blue-600` walks straight past it.
+ */
+const PREFIX = '(?:bg|text|border|ring|ring-offset|divide|placeholder|from|via|to|decoration|outline|accent|caret|shadow|fill|stroke)(?:-[trblxyse])?';
+
+const NUMBERED = new RegExp(`\\b${PREFIX}-(?:${PALETTE})-\\d{2,3}\\b`, 'g');
+const NAMED = new RegExp(`\\b${PREFIX}-(?:white|black)\\b`, 'g');
+
+/** Every `.ts`/`.tsx` file under `src/`, depth-first. */
+const sourceFiles = (dir) =>
+  readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) return sourceFiles(path);
+    return /\.tsx?$/.test(path) ? [path] : [];
+  });
+
+const findings = sourceFiles(SRC).flatMap((path) =>
+  readFileSync(path, 'utf8')
+    .split('\n')
+    .flatMap((line, index) => {
+      const hits = [...line.matchAll(NUMBERED), ...line.matchAll(NAMED)].map((m) => m[0]);
+      return hits.length ? [`${relative(SRC, path)}:${index + 1}  ${[...new Set(hits)].join(', ')}`] : [];
+    }),
+);
+
+if (findings.length > 0) {
+  console.error('Palette colours used directly. Use a semantic token from tailwind.config.js instead:\n');
+  findings.forEach((f) => console.error(`  ${f}`));
+  console.error(`\n${findings.length} line(s).`);
+  process.exit(1);
+}
+
+console.log(`No palette colours in src/ — all ${sourceFiles(SRC).length} source files use tokens.`);

--- a/frontend/scripts/check-colours.mjs
+++ b/frontend/scripts/check-colours.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Fails if any Tailwind palette colour is used directly in `src/`.
+ * Fails if any Tailwind palette colour is used directly in the files Tailwind compiles.
  *
  * Tailwind fails silently: `bg-surfce` emits no CSS and raises no error, so the element renders with no
  * background at all — which on a dark canvas reads as a deliberate transparent panel rather than a
@@ -9,12 +9,22 @@
  * It catches the opposite mistake too: a literal `bg-white` reintroduced by a copy-paste would render
  * correctly in light and be invisible against dark text. Colours belong in `src/index.css`, once per
  * theme, and are reached through the semantic tokens declared in `tailwind.config.js`.
+ *
+ * Scope follows the `content` glob in `tailwind.config.js`, which is `index.html` as well as `src/`.
+ * A palette class in the HTML shell compiles exactly like one in a component, so checking only `src/`
+ * would leave a hole in the one guard that exists to have none.
+ *
+ * Known boundary: this matches named utilities, so arbitrary values (`bg-[#fff]`, `text-[rgb(0,0,0)]`)
+ * pass through. Nothing in the app uses that form, and a regex over arbitrary CSS would cost more in
+ * false positives than it buys.
  */
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const SRC = join(fileURLToPath(new URL('.', import.meta.url)), '..', 'src');
+const FRONTEND = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+const SRC = join(FRONTEND, 'src');
+const HTML_SHELL = join(FRONTEND, 'index.html');
 
 const PALETTE = [
   'slate', 'gray', 'zinc', 'neutral', 'stone', 'red', 'orange', 'amber', 'yellow', 'lime', 'green',
@@ -40,12 +50,17 @@ const sourceFiles = (dir) =>
     return /\.tsx?$/.test(path) ? [path] : [];
   });
 
-const findings = sourceFiles(SRC).flatMap((path) =>
+/** Everything Tailwind compiles class names out of: the HTML shell plus the component tree. */
+const compiledFiles = () => [HTML_SHELL, ...sourceFiles(SRC)];
+
+const findings = compiledFiles().flatMap((path) =>
   readFileSync(path, 'utf8')
     .split('\n')
     .flatMap((line, index) => {
       const hits = [...line.matchAll(NUMBERED), ...line.matchAll(NAMED)].map((m) => m[0]);
-      return hits.length ? [`${relative(SRC, path)}:${index + 1}  ${[...new Set(hits)].join(', ')}`] : [];
+      return hits.length
+        ? [`${relative(FRONTEND, path)}:${index + 1}  ${[...new Set(hits)].join(', ')}`]
+        : [];
     }),
 );
 
@@ -56,4 +71,4 @@ if (findings.length > 0) {
   process.exit(1);
 }
 
-console.log(`No palette colours in src/ — all ${sourceFiles(SRC).length} source files use tokens.`);
+console.log(`No palette colours — all ${compiledFiles().length} compiled files use tokens.`);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
+import { ThemeProvider } from './contexts/ThemeProvider';
 import AppRouter from './router';
 
 /**
@@ -20,17 +21,21 @@ const queryClient = new QueryClient({
 });
 
 /**
- * Application root: installs the query cache and the auth provider around the router.
+ * Application root: installs the theme, the query cache and the auth provider around the router.
  *
- * The order matters — auth reads through the query client, and everything the router renders needs
- * both.
+ * The order matters. Auth reads through the query client, and everything the router renders needs
+ * both. The theme sits outside them all because it depends on neither a session nor server state, and
+ * because the login and register pages render outside `Layout` but still inside `App` — which is what
+ * puts the theme toggle within reach before anyone has signed in.
  */
 const App: React.FC = () => (
-  <QueryClientProvider client={queryClient}>
-    <AuthProvider>
-      <AppRouter />
-    </AuthProvider>
-  </QueryClientProvider>
+  <ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <AppRouter />
+      </AuthProvider>
+    </QueryClientProvider>
+  </ThemeProvider>
 );
 
 export default App;

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -13,7 +13,7 @@ interface LayoutProps {
  * Applied by the router rather than by each page, so no authenticated page can be added without it.
  */
 const Layout: React.FC<LayoutProps> = ({ children }) => (
-  <div className="min-h-screen bg-gray-50 flex flex-col">
+  <div className="min-h-screen bg-canvas flex flex-col">
     <Navbar />
     <div className="flex flex-1">
       <Sidebar />

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -9,15 +9,15 @@ const Navbar: React.FC = () => {
   const { user, logout } = useAuth();
 
   return (
-    <nav className="bg-white border-b border-gray-200 h-16 flex items-center px-6 justify-between sticky top-0 z-30">
+    <nav className="bg-surface border-b border-line h-16 flex items-center px-6 justify-between sticky top-0 z-30">
       <Link to="/dashboard" className="flex items-center gap-2">
         <span className="text-2xl">💪</span>
-        <span className="font-bold text-gray-900 text-lg">UpHealther</span>
+        <span className="font-bold text-fg text-lg">UpHealther</span>
       </Link>
       <div className="flex items-center gap-3">
         <NotificationBell />
         {user && (
-          <span className="text-sm text-gray-600 hidden sm:block">
+          <span className="text-sm text-fg-subtle hidden sm:block">
             Hi, <span className="font-medium">{user.name}</span>
           </span>
         )}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -3,8 +3,9 @@ import { Link } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
 import Button from '../ui/Button';
 import NotificationBell from '../notifications/NotificationBell';
+import ThemeToggle from '../theme/ThemeToggle';
 
-/** Top bar: brand link home, the notification bell, the signed-in user's name, and logout. */
+/** Top bar: brand link home, the theme toggle, the notification bell, the signed-in user's name, and logout. */
 const Navbar: React.FC = () => {
   const { user, logout } = useAuth();
 
@@ -15,6 +16,7 @@ const Navbar: React.FC = () => {
         <span className="font-bold text-fg text-lg">UpHealther</span>
       </Link>
       <div className="flex items-center gap-3">
+        <ThemeToggle />
         <NotificationBell />
         {user && (
           <span className="text-sm text-fg-subtle hidden sm:block">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -32,7 +32,7 @@ const navItems: NavItem[] = [
  * reachable from the dashboard.
  */
 const Sidebar: React.FC = () => (
-  <aside className="w-60 bg-gray-50 border-r border-gray-200 min-h-full flex-shrink-0 hidden md:block">
+  <aside className="w-60 bg-surface border-r border-line min-h-full flex-shrink-0 hidden md:block">
     <nav className="py-4">
       {navItems.map((item) => (
         <NavLink
@@ -41,8 +41,8 @@ const Sidebar: React.FC = () => (
           className={({ isActive }) =>
             `flex items-center gap-3 px-4 py-2.5 text-sm font-medium transition-colors ${
               isActive
-                ? 'bg-blue-50 text-blue-700 border-r-2 border-blue-600'
-                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                ? 'bg-brand-soft text-brand-fg border-r-2 border-brand'
+                : 'text-fg-subtle hover:bg-muted hover:text-fg'
             }`
           }
         >

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -29,12 +29,12 @@ const NotificationBell: React.FC = () => {
     <div className="relative" ref={containerRef}>
       <button
         onClick={() => setOpen((o) => !o)}
-        className="relative w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors"
+        className="relative w-9 h-9 flex items-center justify-center rounded-full hover:bg-muted transition-colors"
         aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
       >
         <span className="text-xl">🔔</span>
         {unreadCount > 0 && (
-          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center rounded-full bg-red-500 text-white text-[10px] font-bold">
+          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center rounded-full bg-danger text-fg-inverted text-[10px] font-bold">
             {unreadCount > 9 ? '9+' : unreadCount}
           </span>
         )}

--- a/frontend/src/components/notifications/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown.tsx
@@ -29,13 +29,13 @@ const NotificationDropdown: React.FC<Props> = ({ onClose }) => {
   };
 
   return (
-    <div className="absolute right-0 mt-2 w-80 max-w-[calc(100vw-2rem)] bg-white rounded-xl border border-gray-200 shadow-xl z-50 overflow-hidden">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
-        <span className="font-semibold text-gray-800 text-sm">
-          Notifications{unreadCount > 0 && <span className="text-blue-600"> ({unreadCount})</span>}
+    <div className="absolute right-0 mt-2 w-80 max-w-[calc(100vw-2rem)] bg-surface rounded-xl border border-line shadow-xl z-50 overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-line-subtle">
+        <span className="font-semibold text-fg-muted text-sm">
+          Notifications{unreadCount > 0 && <span className="text-brand-fg"> ({unreadCount})</span>}
         </span>
         {unreadCount > 0 && (
-          <button onClick={markAllRead} className="text-xs text-blue-600 hover:underline">
+          <button onClick={markAllRead} className="text-xs text-brand-fg hover:underline">
             Mark all read
           </button>
         )}
@@ -44,15 +44,15 @@ const NotificationDropdown: React.FC<Props> = ({ onClose }) => {
       {desktopPermission === 'default' && (
         <button
           onClick={requestDesktopPermission}
-          className="w-full text-left px-4 py-2 text-xs text-blue-700 bg-blue-50 hover:bg-blue-100 border-b border-gray-100"
+          className="w-full text-left px-4 py-2 text-xs text-brand-fg bg-brand-soft hover:bg-brand-soft-hover border-b border-line-subtle"
         >
           🔔 Enable desktop notifications
         </button>
       )}
 
-      <div className="max-h-96 overflow-y-auto divide-y divide-gray-100">
+      <div className="max-h-96 overflow-y-auto divide-y divide-line-subtle">
         {recent.length === 0 ? (
-          <p className="text-sm text-gray-500 text-center py-8">No notifications yet.</p>
+          <p className="text-sm text-fg-subtle text-center py-8">No notifications yet.</p>
         ) : (
           recent.map((n) => <NotificationItem key={n.id} notification={n} onSelect={select} />)
         )}
@@ -60,7 +60,7 @@ const NotificationDropdown: React.FC<Props> = ({ onClose }) => {
 
       <button
         onClick={() => { onClose(); navigate('/notifications'); }}
-        className="w-full text-center px-4 py-2.5 text-sm font-medium text-blue-600 hover:bg-gray-50 border-t border-gray-100"
+        className="w-full text-center px-4 py-2.5 text-sm font-medium text-brand-fg hover:bg-sunken border-t border-line-subtle"
       >
         View all notifications
       </button>

--- a/frontend/src/components/notifications/NotificationItem.tsx
+++ b/frontend/src/components/notifications/NotificationItem.tsx
@@ -23,16 +23,16 @@ const NotificationItem: React.FC<Props> = ({ notification, onSelect }) => {
   return (
     <button
       onClick={() => onSelect(notification)}
-      className={`w-full text-left flex gap-3 p-3 transition-colors hover:bg-gray-50 ${notification.read ? '' : 'bg-blue-50/50'}`}
+      className={`w-full text-left flex gap-3 p-3 transition-colors hover:bg-sunken ${notification.read ? '' : 'bg-brand-soft/50'}`}
     >
       <span className="text-lg leading-none mt-0.5">{meta.icon}</span>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <p className="text-sm font-medium text-gray-900 truncate">{notification.title}</p>
-          {!notification.read && <span className="w-2 h-2 rounded-full bg-blue-500 shrink-0" aria-label="unread" />}
+          <p className="text-sm font-medium text-fg truncate">{notification.title}</p>
+          {!notification.read && <span className="w-2 h-2 rounded-full bg-brand shrink-0" aria-label="unread" />}
         </div>
-        {notification.message && <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">{notification.message}</p>}
-        <p className="text-[11px] text-gray-400 mt-1">{relativeTime(notification.createdAt)}</p>
+        {notification.message && <p className="text-xs text-fg-subtle mt-0.5 line-clamp-2">{notification.message}</p>}
+        <p className="text-[11px] text-fg-faint mt-1">{relativeTime(notification.createdAt)}</p>
       </div>
     </button>
   );

--- a/frontend/src/components/notifications/ToastContainer.tsx
+++ b/frontend/src/components/notifications/ToastContainer.tsx
@@ -43,7 +43,7 @@ const ToastContainer: React.FC<Props> = ({ toasts, onDismiss }) => {
             key={t.id}
             role="status"
             aria-live="polite"
-            className={`${meta.bg} ${meta.ring} border rounded-xl shadow-lg p-3 flex items-start gap-2 animate-fade-in`}
+            className={`${meta.bg} ${meta.border} border rounded-xl shadow-lg p-3 flex items-start gap-2 animate-fade-in`}
           >
             <button
               type="button"
@@ -56,13 +56,13 @@ const ToastContainer: React.FC<Props> = ({ toasts, onDismiss }) => {
               <span className="text-lg leading-none mt-0.5">{meta.icon}</span>
               <span className="flex-1 min-w-0">
                 <span className={`block text-sm font-semibold ${meta.text} truncate`}>{t.title}</span>
-                {t.message && <span className="block text-xs text-gray-600 mt-0.5 line-clamp-2">{t.message}</span>}
+                {t.message && <span className="block text-xs text-fg-subtle mt-0.5 line-clamp-2">{t.message}</span>}
               </span>
             </button>
             <button
               type="button"
               onClick={() => onDismiss(t.id)}
-              className="text-gray-400 hover:text-gray-600 text-lg leading-none shrink-0"
+              className="text-fg-faint hover:text-fg-subtle text-lg leading-none shrink-0"
               aria-label="Dismiss notification"
             >
               &times;

--- a/frontend/src/components/notifications/ToastContainer.tsx
+++ b/frontend/src/components/notifications/ToastContainer.tsx
@@ -43,7 +43,7 @@ const ToastContainer: React.FC<Props> = ({ toasts, onDismiss }) => {
             key={t.id}
             role="status"
             aria-live="polite"
-            className={`${meta.bg} ${meta.ring} border rounded-xl shadow-lg p-3 flex items-start gap-2 animate-[fadeIn_0.2s_ease-out]`}
+            className={`${meta.bg} ${meta.ring} border rounded-xl shadow-lg p-3 flex items-start gap-2 animate-fade-in`}
           >
             <button
               type="button"

--- a/frontend/src/components/notifications/notificationMeta.test.ts
+++ b/frontend/src/components/notifications/notificationMeta.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { relativeTime } from './notificationMeta';
+
+/**
+ * `relativeTime` reads `Date.now()`, so the clock is frozen rather than the assertions loosened —
+ * otherwise a test straddling a minute boundary fails once in a while and teaches everyone to re-run.
+ */
+const NOW = new Date('2026-08-19T12:00:00.000Z');
+
+/** Offsets from {@link NOW}, expressed the way the function's thresholds are. */
+const secondsAgo = (seconds: number) => new Date(NOW.getTime() - seconds * 1000).toISOString();
+const minutesAgo = (minutes: number) => secondsAgo(minutes * 60);
+const hoursAgo = (hours: number) => minutesAgo(hours * 60);
+const daysAgo = (days: number) => hoursAgo(days * 24);
+
+describe('relativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('GivenATimestampUnderAMinuteOld_WhenFormatted_ThenItReadsJustNow', () => {
+    expect(relativeTime(secondsAgo(30))).toBe('just now');
+  });
+
+  it('GivenATimestampOfExactlyOneMinute_WhenFormatted_ThenItReadsInMinutes', () => {
+    expect(relativeTime(minutesAgo(1))).toBe('1m ago');
+  });
+
+  it('GivenATimestampOfHours_WhenFormatted_ThenItReadsInHours', () => {
+    expect(relativeTime(hoursAgo(3))).toBe('3h ago');
+  });
+
+  it('GivenATimestampOfDays_WhenFormatted_ThenItReadsInDays', () => {
+    expect(relativeTime(daysAgo(2))).toBe('2d ago');
+  });
+
+  it('GivenATimestampOverAWeekOld_WhenFormatted_ThenItFallsBackToALocaleDate', () => {
+    const iso = daysAgo(30);
+
+    expect(relativeTime(iso)).toBe(new Date(iso).toLocaleDateString());
+  });
+
+  it('GivenATimestampInTheFuture_WhenFormatted_ThenItReadsJustNow', () => {
+    expect(relativeTime(new Date(NOW.getTime() + 60_000).toISOString())).toBe('just now');
+  });
+});

--- a/frontend/src/components/notifications/notificationMeta.ts
+++ b/frontend/src/components/notifications/notificationMeta.ts
@@ -1,11 +1,18 @@
 import type { NotificationCategory } from '../../types';
 
-/** Icon + Tailwind classes per notification category, shared by the toast, dropdown and list. */
-export const categoryMeta: Record<NotificationCategory, { icon: string; bg: string; ring: string; text: string }> = {
-  INFO: { icon: 'ℹ️', bg: 'bg-blue-50', ring: 'border-blue-200', text: 'text-blue-700' },
-  SUCCESS: { icon: '✅', bg: 'bg-green-50', ring: 'border-green-200', text: 'text-green-700' },
-  WARNING: { icon: '⚠️', bg: 'bg-red-50', ring: 'border-red-200', text: 'text-red-700' },
-  REMINDER: { icon: '⏰', bg: 'bg-orange-50', ring: 'border-orange-200', text: 'text-orange-700' },
+/**
+ * Icon + token classes per notification category, shared by the toast, dropdown and list.
+ *
+ * Each category owns a hue that means only that category. WARNING is amber rather than red, so a
+ * warning cannot be mistaken for a failure; REMINDER is violet rather than orange, so it cannot be
+ * mistaken for a streak celebration; INFO is cyan rather than the brand blue the sidebar's active
+ * state already uses.
+ */
+export const categoryMeta: Record<NotificationCategory, { icon: string; bg: string; border: string; text: string }> = {
+  INFO: { icon: 'ℹ️', bg: 'bg-info-soft', border: 'border-info-line', text: 'text-info-fg' },
+  SUCCESS: { icon: '✅', bg: 'bg-success-soft', border: 'border-success-line', text: 'text-success-fg' },
+  WARNING: { icon: '⚠️', bg: 'bg-warning-soft', border: 'border-warning-line', text: 'text-warning-fg' },
+  REMINDER: { icon: '⏰', bg: 'bg-reminder-soft', border: 'border-reminder-line', text: 'text-reminder-fg' },
 };
 
 /**

--- a/frontend/src/components/theme/ThemeToggle.test.tsx
+++ b/frontend/src/components/theme/ThemeToggle.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../contexts/ThemeProvider';
+import ThemeToggle from './ThemeToggle';
+import { installMatchMedia } from '../../test/matchMediaStub';
+
+const renderToggle = () =>
+  render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>,
+  );
+
+const isDark = () => document.documentElement.classList.contains('dark');
+
+describe('ThemeToggle', () => {
+  it('GivenAnyTheme_WhenTheToggleRenders_ThenTheGroupIsNamedTheme', () => {
+    renderToggle();
+
+    expect(screen.getByRole('group', { name: 'Theme' })).toBeDefined();
+  });
+
+  it('GivenAnyTheme_WhenTheToggleRenders_ThenAllThreeChoicesArePresent', () => {
+    renderToggle();
+
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+  });
+
+  it('GivenTheSystemTheme_WhenTheToggleRenders_ThenTheSystemRadioIsChecked', () => {
+    renderToggle();
+
+    const system = screen.getByRole('radio', { name: /System/ }) as HTMLInputElement;
+    expect(system.checked).toBe(true);
+  });
+
+  it('GivenAStoredDarkTheme_WhenTheToggleRenders_ThenTheDarkRadioIsChecked', () => {
+    localStorage.setItem('theme', 'dark');
+
+    renderToggle();
+
+    expect((screen.getByRole('radio', { name: 'Dark' }) as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByRole('radio', { name: /System/ }) as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('GivenTheLightTheme_WhenTheDarkOptionIsSelected_ThenTheDocumentGainsTheDarkClass', () => {
+    localStorage.setItem('theme', 'light');
+    renderToggle();
+    expect(isDark()).toBe(false);
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Dark' }));
+
+    expect(isDark()).toBe(true);
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  // "System" alone tells a screen-reader user the rule but not the outcome — which is the one thing
+  // they cannot otherwise perceive, since the outcome is conveyed purely by colour.
+  it('GivenTheSystemThemeResolvingToDark_WhenTheToggleRenders_ThenTheSystemOptionNamesTheResolvedTheme', () => {
+    installMatchMedia(true);
+
+    renderToggle();
+
+    expect(screen.getByRole('radio', { name: 'System (currently dark)' })).toBeDefined();
+  });
+
+  it('GivenTheSystemThemeResolvingToLight_WhenTheToggleRenders_ThenTheSystemOptionNamesTheResolvedTheme', () => {
+    installMatchMedia(false);
+
+    renderToggle();
+
+    expect(screen.getByRole('radio', { name: 'System (currently light)' })).toBeDefined();
+  });
+
+  it('GivenAnExplicitTheme_WhenTheSystemOptionIsSelected_ThenTheDocumentFollowsTheOperatingSystem', () => {
+    localStorage.setItem('theme', 'light');
+    installMatchMedia(true);
+    renderToggle();
+    expect(isDark()).toBe(false);
+
+    fireEvent.click(screen.getByRole('radio', { name: /System/ }));
+
+    expect(isDark()).toBe(true);
+  });
+});

--- a/frontend/src/components/theme/ThemeToggle.tsx
+++ b/frontend/src/components/theme/ThemeToggle.tsx
@@ -64,7 +64,7 @@ const ThemeToggle: React.FC = () => {
     <fieldset className="flex items-center gap-0.5 rounded-full bg-muted p-0.5">
       <legend className="sr-only">Theme</legend>
       {options.map((option) => (
-        <label key={option.value} title={option.label} className="cursor-pointer">
+        <label key={option.value} title={option.label} className="group cursor-pointer">
           <input
             type="radio"
             name="theme"
@@ -73,7 +73,19 @@ const ThemeToggle: React.FC = () => {
             onChange={() => setTheme(option.value)}
             className="peer sr-only"
           />
-          <span className="flex w-8 h-8 items-center justify-center rounded-full text-fg-subtle transition-colors peer-hover:text-fg peer-checked:bg-brand peer-checked:text-fg-inverted peer-focus-visible:ring-2 peer-focus-visible:ring-focus peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-muted">
+          {/*
+            Hover is `group-*` while everything else is `peer-*`, and the difference is not arbitrary.
+            The peer here is the input, which is `sr-only` — a 1px clipped box behind the icon — so a
+            pointer never reaches it and `peer-hover` would be dead style. Checked and focus-visible are
+            states of the input itself, so those stay on the peer.
+
+            `peer-checked:group-hover:text-fg-inverted` looks redundant and is kept deliberately.
+            Tailwind happens to emit `peer-checked` after `group-hover`, so the selected pill would hold
+            its inverted text on hover anyway — but that is an ordering internal to Tailwind, not a
+            guarantee, and if it ever changed the only symptom would be dark-on-blue text nobody thought
+            to test. Stating the combination pins it.
+          */}
+          <span className="flex w-8 h-8 items-center justify-center rounded-full text-fg-subtle transition-colors group-hover:text-fg peer-checked:bg-brand peer-checked:text-fg-inverted peer-checked:group-hover:text-fg-inverted peer-focus-visible:ring-2 peer-focus-visible:ring-focus peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-muted">
             {option.icon}
             <span className="sr-only">
               {option.value === 'system' ? `${option.label} (currently ${resolvedTheme})` : option.label}

--- a/frontend/src/components/theme/ThemeToggle.tsx
+++ b/frontend/src/components/theme/ThemeToggle.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { useTheme } from '../../hooks/useTheme';
+import type { Theme } from '../../contexts/themeContextValue';
+
+/**
+ * Shared icon attributes.
+ *
+ * `stroke="currentColor"` is the point: an SVG icon inherits the token colour and therefore follows the
+ * theme it switches, where an emoji glyph carries its own fixed colours and cannot.
+ */
+const iconProps = {
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.8,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  className: 'w-4 h-4',
+  'aria-hidden': true,
+};
+
+const SunIcon: React.FC = () => (
+  <svg {...iconProps}>
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+  </svg>
+);
+
+const MonitorIcon: React.FC = () => (
+  <svg {...iconProps}>
+    <rect x="2" y="4" width="20" height="13" rx="2" />
+    <path d="M8 21h8M12 17v4" />
+  </svg>
+);
+
+const MoonIcon: React.FC = () => (
+  <svg {...iconProps}>
+    <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />
+  </svg>
+);
+
+/** The three states in increasing darkness, so the control reads as a scale rather than a menu. */
+const options: { value: Theme; label: string; icon: React.ReactNode }[] = [
+  { value: 'light', label: 'Light', icon: <SunIcon /> },
+  { value: 'system', label: 'System', icon: <MonitorIcon /> },
+  { value: 'dark', label: 'Dark', icon: <MoonIcon /> },
+];
+
+/**
+ * Three-state theme control: light, system, dark.
+ *
+ * Native radio inputs rather than buttons with ARIA. A radio group is what this is, and the real
+ * element brings arrow-key navigation, the group relationship and the "2 of 3, selected" announcement
+ * with it — none of which comes free from three buttons. The inputs are `sr-only`, which clips them
+ * visually while leaving them focusable and operable.
+ *
+ * The System option names what it currently resolves to, because "System" alone gives a screen-reader
+ * user the rule but not the outcome — and the outcome is otherwise conveyed by colour alone.
+ */
+const ThemeToggle: React.FC = () => {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+
+  return (
+    <fieldset className="flex items-center gap-0.5 rounded-full bg-muted p-0.5">
+      <legend className="sr-only">Theme</legend>
+      {options.map((option) => (
+        <label key={option.value} title={option.label} className="cursor-pointer">
+          <input
+            type="radio"
+            name="theme"
+            value={option.value}
+            checked={theme === option.value}
+            onChange={() => setTheme(option.value)}
+            className="peer sr-only"
+          />
+          <span className="flex w-8 h-8 items-center justify-center rounded-full text-fg-subtle transition-colors peer-hover:text-fg peer-checked:bg-brand peer-checked:text-fg-inverted peer-focus-visible:ring-2 peer-focus-visible:ring-focus peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-muted">
+            {option.icon}
+            <span className="sr-only">
+              {option.value === 'system' ? `${option.label} (currently ${resolvedTheme})` : option.label}
+            </span>
+          </span>
+        </label>
+      ))}
+    </fieldset>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -1,17 +1,20 @@
 import React from 'react';
 
+/** The fixed set of badge colours. Exported so the maps that choose one cannot drift from it. */
+export type BadgeVariant = 'green' | 'yellow' | 'blue' | 'red' | 'gray' | 'purple';
+
 /**
  * @param variant colour scheme; the palette is fixed so badges stay consistent across the app
  * @param children the label
  * @param className extra classes appended after the variant's, so they win on conflict
  */
 interface BadgeProps {
-  variant?: 'green' | 'yellow' | 'blue' | 'red' | 'gray' | 'purple';
+  variant?: BadgeVariant;
   children: React.ReactNode;
   className?: string;
 }
 
-const variantClasses: Record<NonNullable<BadgeProps['variant']>, string> = {
+const variantClasses: Record<BadgeVariant, string> = {
   green: 'bg-tint-green-soft text-tint-green-fg',
   yellow: 'bg-tint-yellow-soft text-tint-yellow-fg',
   blue: 'bg-tint-blue-soft text-tint-blue-fg',

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -11,13 +11,13 @@ interface BadgeProps {
   className?: string;
 }
 
-const variantClasses: Record<string, string> = {
-  green: 'bg-green-100 text-green-800',
-  yellow: 'bg-yellow-100 text-yellow-800',
-  blue: 'bg-blue-100 text-blue-800',
-  red: 'bg-red-100 text-red-800',
-  gray: 'bg-gray-100 text-gray-700',
-  purple: 'bg-purple-100 text-purple-800',
+const variantClasses: Record<NonNullable<BadgeProps['variant']>, string> = {
+  green: 'bg-tint-green-soft text-tint-green-fg',
+  yellow: 'bg-tint-yellow-soft text-tint-yellow-fg',
+  blue: 'bg-tint-blue-soft text-tint-blue-fg',
+  red: 'bg-tint-red-soft text-tint-red-fg',
+  gray: 'bg-muted text-fg-muted',
+  purple: 'bg-tint-purple-soft text-tint-purple-fg',
 };
 
 /** Small rounded label used for statuses, types and difficulties. */

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -17,10 +17,10 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const variantClasses: Record<string, string> = {
-  primary: 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500',
-  secondary: 'bg-gray-100 text-gray-800 hover:bg-gray-200 focus:ring-gray-400',
-  danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
-  ghost: 'bg-transparent text-gray-600 hover:bg-gray-100 focus:ring-gray-400',
+  primary: 'bg-brand text-fg-inverted hover:bg-brand-hover',
+  secondary: 'bg-muted text-fg-muted hover:bg-muted-strong',
+  danger: 'bg-danger text-fg-inverted hover:bg-danger-hover',
+  ghost: 'bg-transparent text-fg-subtle hover:bg-muted',
 };
 
 const sizeClasses: Record<string, string> = {

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -10,11 +10,11 @@ interface CardProps {
   className?: string;
 }
 
-/** White panel with an optional header. The standard container for a section of a page. */
+/** Themed panel with an optional header. The standard container for a section of a page. */
 const Card: React.FC<CardProps> = ({ children, header, className = '' }) => (
-  <div className={`bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden ${className}`}>
+  <div className={`bg-surface rounded-xl shadow-sm border border-line overflow-hidden ${className}`}>
     {header && (
-      <div className="px-6 py-4 border-b border-gray-200 font-semibold text-gray-800">
+      <div className="px-6 py-4 border-b border-line font-semibold text-fg-muted">
         {header}
       </div>
     )}

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -22,8 +22,8 @@ interface EmptyStateProps {
 const EmptyState: React.FC<EmptyStateProps> = ({ icon = '📭', title, description, action }) => (
   <div className="flex flex-col items-center justify-center py-16 text-center">
     <div className="text-5xl mb-4">{icon}</div>
-    <h3 className="text-lg font-semibold text-gray-800 mb-1">{title}</h3>
-    {description && <p className="text-sm text-gray-500 mb-4 max-w-sm">{description}</p>}
+    <h3 className="text-lg font-semibold text-fg-muted mb-1">{title}</h3>
+    {description && <p className="text-sm text-fg-subtle mb-4 max-w-sm">{description}</p>}
     {action && <div>{action}</div>}
   </div>
 );

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -24,18 +24,18 @@ const Input: React.FC<InputProps> = ({ label, error, id, className = '', ...rest
   return (
     <div className="flex flex-col gap-1">
       {label && (
-        <label htmlFor={inputId} className="text-sm font-medium text-gray-700">
+        <label htmlFor={inputId} className="text-sm font-medium text-fg-muted">
           {label}
         </label>
       )}
       <input
         id={inputId}
-        className={`rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-          error ? 'border-red-500 focus:ring-red-400' : 'border-gray-300'
+        className={`rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 ${
+          error ? 'border-danger focus:ring-danger' : 'border-line-strong'
         } ${className}`}
         {...rest}
       />
-      {error && <p className="text-xs text-red-500">{error}</p>}
+      {error && <p className="text-xs text-danger-fg">{error}</p>}
     </div>
   );
 };

--- a/frontend/src/components/ui/LoadingSpinner.tsx
+++ b/frontend/src/components/ui/LoadingSpinner.tsx
@@ -11,7 +11,7 @@ const sizeMap = { sm: 'h-4 w-4', md: 'h-8 w-8', lg: 'h-12 w-12' };
 const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ size = 'md' }) => (
   <div className="flex items-center justify-center">
     <div
-      className={`${sizeMap[size]} animate-spin rounded-full border-2 border-gray-300 border-t-blue-600`}
+      className={`${sizeMap[size]} animate-spin rounded-full border-2 border-line-strong border-t-brand`}
     />
   </div>
 );

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -33,13 +33,13 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
-      <div className="relative z-10 w-full max-w-lg rounded-xl bg-white shadow-xl mx-4">
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-800">{title}</h2>
+      <div className="absolute inset-0 bg-overlay/50" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-lg rounded-xl bg-surface border border-line-strong shadow-xl mx-4">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-line">
+          <h2 className="text-lg font-semibold text-fg-muted">{title}</h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 text-2xl leading-none"
+            className="text-fg-faint hover:text-fg-subtle text-2xl leading-none"
             aria-label="Close modal"
           >
             &times;

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -15,8 +15,8 @@ interface PageHeaderProps {
 const PageHeader: React.FC<PageHeaderProps> = ({ title, subtitle, action }) => (
   <div className="flex items-start justify-between mb-6">
     <div>
-      <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
-      {subtitle && <p className="mt-1 text-sm text-gray-500">{subtitle}</p>}
+      <h1 className="text-2xl font-bold text-fg">{title}</h1>
+      {subtitle && <p className="mt-1 text-sm text-fg-subtle">{subtitle}</p>}
     </div>
     {action && <div>{action}</div>}
   </div>

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -25,14 +25,14 @@ const Select: React.FC<SelectProps> = ({ label, options, error, id, className = 
   return (
     <div className="flex flex-col gap-1">
       {label && (
-        <label htmlFor={selectId} className="text-sm font-medium text-gray-700">
+        <label htmlFor={selectId} className="text-sm font-medium text-fg-muted">
           {label}
         </label>
       )}
       <select
         id={selectId}
-        className={`rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white ${
-          error ? 'border-red-500 focus:ring-red-400' : 'border-gray-300'
+        className={`rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 bg-surface ${
+          error ? 'border-danger focus:ring-danger' : 'border-line-strong'
         } ${className}`}
         {...rest}
       >
@@ -42,7 +42,7 @@ const Select: React.FC<SelectProps> = ({ label, options, error, id, className = 
           </option>
         ))}
       </select>
-      {error && <p className="text-xs text-red-500">{error}</p>}
+      {error && <p className="text-xs text-danger-fg">{error}</p>}
     </div>
   );
 };

--- a/frontend/src/components/upgrade/UpgradeCard.tsx
+++ b/frontend/src/components/upgrade/UpgradeCard.tsx
@@ -5,6 +5,7 @@ import UpgradeStatusBadge from './UpgradeStatusBadge';
 import UpgradeTypeBadge from './UpgradeTypeBadge';
 import Badge from '../ui/Badge';
 import Button from '../ui/Button';
+import { difficultyVariant, UNKNOWN_DIFFICULTY_VARIANT } from './upgradeMeta';
 
 /**
  * @param upgrade        the upgrade to show
@@ -18,13 +19,6 @@ interface Props {
   showActions?: boolean;
 }
 
-/** Difficulty to badge colour: green through red, so HARD reads as the demanding one. */
-const difficultyVariant: Record<string, 'green' | 'yellow' | 'red'> = {
-  EASY: 'green',
-  MEDIUM: 'yellow',
-  HARD: 'red',
-};
-
 /**
  * Summary card for one upgrade, with the transitions that are legal from its current status.
  *
@@ -36,27 +30,27 @@ const UpgradeCard: React.FC<Props> = ({ upgrade, onStatusChange, showActions = t
   const navigate = useNavigate();
 
   return (
-    <div className="bg-white rounded-xl border border-gray-200 p-4 shadow-sm hover:shadow-md transition-shadow">
+    <div className="bg-surface rounded-xl border border-line p-4 shadow-sm hover:shadow-md transition-shadow">
       <div className="flex items-start justify-between gap-2">
         <div className="flex-1 min-w-0">
           <h3
-            className="font-semibold text-gray-900 truncate cursor-pointer hover:text-blue-600"
+            className="font-semibold text-fg truncate cursor-pointer hover:text-brand-fg"
             onClick={() => navigate(`/upgrades/${upgrade.id}`)}
           >
             {upgrade.title}
           </h3>
           {upgrade.description && (
-            <p className="text-sm text-gray-500 mt-1 line-clamp-2">{upgrade.description}</p>
+            <p className="text-sm text-fg-subtle mt-1 line-clamp-2">{upgrade.description}</p>
           )}
         </div>
       </div>
       <div className="flex flex-wrap gap-2 mt-3">
         <UpgradeStatusBadge status={upgrade.status} />
         <UpgradeTypeBadge type={upgrade.type} />
-        <Badge variant={difficultyVariant[upgrade.difficulty] ?? 'gray'}>{upgrade.difficulty}</Badge>
+        <Badge variant={difficultyVariant[upgrade.difficulty] ?? UNKNOWN_DIFFICULTY_VARIANT}>{upgrade.difficulty}</Badge>
       </div>
       {showActions && onStatusChange && (
-        <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t border-gray-100">
+        <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t border-line-subtle">
           {upgrade.status === 'IDEA' && (
             <Button size="sm" variant="secondary" onClick={() => onStatusChange(upgrade.id, 'PLANNED')}>
               Plan

--- a/frontend/src/components/upgrade/upgradeMeta.ts
+++ b/frontend/src/components/upgrade/upgradeMeta.ts
@@ -1,0 +1,17 @@
+import type { BadgeVariant } from '../ui/Badge';
+
+/**
+ * Difficulty to badge colour: green through red, so HARD reads as the demanding one.
+ *
+ * Shared rather than duplicated: the upgrade card and the upgrade details page both render this badge,
+ * and they disagreed — the card used this map and the details page an inline ternary whose final branch
+ * fell through to red for any unknown value.
+ */
+export const difficultyVariant: Record<string, BadgeVariant> = {
+  EASY: 'green',
+  MEDIUM: 'yellow',
+  HARD: 'red',
+};
+
+/** The variant for an unrecognised difficulty. Grey says "no opinion" rather than mislabelling it HARD. */
+export const UNKNOWN_DIFFICULTY_VARIANT: BadgeVariant = 'gray';

--- a/frontend/src/components/upgrade/upgradeMeta.ts
+++ b/frontend/src/components/upgrade/upgradeMeta.ts
@@ -1,4 +1,5 @@
 import type { BadgeVariant } from '../ui/Badge';
+import type { Difficulty } from '../../types';
 
 /**
  * Difficulty to badge colour: green through red, so HARD reads as the demanding one.
@@ -6,12 +7,20 @@ import type { BadgeVariant } from '../ui/Badge';
  * Shared rather than duplicated: the upgrade card and the upgrade details page both render this badge,
  * and they disagreed — the card used this map and the details page an inline ternary whose final branch
  * fell through to red for any unknown value.
+ *
+ * Keyed on `Difficulty` rather than `string` so adding a difficulty to the union fails the build here
+ * instead of rendering a colourless badge.
  */
-export const difficultyVariant: Record<string, BadgeVariant> = {
+export const difficultyVariant: Record<Difficulty, BadgeVariant> = {
   EASY: 'green',
   MEDIUM: 'yellow',
   HARD: 'red',
 };
 
-/** The variant for an unrecognised difficulty. Grey says "no opinion" rather than mislabelling it HARD. */
+/**
+ * The variant for an unrecognised difficulty. Grey says "no opinion" rather than mislabelling it HARD.
+ *
+ * Callers still need this despite the map above being total: `difficulty` arrives as unvalidated JSON
+ * from the API, so its static type is a claim about the backend rather than a fact about the value.
+ */
 export const UNKNOWN_DIFFICULTY_VARIANT: BadgeVariant = 'gray';

--- a/frontend/src/contexts/ThemeProvider.test.tsx
+++ b/frontend/src/contexts/ThemeProvider.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { ThemeProvider } from './ThemeProvider';
+import { useTheme } from '../hooks/useTheme';
+import { installMatchMedia, uninstallMatchMedia } from '../test/matchMediaStub';
+
+/** Renders the context's current values, so a test can assert on what a consumer would actually see. */
+const ThemeReadout: React.FC = () => {
+  const { theme, resolvedTheme } = useTheme();
+  return (
+    <>
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="resolved">{resolvedTheme}</span>
+    </>
+  );
+};
+
+/** A button that switches the theme, so the setter is exercised the way the toggle uses it. */
+const SetThemeButton: React.FC<{ to: 'light' | 'dark' | 'system' }> = ({ to }) => {
+  const { setTheme } = useTheme();
+  return (
+    <button type="button" onClick={() => setTheme(to)}>
+      set {to}
+    </button>
+  );
+};
+
+const renderProvider = (children: React.ReactNode = <ThemeReadout />) =>
+  render(<ThemeProvider>{children}</ThemeProvider>);
+
+const isDark = () => document.documentElement.classList.contains('dark');
+
+describe('ThemeProvider', () => {
+  describe('resolving the initial theme', () => {
+    it('GivenNoStoredTheme_WhenTheProviderMounts_ThenTheThemeIsSystem', () => {
+      renderProvider();
+
+      expect(screen.getByTestId('theme').textContent).toBe('system');
+    });
+
+    it('GivenAnUnrecognisedStoredValue_WhenTheProviderMounts_ThenTheThemeIsSystem', () => {
+      localStorage.setItem('theme', 'auto');
+
+      renderProvider();
+
+      expect(screen.getByTestId('theme').textContent).toBe('system');
+    });
+
+    it('GivenAStoredDarkTheme_WhenTheProviderMounts_ThenTheDarkClassIsOnTheDocumentElement', () => {
+      localStorage.setItem('theme', 'dark');
+
+      renderProvider();
+
+      expect(isDark()).toBe(true);
+    });
+
+    it('GivenAStoredLightTheme_WhenTheSystemPrefersDark_ThenTheDarkClassIsAbsent', () => {
+      localStorage.setItem('theme', 'light');
+      installMatchMedia(true);
+
+      renderProvider();
+
+      expect(isDark()).toBe(false);
+    });
+
+    it('GivenTheSystemTheme_WhenTheSystemPrefersDark_ThenTheResolvedThemeIsDark', () => {
+      installMatchMedia(true);
+
+      renderProvider();
+
+      expect(screen.getByTestId('resolved').textContent).toBe('dark');
+      expect(isDark()).toBe(true);
+    });
+  });
+
+  describe('following the system preference', () => {
+    it('GivenTheSystemTheme_WhenTheSystemPreferenceChangesToDark_ThenTheDarkClassIsAdded', () => {
+      const media = installMatchMedia(false);
+      renderProvider();
+      expect(isDark()).toBe(false);
+
+      act(() => media.setMatches(true));
+
+      expect(isDark()).toBe(true);
+    });
+
+    it('GivenTheSystemTheme_WhenTheSystemPreferenceChangesBackToLight_ThenTheDarkClassIsRemoved', () => {
+      const media = installMatchMedia(true);
+      renderProvider();
+      expect(isDark()).toBe(true);
+
+      act(() => media.setMatches(false));
+
+      expect(isDark()).toBe(false);
+    });
+
+    it('GivenAnExplicitLightTheme_WhenTheSystemPreferenceChangesToDark_ThenTheDarkClassIsStillAbsent', () => {
+      localStorage.setItem('theme', 'light');
+      const media = installMatchMedia(false);
+      renderProvider();
+
+      act(() => media.setMatches(true));
+
+      expect(isDark()).toBe(false);
+    });
+  });
+
+  describe('changing and persisting the theme', () => {
+    it('GivenAnyTheme_WhenSetThemeIsCalled_ThenTheChoiceIsWrittenToLocalStorage', () => {
+      renderProvider(<SetThemeButton to="dark" />);
+
+      act(() => screen.getByRole('button').click());
+
+      expect(localStorage.getItem('theme')).toBe('dark');
+      expect(isDark()).toBe(true);
+    });
+
+    it('GivenAnExplicitTheme_WhenSetThemeIsCalledWithSystem_ThenTheDocumentFollowsTheSystemPreferenceAgain', () => {
+      localStorage.setItem('theme', 'light');
+      installMatchMedia(true);
+      renderProvider(<SetThemeButton to="system" />);
+      expect(isDark()).toBe(false);
+
+      act(() => screen.getByRole('button').click());
+
+      expect(isDark()).toBe(true);
+    });
+  });
+
+  describe('surviving a hostile environment', () => {
+    it('GivenLocalStorageThrowsOnRead_WhenTheProviderMounts_ThenItFallsBackToSystemWithoutThrowing', () => {
+      const getItem = Storage.prototype.getItem;
+      Storage.prototype.getItem = () => {
+        throw new Error('SecurityError: storage is disabled');
+      };
+
+      try {
+        renderProvider();
+        expect(screen.getByTestId('theme').textContent).toBe('system');
+      } finally {
+        Storage.prototype.getItem = getItem;
+      }
+    });
+
+    it('GivenLocalStorageThrowsOnWrite_WhenSetThemeIsCalled_ThenTheThemeStillChanges', () => {
+      const setItem = Storage.prototype.setItem;
+      Storage.prototype.setItem = () => {
+        throw new Error('QuotaExceededError');
+      };
+
+      try {
+        renderProvider(<SetThemeButton to="dark" />);
+        act(() => screen.getByRole('button').click());
+        expect(isDark()).toBe(true);
+      } finally {
+        Storage.prototype.setItem = setItem;
+      }
+    });
+
+    it('GivenNoMatchMediaSupport_WhenTheProviderMounts_ThenItResolvesToLight', () => {
+      uninstallMatchMedia();
+
+      renderProvider();
+
+      expect(screen.getByTestId('resolved').textContent).toBe('light');
+      expect(isDark()).toBe(false);
+    });
+  });
+
+  describe('subscription lifecycle', () => {
+    it('GivenTheProviderIsUnmounted_WhenTheSystemPreferenceChanges_ThenNoListenerRemains', () => {
+      const media = installMatchMedia(false);
+      const { unmount } = renderProvider();
+
+      unmount();
+
+      expect(media.listenerCount()).toBe(0);
+    });
+
+    it('GivenStrictMode_WhenTheProviderMounts_ThenExactlyOneMediaQueryListenerIsRegistered', () => {
+      const media = installMatchMedia(false);
+
+      render(
+        <React.StrictMode>
+          <ThemeProvider>
+            <ThemeReadout />
+          </ThemeProvider>
+        </React.StrictMode>,
+      );
+
+      expect(media.listenerCount()).toBe(1);
+    });
+
+    it('GivenStrictMode_WhenTheProviderMounts_ThenTheDarkClassIsAppliedExactlyOnce', () => {
+      localStorage.setItem('theme', 'dark');
+
+      render(
+        <React.StrictMode>
+          <ThemeProvider>
+            <ThemeReadout />
+          </ThemeProvider>
+        </React.StrictMode>,
+      );
+
+      expect(document.documentElement.className.match(/dark/g)).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/src/contexts/ThemeProvider.tsx
+++ b/frontend/src/contexts/ThemeProvider.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { ThemeContext } from './themeContextValue';
+import type { Theme } from './themeContextValue';
+
+/** Shared with the boot script in `index.html`; changing one without the other reintroduces the flash. */
+const STORAGE_KEY = 'theme';
+const DARK_QUERY = '(prefers-color-scheme: dark)';
+
+/**
+ * Reads the saved choice, treating anything unrecognised as `system`.
+ *
+ * Guarded because reading `localStorage` can throw outright rather than return null — Firefox with
+ * storage disabled raises a SecurityError on property access, as does a third-party context with site
+ * data blocked. There is no error boundary above this provider, so an unguarded read would blank the
+ * whole application rather than degrade.
+ */
+const readStoredTheme = (): Theme => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored === 'light' || stored === 'dark' ? stored : 'system';
+  } catch {
+    // Storage unavailable: fall back to following the operating system.
+    return 'system';
+  }
+};
+
+/** The dark-preference query, or null where `matchMedia` is missing (some embedded webviews). */
+const darkMediaQuery = (): MediaQueryList | null =>
+  typeof window.matchMedia === 'function' ? window.matchMedia(DARK_QUERY) : null;
+
+/**
+ * Owns the theme: the user's choice, the operating system's preference, and the `dark` class on
+ * `<html>` that the whole stylesheet keys off.
+ *
+ * Mounted outermost, above the query client, because the theme is neither server state nor tied to a
+ * session — the login page needs it as much as the dashboard does.
+ *
+ * The class is also set before React runs, by the boot script in `index.html`. That script is what
+ * prevents the flash; this provider is what keeps the class true afterwards. The two agree by
+ * construction: same key, same values, same resolution rule.
+ */
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setThemeState] = useState<Theme>(readStoredTheme);
+  const [systemPrefersDark, setSystemPrefersDark] = useState(() => darkMediaQuery()?.matches ?? false);
+
+  // `system` means "follow it", not "follow it once at boot", so the query is subscribed to rather than
+  // sampled. Under StrictMode this effect runs, tears down and runs again on mount; the removal in the
+  // cleanup is the only thing stopping that from leaving two listeners behind, which would flip the
+  // resolved theme twice per change.
+  useEffect(() => {
+    const query = darkMediaQuery();
+    if (!query) return;
+
+    // Re-read here: the preference can change between the first render and this effect, and the initial
+    // state would then be stale with no event coming to correct it.
+    setSystemPrefersDark(query.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => setSystemPrefersDark(event.matches);
+    query.addEventListener('change', handleChange);
+    return () => query.removeEventListener('change', handleChange);
+  }, []);
+
+  const resolvedTheme = theme === 'system' ? (systemPrefersDark ? 'dark' : 'light') : theme;
+
+  // The two-argument `toggle` sets the class to a value rather than flipping it, so a double invocation
+  // under StrictMode lands in the same place as a single one.
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', resolvedTheme === 'dark');
+  }, [resolvedTheme]);
+
+  /** Records the choice. The state change is deliberately not conditional on the write succeeding. */
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // Storage full or blocked. The theme still changes for this session; it just will not survive a
+      // reload, which is a better outcome than refusing to switch at all.
+    }
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>{children}</ThemeContext.Provider>
+  );
+};

--- a/frontend/src/contexts/bootScript.test.tsx
+++ b/frontend/src/contexts/bootScript.test.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from './ThemeProvider';
+import { useTheme } from '../hooks/useTheme';
+import { installMatchMedia } from '../test/matchMediaStub';
+// Vite's `?raw` rather than `node:fs`: it resolves the file the same way the build does, and it keeps
+// the app's `tsconfig.json` free of Node types — see ADR-004.
+import indexHtml from '../../index.html?raw';
+
+/**
+ * The contract between the pre-paint boot script in `index.html` and `ThemeProvider`.
+ *
+ * The theme resolution rule is implemented twice — once in inline ES5 that runs during head parse, and
+ * once in the provider that takes over on mount — because nothing else can put the class on `<html>`
+ * before the first paint. The duplication is deliberate; the two silently drifting apart is not.
+ *
+ * If they disagree, the page paints one theme and then flips to the other. That is precisely the defect
+ * the boot script exists to prevent, it is invisible to every other test in this suite, and it is
+ * invisible to a reviewer reading either file on its own. So the agreement is asserted here rather than
+ * asserted in a comment.
+ *
+ * The script is read from `index.html` and executed verbatim rather than reimplemented, because a copy
+ * of it in this file would be one more thing that can drift.
+ */
+const BOOT_SCRIPT = (() => {
+  // The classic inline script, as opposed to the module script that loads the bundle.
+  const inline = [...indexHtml.matchAll(/<script(?![^>]*\b(?:src|type)=)[^>]*>([\s\S]*?)<\/script>/g)];
+
+  if (inline.length !== 1) {
+    throw new Error(
+      `Expected exactly one classic inline script in index.html, found ${inline.length}. ` +
+        'If the boot script moved or was split, this contract test needs to follow it.',
+    );
+  }
+
+  return inline[0][1];
+})();
+
+/**
+ * Runs the shipped boot script against the current window.
+ *
+ * `new Function` rather than a jsdom `<script>` insertion: it keeps execution synchronous and in this
+ * realm, so the stubbed `matchMedia` and `localStorage` are the ones the script sees.
+ *
+ * The usual objection to `new Function` does not apply. Nothing is interpolated into the body — it is
+ * the literal contents of a version-controlled file in this repository, read whole, and executing it
+ * unaltered is the entire point: a reimplementation here could drift from the shipped script exactly
+ * the way the shipped script can drift from the provider, which is the drift this file exists to catch.
+ */
+const runBootScript = () => {
+  new Function(BOOT_SCRIPT)();
+};
+
+const isDark = () => document.documentElement.classList.contains('dark');
+
+const clearTheClass = () => {
+  document.documentElement.className = '';
+};
+
+/** A button that switches the theme, so the provider persists through its real code path. */
+const SetThemeButton: React.FC<{ to: 'light' | 'dark' | 'system' }> = ({ to }) => {
+  const { setTheme } = useTheme();
+  return (
+    <button type="button" onClick={() => setTheme(to)}>
+      set {to}
+    </button>
+  );
+};
+
+/**
+ * Every combination of stored choice and operating-system preference that reaches the resolution rule,
+ * including the two malformed cases — because "anything unrecognised means system" is part of the rule
+ * and is written out separately in each implementation.
+ */
+const scenarios: { stored: string | null; systemDark: boolean; expectedDark: boolean }[] = [
+  { stored: null, systemDark: false, expectedDark: false },
+  { stored: null, systemDark: true, expectedDark: true },
+  { stored: 'light', systemDark: false, expectedDark: false },
+  { stored: 'light', systemDark: true, expectedDark: false },
+  { stored: 'dark', systemDark: false, expectedDark: true },
+  { stored: 'dark', systemDark: true, expectedDark: true },
+  { stored: 'system', systemDark: false, expectedDark: false },
+  { stored: 'system', systemDark: true, expectedDark: true },
+  { stored: 'auto', systemDark: true, expectedDark: true },
+  { stored: '', systemDark: false, expectedDark: false },
+];
+
+const seed = (stored: string | null, systemDark: boolean) => {
+  localStorage.clear();
+  if (stored !== null) localStorage.setItem('theme', stored);
+  installMatchMedia(systemDark);
+  clearTheClass();
+};
+
+describe('the boot script and ThemeProvider agree', () => {
+  it('GivenAnyStoredChoiceAndSystemPreference_WhenTheBootScriptRuns_ThenItResolvesTheThemeTheProviderWould', () => {
+    for (const { stored, systemDark, expectedDark } of scenarios) {
+      const describeCase = `stored=${JSON.stringify(stored)} systemDark=${systemDark}`;
+
+      seed(stored, systemDark);
+      runBootScript();
+      const bootResult = isDark();
+
+      seed(stored, systemDark);
+      render(<ThemeProvider>{null}</ThemeProvider>);
+      const providerResult = isDark();
+      cleanup();
+
+      expect(`${describeCase} -> boot:${bootResult}`).toBe(`${describeCase} -> boot:${expectedDark}`);
+      expect(`${describeCase} -> provider:${providerResult}`).toBe(
+        `${describeCase} -> provider:${expectedDark}`,
+      );
+    }
+  });
+
+  /**
+   * Binds the two to the same storage key without naming it twice.
+   *
+   * The provider writes through its own setter and the script reads on the next load, so renaming
+   * `STORAGE_KEY` in one place fails here instead of quietly reintroducing the flash.
+   */
+  it('GivenTheProviderPersistedAChoice_WhenTheBootScriptRunsOnTheNextLoad_ThenItReadsThatChoice', () => {
+    installMatchMedia(false);
+    render(
+      <ThemeProvider>
+        <SetThemeButton to="dark" />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'set dark' }));
+    expect(isDark()).toBe(true);
+
+    cleanup();
+    clearTheClass();
+    runBootScript();
+
+    expect(isDark()).toBe(true);
+  });
+
+  it('GivenTheProviderPersistedLightAgainstADarkSystem_WhenTheBootScriptRuns_ThenTheChoiceStillWins', () => {
+    installMatchMedia(true);
+    render(
+      <ThemeProvider>
+        <SetThemeButton to="light" />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'set light' }));
+
+    cleanup();
+    clearTheClass();
+    runBootScript();
+
+    expect(isDark()).toBe(false);
+  });
+
+  /**
+   * The script has to survive storage being unreadable, because it runs before React and there is no
+   * error boundary that early — an exception here leaves the page with no application at all.
+   */
+  it('GivenLocalStorageThrowsOnRead_WhenTheBootScriptRuns_ThenItBootsLightWithoutThrowing', () => {
+    installMatchMedia(false);
+    clearTheClass();
+    const getItem = Storage.prototype.getItem;
+    Storage.prototype.getItem = () => {
+      throw new Error('SecurityError: storage is blocked');
+    };
+
+    try {
+      expect(() => runBootScript()).not.toThrow();
+      expect(isDark()).toBe(false);
+    } finally {
+      Storage.prototype.getItem = getItem;
+    }
+  });
+});

--- a/frontend/src/contexts/themeContextValue.ts
+++ b/frontend/src/contexts/themeContextValue.ts
@@ -1,0 +1,29 @@
+import { createContext } from 'react';
+
+/**
+ * The three states the user can choose between.
+ *
+ * `system` is not a snapshot of the operating system's preference taken at boot — it is a standing
+ * instruction to follow it, including while the tab is open.
+ */
+export type Theme = 'light' | 'dark' | 'system';
+
+/**
+ * What the theme context exposes: the user's choice, what that choice currently resolves to, and the
+ * setter that persists it.
+ *
+ * `theme` and `resolvedTheme` are both needed and are not interchangeable. Anything rendering the
+ * *choice* must read `theme`, or selecting "System" would light up "Dark"; anything rendering the
+ * *effect* must read `resolvedTheme`.
+ */
+export interface ThemeContextType {
+  theme: Theme;
+  resolvedTheme: 'light' | 'dark';
+  setTheme: (theme: Theme) => void;
+}
+
+/**
+ * The context object itself, kept in its own module so the file holding the provider component exports
+ * only components — which is what lets React Fast Refresh work on it.
+ */
+export const ThemeContext = createContext<ThemeContextType | null>(null);

--- a/frontend/src/hooks/useTheme.test.tsx
+++ b/frontend/src/hooks/useTheme.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { useTheme } from './useTheme';
+
+const Consumer: React.FC = () => {
+  useTheme();
+  return null;
+};
+
+describe('useTheme', () => {
+  it('GivenNoProvider_WhenUseThemeIsCalled_ThenItThrowsAGuidingError', () => {
+    // React logs the error boundary trace to the console before rethrowing; silenced so a deliberate
+    // failure does not look like a broken test run.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      expect(() => render(<Consumer />)).toThrowError('useTheme must be used within ThemeProvider');
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+import { ThemeContext } from '../contexts/themeContextValue';
+
+/**
+ * Reads the theme context: the chosen theme, what it resolves to now, and the setter.
+ *
+ * @throws Error when called outside `ThemeProvider` — a null context would otherwise surface much later
+ * as an unexplained "cannot read property of null" inside a component.
+ */
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,191 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/**
+ * The theme's single source of truth.
+ *
+ * Values are space-separated RGB channels rather than hex so Tailwind can compose an alpha onto them —
+ * see the `<alpha-value>` pattern in `tailwind.config.js`.
+ *
+ * Every foreground/background pair used in the app was checked against WCAG AA: 4.5:1 for text, 3:1 for
+ * control boundaries and graphical state. The worst text pair is 4.63:1 and the worst non-text pair is
+ * 3.29:1. `line` and `line-subtle` are deliberate exceptions — a card's outline and a list's divider
+ * identify no component or state, and forcing 3:1 there would put a mid-grey box round every panel.
+ *
+ * `.dark` is put on `<html>` by the boot script in `index.html` before first paint, and kept in step
+ * afterwards by `ThemeProvider`.
+ */
+@layer base {
+  :root {
+    color-scheme: light;
+
+    --color-canvas: 249 250 251;
+    --color-surface: 255 255 255;
+    --color-sunken: 249 250 251;
+    --color-muted: 243 244 246;
+    --color-muted-strong: 229 231 235;
+
+    --color-line-subtle: 239 241 244;
+    --color-line: 229 231 235;
+    --color-line-strong: 124 133 147;
+
+    --color-fg: 17 24 39;
+    --color-fg-muted: 55 65 81;
+    --color-fg-subtle: 91 100 114;
+    --color-fg-faint: 107 114 128;
+    --color-fg-inverted: 255 255 255;
+
+    --color-overlay: 17 24 39;
+    --color-focus: 29 78 216;
+
+    --color-brand: 37 99 235;
+    --color-brand-hover: 29 78 216;
+    --color-brand-soft: 239 246 255;
+    --color-brand-soft-hover: 219 234 254;
+    --color-brand-line: 147 197 253;
+    --color-brand-fg: 29 78 216;
+
+    --color-success: 21 128 61;
+    --color-success-soft: 240 253 244;
+    --color-success-line: 134 239 172;
+    --color-success-fg: 21 128 61;
+
+    --color-warning-soft: 255 251 235;
+    --color-warning-line: 252 211 77;
+    --color-warning-fg: 146 64 14;
+
+    --color-danger: 220 38 38;
+    --color-danger-hover: 185 28 28;
+    --color-danger-soft: 254 242 242;
+    --color-danger-line: 252 165 165;
+    --color-danger-fg: 185 28 28;
+
+    --color-info-soft: 236 254 255;
+    --color-info-line: 103 232 249;
+    --color-info-fg: 21 94 117;
+
+    --color-reminder-soft: 245 243 255;
+    --color-reminder-line: 196 181 253;
+    --color-reminder-fg: 109 40 217;
+
+    --color-streak-soft: 255 247 237;
+    --color-streak-line: 253 186 116;
+    --color-streak-fg: 194 65 12;
+
+    --color-accent-soft: 224 231 255;
+    --color-accent-fg: 79 70 229;
+
+    --color-tint-green-soft: 220 252 231;
+    --color-tint-green-fg: 22 101 52;
+    --color-tint-yellow-soft: 254 249 195;
+    --color-tint-yellow-fg: 133 77 14;
+    --color-tint-blue-soft: 219 234 254;
+    --color-tint-blue-fg: 30 64 175;
+    --color-tint-red-soft: 254 226 226;
+    --color-tint-red-fg: 153 27 27;
+    --color-tint-purple-soft: 243 232 255;
+    --color-tint-purple-fg: 107 33 168;
+  }
+
+  .dark {
+    /*
+     * Tells the browser to render its own chrome dark: the native `<select>` popup that `Select.tsx`
+     * relies on, number-input spinners, scrollbars and the default caret. Nothing in CSS can reach
+     * those, so without this they stay light on a dark page.
+     */
+    color-scheme: dark;
+
+    --color-canvas: 13 16 21;
+    --color-surface: 23 27 34;
+    --color-sunken: 33 38 48;
+    --color-muted: 43 49 59;
+    --color-muted-strong: 58 65 77;
+
+    --color-line-subtle: 37 43 52;
+    --color-line: 51 58 69;
+    --color-line-strong: 107 118 134;
+
+    --color-fg: 242 244 247;
+    --color-fg-muted: 199 205 216;
+    --color-fg-subtle: 154 164 178;
+    --color-fg-faint: 138 148 163;
+    --color-fg-inverted: 255 255 255;
+
+    --color-overlay: 0 0 0;
+    --color-focus: 147 197 253;
+
+    --color-brand: 37 99 235;
+    --color-brand-hover: 29 78 216;
+    --color-brand-soft: 23 38 63;
+    --color-brand-soft-hover: 30 49 84;
+    --color-brand-line: 44 76 130;
+    --color-brand-fg: 147 197 253;
+
+    --color-success: 34 197 94;
+    --color-success-soft: 16 46 30;
+    --color-success-line: 33 107 65;
+    --color-success-fg: 110 231 160;
+
+    --color-warning-soft: 51 38 10;
+    --color-warning-line: 124 90 22;
+    --color-warning-fg: 252 211 77;
+
+    --color-danger: 220 38 38;
+    --color-danger-hover: 185 28 28;
+    --color-danger-soft: 58 24 28;
+    --color-danger-line: 127 42 42;
+    --color-danger-fg: 252 165 165;
+
+    --color-info-soft: 15 44 52;
+    --color-info-line: 23 98 122;
+    --color-info-fg: 103 232 249;
+
+    --color-reminder-soft: 36 30 64;
+    --color-reminder-line: 76 61 147;
+    --color-reminder-fg: 196 181 253;
+
+    --color-streak-soft: 51 33 14;
+    --color-streak-line: 138 78 27;
+    --color-streak-fg: 253 186 116;
+
+    --color-accent-soft: 35 40 88;
+    --color-accent-fg: 165 180 252;
+
+    --color-tint-green-soft: 20 48 31;
+    --color-tint-green-fg: 134 239 172;
+    --color-tint-yellow-soft: 51 42 11;
+    --color-tint-yellow-fg: 253 224 71;
+    --color-tint-blue-soft: 23 38 63;
+    --color-tint-blue-fg: 147 197 253;
+    --color-tint-red-soft: 58 24 28;
+    --color-tint-red-fg: 252 165 165;
+    --color-tint-purple-soft: 42 30 66;
+    --color-tint-purple-fg: 216 180 254;
+  }
+
+  /*
+   * On `html` rather than `body`: this is what the browser paints for overscroll, and for the frame
+   * between the boot script running and React mounting, so nothing flashes white.
+   */
+  html {
+    background-color: rgb(var(--color-canvas));
+  }
+
+  body {
+    color: rgb(var(--color-fg));
+  }
+
+  /* Preflight hard-codes gray-400 here, which is 2.54:1 on white — below AA for text. */
+  ::placeholder {
+    color: rgb(var(--color-fg-faint));
+    opacity: 1;
+  }
+
+  /* The toasts animate in; someone who has asked for less motion should still see them appear. */
+  @media (prefers-reduced-motion: reduce) {
+    .animate-fade-in {
+      animation: none;
+    }
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -182,10 +182,18 @@
     opacity: 1;
   }
 
-  /* The toasts animate in; someone who has asked for less motion should still see them appear. */
-  @media (prefers-reduced-motion: reduce) {
-    .animate-fade-in {
-      animation: none;
-    }
+}
+
+/*
+ * The toasts animate in; someone who has asked for less motion should still see them appear.
+ *
+ * Deliberately outside `@layer base`. Tailwind emits base before utilities and both selectors are
+ * specificity (0,1,0), so the same rule inside the base layer loses to the `animate-fade-in` utility on
+ * source order and silently does nothing. Unlayered CSS outranks every Tailwind layer, so this wins
+ * where it belongs and needs no `!important`.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in {
+    animation: none;
   }
 }

--- a/frontend/src/pages/ActiveUpgradesPage.tsx
+++ b/frontend/src/pages/ActiveUpgradesPage.tsx
@@ -26,7 +26,7 @@ const ActiveUpgradesPage: React.FC = () => {
   });
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-red-500 text-center py-10">Failed to load upgrades.</p>;
+  if (error) return <p className="text-danger-fg text-center py-10">Failed to load upgrades.</p>;
 
   return (
     <div className="max-w-4xl mx-auto">

--- a/frontend/src/pages/DailyCheckinPage.tsx
+++ b/frontend/src/pages/DailyCheckinPage.tsx
@@ -74,8 +74,8 @@ const DailyCheckinPage: React.FC = () => {
     return (
       <div className="max-w-xl mx-auto text-center py-20">
         <div className="text-6xl mb-4">🎉</div>
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">Check-in Complete!</h2>
-        <p className="text-gray-500 mb-6">Great job tracking your upgrades today.</p>
+        <h2 className="text-2xl font-bold text-fg mb-2">Check-in Complete!</h2>
+        <p className="text-fg-subtle mb-6">Great job tracking your upgrades today.</p>
         <Button onClick={() => navigate('/dashboard')}>Back to Dashboard</Button>
       </div>
     );
@@ -91,7 +91,7 @@ const DailyCheckinPage: React.FC = () => {
         <form onSubmit={handleSubmit} className="space-y-4">
           {upgrades.map((u: HealthUpgrade) => (
             <Card key={u.id} header={u.title}>
-              {u.description && <p className="text-sm text-gray-500 mb-3">{u.description}</p>}
+              {u.description && <p className="text-sm text-fg-subtle mb-3">{u.description}</p>}
 
               {trackingType(u) === 'BOOLEAN' && (
                 <label className="flex items-center gap-3 cursor-pointer">
@@ -109,12 +109,12 @@ const DailyCheckinPage: React.FC = () => {
                 <div className="flex items-center gap-2">
                   <input
                     type="number"
-                    className="rounded-lg border border-gray-300 px-3 py-2 text-sm w-28 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="rounded-lg border border-line-strong px-3 py-2 text-sm w-28 focus:outline-none focus:ring-2"
                     placeholder="0"
                     value={progressMap[u.id]?.numericValue ?? ''}
                     onChange={(e) => updateProgress(u.id, { numericValue: numOrUndef(e.target.value) })}
                   />
-                  <span className="text-sm text-gray-500">{u.trackingConfig?.targetUnit ?? ''}</span>
+                  <span className="text-sm text-fg-subtle">{u.trackingConfig?.targetUnit ?? ''}</span>
                 </div>
               )}
 
@@ -125,7 +125,7 @@ const DailyCheckinPage: React.FC = () => {
                       key={n}
                       type="button"
                       onClick={() => updateProgress(u.id, { rating: n })}
-                      className={`w-10 h-10 rounded-full text-sm font-semibold transition-colors ${progressMap[u.id]?.rating === n ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
+                      className={`w-10 h-10 rounded-full text-sm font-semibold transition-colors ${progressMap[u.id]?.rating === n ? 'bg-brand text-fg-inverted' : 'bg-muted text-fg-muted hover:bg-muted-strong'}`}
                     >
                       {n}
                     </button>
@@ -135,7 +135,7 @@ const DailyCheckinPage: React.FC = () => {
 
               {trackingType(u) === 'TEXT' && (
                 <textarea
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="w-full rounded-lg border border-line-strong px-3 py-2 text-sm focus:outline-none focus:ring-2"
                   rows={2}
                   placeholder="Add your note..."
                   value={progressMap[u.id]?.note ?? ''}
@@ -146,7 +146,7 @@ const DailyCheckinPage: React.FC = () => {
               {trackingType(u) !== 'TEXT' && (
                 <input
                   type="text"
-                  className="mt-3 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-600 focus:outline-none focus:ring-1 focus:ring-gray-400"
+                  className="mt-3 w-full rounded-lg border border-line px-3 py-2 text-sm text-fg-subtle focus:outline-none focus:ring-1"
                   placeholder="Optional note..."
                   value={progressMap[u.id]?.note ?? ''}
                   onChange={(e) => updateProgress(u.id, { note: e.target.value })}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -34,7 +34,7 @@ const DashboardPage: React.FC = () => {
   };
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-red-500 text-center py-10">Failed to load dashboard.</p>;
+  if (error) return <p className="text-danger-fg text-center py-10">Failed to load dashboard.</p>;
 
   // Rounded, not scaled: the API sends a percentage already (see DashboardDto.weeklyCompletionRate).
   const completionPct = Math.round(data?.weeklyCompletionRate ?? 0);
@@ -44,53 +44,53 @@ const DashboardPage: React.FC = () => {
     <div className="max-w-6xl mx-auto space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">
+          <h1 className="text-2xl font-bold text-fg">
             Good {new Date().getHours() < 12 ? 'morning' : new Date().getHours() < 18 ? 'afternoon' : 'evening'},{' '}
             {user?.name?.split(' ')[0]} 👋
           </h1>
-          <p className="text-gray-500 mt-1">{new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}</p>
+          <p className="text-fg-subtle mt-1">{new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}</p>
         </div>
         <Button onClick={() => navigate('/upgrades/backlog')}>+ Add Upgrade</Button>
       </div>
 
       {(data?.overdueUpgrades?.length ?? 0) > 0 && (
-        <div className="bg-red-50 border border-red-200 rounded-xl p-4 flex items-center gap-3">
+        <div className="bg-danger-soft border border-danger-line rounded-xl p-4 flex items-center gap-3">
           <span className="text-2xl">⚠️</span>
           <div>
-            <p className="font-medium text-red-800">{data!.overdueUpgrades.length} overdue upgrade{data!.overdueUpgrades.length > 1 ? 's' : ''}</p>
-            <p className="text-sm text-red-600">Some upgrades are past their target date.</p>
+            <p className="font-medium text-danger-fg">{data!.overdueUpgrades.length} overdue upgrade{data!.overdueUpgrades.length > 1 ? 's' : ''}</p>
+            <p className="text-sm text-danger-fg">Some upgrades are past their target date.</p>
           </div>
         </div>
       )}
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Card className="text-center">
-          <div className="text-3xl font-bold text-blue-600">{data?.activeUpgrades.length ?? 0}</div>
-          <div className="text-sm text-gray-500 mt-1">Active</div>
+          <div className="text-3xl font-bold text-brand-fg">{data?.activeUpgrades.length ?? 0}</div>
+          <div className="text-sm text-fg-subtle mt-1">Active</div>
         </Card>
         <Card className="text-center">
-          <div className="text-3xl font-bold text-indigo-600">{data?.plannedUpgrades.length ?? 0}</div>
-          <div className="text-sm text-gray-500 mt-1">Planned</div>
+          <div className="text-3xl font-bold text-accent-fg">{data?.plannedUpgrades.length ?? 0}</div>
+          <div className="text-sm text-fg-subtle mt-1">Planned</div>
         </Card>
         <Card className="text-center">
-          <div className="text-3xl font-bold text-green-600">{completionPct}%</div>
-          <div className="text-sm text-gray-500 mt-1">Weekly Rate</div>
+          <div className="text-3xl font-bold text-success-fg">{completionPct}%</div>
+          <div className="text-sm text-fg-subtle mt-1">Weekly Rate</div>
         </Card>
         <Card className="text-center">
-          <div className="text-3xl font-bold text-orange-500">{streakEntries.length}</div>
-          <div className="text-sm text-gray-500 mt-1">Streaks</div>
+          <div className="text-3xl font-bold text-streak-fg">{streakEntries.length}</div>
+          <div className="text-sm text-fg-subtle mt-1">Streaks</div>
         </Card>
       </div>
 
       <Card header="Weekly Completion Rate">
         <div className="flex items-center gap-4">
-          <div className="flex-1 bg-gray-200 rounded-full h-4 overflow-hidden">
+          <div className="flex-1 bg-muted-strong rounded-full h-4 overflow-hidden">
             <div
-              className="h-full bg-green-500 rounded-full transition-all duration-500"
+              className="h-full bg-success rounded-full transition-all duration-500"
               style={{ width: `${completionPct}%` }}
             />
           </div>
-          <span className="text-sm font-semibold text-gray-700 w-12 text-right">{completionPct}%</span>
+          <span className="text-sm font-semibold text-fg-muted w-12 text-right">{completionPct}%</span>
         </div>
       </Card>
 
@@ -125,9 +125,9 @@ const DashboardPage: React.FC = () => {
         <Card header="Current Streaks 🔥">
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
             {streakEntries.map(([id, count]) => (
-              <div key={id} className="bg-orange-50 rounded-lg p-3 text-center">
-                <div className="text-2xl font-bold text-orange-600">{count}</div>
-                <div className="text-xs text-gray-500 mt-1">days</div>
+              <div key={id} className="bg-streak-soft rounded-lg p-3 text-center">
+                <div className="text-2xl font-bold text-streak-fg">{count}</div>
+                <div className="text-xs text-fg-subtle mt-1">days</div>
               </div>
             ))}
           </div>
@@ -138,9 +138,9 @@ const DashboardPage: React.FC = () => {
         <Card header="Recently Completed 🎉">
           <div className="space-y-2">
             {data!.recentlyCompleted.map((u) => (
-              <div key={u.id} className="flex items-center gap-3 p-2 rounded-lg bg-gray-50">
-                <span className="text-green-500 text-lg">✓</span>
-                <span className="text-sm font-medium text-gray-800">{u.title}</span>
+              <div key={u.id} className="flex items-center gap-3 p-2 rounded-lg bg-sunken">
+                <span className="text-success-fg text-lg">✓</span>
+                <span className="text-sm font-medium text-fg-muted">{u.title}</span>
               </div>
             ))}
           </div>

--- a/frontend/src/pages/HealthAreasPage.tsx
+++ b/frontend/src/pages/HealthAreasPage.tsx
@@ -65,7 +65,7 @@ const HealthAreasPage: React.FC = () => {
   };
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-red-500 text-center py-10">Failed to load health areas.</p>;
+  if (error) return <p className="text-danger-fg text-center py-10">Failed to load health areas.</p>;
 
   return (
     <div className="max-w-4xl mx-auto">
@@ -90,14 +90,14 @@ const HealthAreasPage: React.FC = () => {
                 <div className="flex items-center gap-2">
                   <span className="text-2xl">{area.icon ?? '🎯'}</span>
                   <div>
-                    <h3 className="font-semibold text-gray-900">{area.name}</h3>
+                    <h3 className="font-semibold text-fg">{area.name}</h3>
                     {area.upgradeCount !== undefined && (
-                      <p className="text-xs text-gray-500">{area.upgradeCount} upgrade{area.upgradeCount !== 1 ? 's' : ''}</p>
+                      <p className="text-xs text-fg-subtle">{area.upgradeCount} upgrade{area.upgradeCount !== 1 ? 's' : ''}</p>
                     )}
                   </div>
                 </div>
               </div>
-              {area.description && <p className="text-sm text-gray-500 mt-2">{area.description}</p>}
+              {area.description && <p className="text-sm text-fg-subtle mt-2">{area.description}</p>}
               <div className="flex gap-2 mt-4">
                 <Button size="sm" variant="secondary" onClick={() => openEdit(area)}>Edit</Button>
                 <Button size="sm" variant="danger" onClick={() => setDeleteId(area.id)}>Delete</Button>
@@ -134,7 +134,7 @@ const HealthAreasPage: React.FC = () => {
       </Modal>
 
       <Modal isOpen={!!deleteId} onClose={() => setDeleteId(null)} title="Delete Health Area">
-        <p className="text-gray-600 mb-4">Are you sure you want to delete this health area? This action cannot be undone.</p>
+        <p className="text-fg-subtle mb-4">Are you sure you want to delete this health area? This action cannot be undone.</p>
         <div className="flex gap-2 justify-end">
           <Button variant="secondary" onClick={() => setDeleteId(null)}>Cancel</Button>
           <Button variant="danger" loading={deleteMutation.isPending} onClick={() => deleteId && deleteMutation.mutate(deleteId)}>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -41,12 +41,12 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-xl p-8 w-full max-w-md">
+    <div className="min-h-screen bg-gradient-to-br from-brand-soft to-accent-soft flex items-center justify-center p-4">
+      <div className="bg-surface rounded-2xl shadow-xl p-8 w-full max-w-md">
         <div className="text-center mb-8">
           <div className="text-5xl mb-3">💪</div>
-          <h1 className="text-2xl font-bold text-gray-900">UpHealther</h1>
-          <p className="text-gray-500 mt-1">Sign in to your account</p>
+          <h1 className="text-2xl font-bold text-fg">UpHealther</h1>
+          <p className="text-fg-subtle mt-1">Sign in to your account</p>
         </div>
         <form onSubmit={handleSubmit} className="space-y-4">
           <Input
@@ -65,14 +65,14 @@ const LoginPage: React.FC = () => {
             placeholder="••••••••"
             autoComplete="current-password"
           />
-          {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+          {error && <p className="text-sm text-danger-fg text-center">{error}</p>}
           <Button type="submit" loading={loading} className="w-full">
             Sign In
           </Button>
         </form>
-        <p className="text-center text-sm text-gray-500 mt-6">
+        <p className="text-center text-sm text-fg-subtle mt-6">
           Don't have an account?{' '}
-          <Link to="/register" className="text-blue-600 hover:underline font-medium">
+          <Link to="/register" className="text-brand-fg hover:underline font-medium">
             Register
           </Link>
         </p>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
+import ThemeToggle from '../components/theme/ThemeToggle';
 
 /**
  * Sign-in page, one of the two routes reachable without a session.
@@ -41,7 +42,11 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-brand-soft to-accent-soft flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-brand-soft to-accent-soft flex items-center justify-center p-4 relative">
+      {/* These pages render outside Layout, so the navbar toggle cannot reach them. */}
+      <div className="absolute top-4 right-4">
+        <ThemeToggle />
+      </div>
       <div className="bg-surface rounded-2xl shadow-xl p-8 w-full max-w-md">
         <div className="text-center mb-8">
           <div className="text-5xl mb-3">💪</div>

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -47,7 +47,7 @@ const NotificationsPage: React.FC = () => {
             key={f}
             onClick={() => setFilter(f)}
             className={`px-3 py-1.5 rounded-lg text-sm font-medium capitalize transition-colors ${
-              filter === f ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              filter === f ? 'bg-brand text-fg-inverted' : 'bg-muted text-fg-muted hover:bg-muted-strong'
             }`}
           >
             {f}{f === 'unread' && unreadCount > 0 ? ` (${unreadCount})` : ''}
@@ -62,7 +62,7 @@ const NotificationsPage: React.FC = () => {
           description="Updates about your upgrades, streaks, reminders and overdue items will show up here."
         />
       ) : (
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-100">
+        <div className="bg-surface rounded-xl border border-line shadow-sm overflow-hidden divide-y divide-line-subtle">
           {shown.map((n) => (
             <NotificationItem key={n.id} notification={n} onSelect={select} />
           ))}

--- a/frontend/src/pages/PlannedUpgradesPage.tsx
+++ b/frontend/src/pages/PlannedUpgradesPage.tsx
@@ -32,7 +32,7 @@ const PlannedUpgradesPage: React.FC = () => {
   });
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-red-500 text-center py-10">Failed to load upgrades.</p>;
+  if (error) return <p className="text-danger-fg text-center py-10">Failed to load upgrades.</p>;
 
   return (
     <div className="max-w-4xl mx-auto">
@@ -48,7 +48,7 @@ const PlannedUpgradesPage: React.FC = () => {
           {sorted.map((u) => (
             <div key={u.id}>
               {u.plannedStartDate && (
-                <p className="text-xs text-gray-400 mb-1 ml-1">
+                <p className="text-xs text-fg-faint mb-1 ml-1">
                   Starts: {new Date(u.plannedStartDate).toLocaleDateString()}
                 </p>
               )}

--- a/frontend/src/pages/ProgressHistoryPage.tsx
+++ b/frontend/src/pages/ProgressHistoryPage.tsx
@@ -26,7 +26,7 @@ const ProgressHistoryPage: React.FC = () => {
   const sorted = [...progress].sort((a: ProgressEntry, b: ProgressEntry) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   if (pLoading || uLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (pError || uError) return <p className="text-red-500 text-center py-10">Failed to load progress history.</p>;
+  if (pError || uError) return <p className="text-danger-fg text-center py-10">Failed to load progress history.</p>;
 
   return (
     <div className="max-w-3xl mx-auto">
@@ -39,23 +39,23 @@ const ProgressHistoryPage: React.FC = () => {
             {sorted.map((entry) => {
               const upgrade = upgradeMap[entry.upgradeId];
               return (
-                <div key={entry.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg text-sm">
+                <div key={entry.id} className="flex items-center justify-between p-3 bg-sunken rounded-lg text-sm">
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900 truncate">{upgrade?.title ?? 'Unknown Upgrade'}</p>
-                    <p className="text-gray-400 text-xs">{new Date(entry.date).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}</p>
+                    <p className="font-medium text-fg truncate">{upgrade?.title ?? 'Unknown Upgrade'}</p>
+                    <p className="text-fg-faint text-xs">{new Date(entry.date).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}</p>
                   </div>
                   <div className="flex items-center gap-2 ml-4">
                     {entry.completed !== undefined && (
                       <Badge variant={entry.completed ? 'green' : 'red'}>{entry.completed ? '✓ Done' : '✗ Missed'}</Badge>
                     )}
                     {entry.numericValue !== undefined && (
-                      <span className="font-semibold text-gray-700">{entry.numericValue} {entry.unit}</span>
+                      <span className="font-semibold text-fg-muted">{entry.numericValue} {entry.unit}</span>
                     )}
                     {entry.rating !== undefined && (
-                      <span className="text-yellow-500">{'⭐'.repeat(entry.rating)}</span>
+                      <span>{'⭐'.repeat(entry.rating)}</span>
                     )}
                     {entry.note && (
-                      <span className="text-gray-400 italic truncate max-w-32">{entry.note}</span>
+                      <span className="text-fg-faint italic truncate max-w-32">{entry.note}</span>
                     )}
                   </div>
                 </div>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -45,12 +45,12 @@ const RegisterPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-xl p-8 w-full max-w-md">
+    <div className="min-h-screen bg-gradient-to-br from-brand-soft to-accent-soft flex items-center justify-center p-4">
+      <div className="bg-surface rounded-2xl shadow-xl p-8 w-full max-w-md">
         <div className="text-center mb-8">
           <div className="text-5xl mb-3">💪</div>
-          <h1 className="text-2xl font-bold text-gray-900">Create Account</h1>
-          <p className="text-gray-500 mt-1">Start your health journey today</p>
+          <h1 className="text-2xl font-bold text-fg">Create Account</h1>
+          <p className="text-fg-subtle mt-1">Start your health journey today</p>
         </div>
         <form onSubmit={handleSubmit} className="space-y-4">
           <Input
@@ -85,14 +85,14 @@ const RegisterPage: React.FC = () => {
             placeholder="••••••••"
             autoComplete="new-password"
           />
-          {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+          {error && <p className="text-sm text-danger-fg text-center">{error}</p>}
           <Button type="submit" loading={loading} className="w-full">
             Create Account
           </Button>
         </form>
-        <p className="text-center text-sm text-gray-500 mt-6">
+        <p className="text-center text-sm text-fg-subtle mt-6">
           Already have an account?{' '}
-          <Link to="/login" className="text-blue-600 hover:underline font-medium">
+          <Link to="/login" className="text-brand-fg hover:underline font-medium">
             Sign In
           </Link>
         </p>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
+import ThemeToggle from '../components/theme/ThemeToggle';
 
 /**
  * Account creation page, and the other route reachable without a session.
@@ -45,7 +46,11 @@ const RegisterPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-brand-soft to-accent-soft flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-brand-soft to-accent-soft flex items-center justify-center p-4 relative">
+      {/* These pages render outside Layout, so the navbar toggle cannot reach them. */}
+      <div className="absolute top-4 right-4">
+        <ThemeToggle />
+      </div>
       <div className="bg-surface rounded-2xl shadow-xl p-8 w-full max-w-md">
         <div className="text-center mb-8">
           <div className="text-5xl mb-3">💪</div>

--- a/frontend/src/pages/UpgradeBacklogPage.tsx
+++ b/frontend/src/pages/UpgradeBacklogPage.tsx
@@ -76,7 +76,7 @@ const UpgradeBacklogPage: React.FC = () => {
   const areaOptions = [{ value: '', label: 'No area' }, ...areas.map((a) => ({ value: a.id, label: a.name }))];
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-red-500 text-center py-10">Failed to load the backlog.</p>;
+  if (error) return <p className="text-danger-fg text-center py-10">Failed to load the backlog.</p>;
 
   return (
     <div className="max-w-4xl mx-auto">

--- a/frontend/src/pages/UpgradeDetailsPage.tsx
+++ b/frontend/src/pages/UpgradeDetailsPage.tsx
@@ -15,6 +15,7 @@ import Modal from '../components/ui/Modal';
 import UpgradeStatusBadge from '../components/upgrade/UpgradeStatusBadge';
 import UpgradeTypeBadge from '../components/upgrade/UpgradeTypeBadge';
 import Badge from '../components/ui/Badge';
+import { difficultyVariant, UNKNOWN_DIFFICULTY_VARIANT } from '../components/upgrade/upgradeMeta';
 import type { CreateProgressRequest, CreateReflectionRequest, TrackingType, Frequency } from '../types';
 
 /** Today as `YYYY-MM-DD`, the date format the progress and reflection APIs expect. */
@@ -118,33 +119,33 @@ const UpgradeDetailsPage: React.FC = () => {
   });
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error || !upgrade) return <p className="text-red-500 text-center py-10">Failed to load this upgrade.</p>;
+  if (error || !upgrade) return <p className="text-danger-fg text-center py-10">Failed to load this upgrade.</p>;
 
   return (
     <div className="max-w-3xl mx-auto space-y-6">
-      <button onClick={() => navigate(-1)} className="text-sm text-blue-600 hover:underline">← Back</button>
+      <button onClick={() => navigate(-1)} className="text-sm text-brand-fg hover:underline">← Back</button>
 
       <Card>
         <div className="flex flex-wrap gap-2 mb-3">
           <UpgradeStatusBadge status={upgrade.status} />
           <UpgradeTypeBadge type={upgrade.type} />
-          <Badge variant={upgrade.difficulty === 'EASY' ? 'green' : upgrade.difficulty === 'MEDIUM' ? 'yellow' : 'red'}>
+          <Badge variant={difficultyVariant[upgrade.difficulty] ?? UNKNOWN_DIFFICULTY_VARIANT}>
             {upgrade.difficulty}
           </Badge>
         </div>
-        <h1 className="text-2xl font-bold text-gray-900">{upgrade.title}</h1>
-        {upgrade.description && <p className="text-gray-600 mt-2">{upgrade.description}</p>}
+        <h1 className="text-2xl font-bold text-fg">{upgrade.title}</h1>
+        {upgrade.description && <p className="text-fg-subtle mt-2">{upgrade.description}</p>}
         {upgrade.motivation && (
-          <div className="mt-4 bg-blue-50 rounded-lg p-3">
-            <p className="text-sm text-blue-700"><strong>Motivation:</strong> {upgrade.motivation}</p>
+          <div className="mt-4 bg-brand-soft rounded-lg p-3">
+            <p className="text-sm text-brand-fg"><strong>Motivation:</strong> {upgrade.motivation}</p>
           </div>
         )}
         {upgrade.successCriteria && (
-          <div className="mt-2 bg-green-50 rounded-lg p-3">
-            <p className="text-sm text-green-700"><strong>Success Criteria:</strong> {upgrade.successCriteria}</p>
+          <div className="mt-2 bg-success-soft rounded-lg p-3">
+            <p className="text-sm text-success-fg"><strong>Success Criteria:</strong> {upgrade.successCriteria}</p>
           </div>
         )}
-        <div className="mt-4 grid grid-cols-2 gap-4 text-sm text-gray-500">
+        <div className="mt-4 grid grid-cols-2 gap-4 text-sm text-fg-subtle">
           {upgrade.plannedStartDate && <div><span className="font-medium">Planned Start:</span> {new Date(upgrade.plannedStartDate).toLocaleDateString()}</div>}
           {upgrade.actualStartDate && <div><span className="font-medium">Actual Start:</span> {new Date(upgrade.actualStartDate).toLocaleDateString()}</div>}
           {upgrade.targetEndDate && <div><span className="font-medium">Target End:</span> {new Date(upgrade.targetEndDate).toLocaleDateString()}</div>}
@@ -152,11 +153,11 @@ const UpgradeDetailsPage: React.FC = () => {
       </Card>
 
       {streak.current > 0 && (
-        <div className="bg-orange-50 border border-orange-200 rounded-xl p-4 flex items-center gap-3">
+        <div className="bg-streak-soft border border-streak-line rounded-xl p-4 flex items-center gap-3">
           <span className="text-3xl">🔥</span>
           <div>
-            <p className="font-semibold text-orange-700">{streak.current}-day streak!</p>
-            <p className="text-sm text-orange-500">Longest streak: {streak.longest} day{streak.longest === 1 ? '' : 's'}. Keep it up!</p>
+            <p className="font-semibold text-streak-fg">{streak.current}-day streak!</p>
+            <p className="text-sm text-streak-fg">Longest streak: {streak.longest} day{streak.longest === 1 ? '' : 's'}. Keep it up!</p>
           </div>
         </div>
       )}
@@ -180,32 +181,32 @@ const UpgradeDetailsPage: React.FC = () => {
       }>
         {upgrade.trackingConfig ? (
           <div className="grid grid-cols-2 gap-3 text-sm">
-            <div><span className="text-gray-500">Type:</span> <span className="font-medium">{upgrade.trackingConfig.trackingType}</span></div>
-            <div><span className="text-gray-500">Frequency:</span> <span className="font-medium">{upgrade.trackingConfig.frequency}</span></div>
+            <div><span className="text-fg-subtle">Type:</span> <span className="font-medium">{upgrade.trackingConfig.trackingType}</span></div>
+            <div><span className="text-fg-subtle">Frequency:</span> <span className="font-medium">{upgrade.trackingConfig.frequency}</span></div>
             {upgrade.trackingConfig.targetNumericValue != null && (
-              <div><span className="text-gray-500">Target:</span> <span className="font-medium">{upgrade.trackingConfig.targetNumericValue} {upgrade.trackingConfig.targetUnit}</span></div>
+              <div><span className="text-fg-subtle">Target:</span> <span className="font-medium">{upgrade.trackingConfig.targetNumericValue} {upgrade.trackingConfig.targetUnit}</span></div>
             )}
           </div>
         ) : (
-          <p className="text-gray-500 text-sm text-center py-4">No tracking configured yet. Configure how you'll track this upgrade.</p>
+          <p className="text-fg-subtle text-sm text-center py-4">No tracking configured yet. Configure how you'll track this upgrade.</p>
         )}
       </Card>
 
       <Card header={<span>Reminders ({reminders.length})</span>}>
         {reminders.length === 0 ? (
-          <p className="text-gray-500 text-sm mb-4">No reminders yet. Add one to get notified.</p>
+          <p className="text-fg-subtle text-sm mb-4">No reminders yet. Add one to get notified.</p>
         ) : (
           <div className="space-y-2 mb-4">
             {reminders.map((r) => (
-              <div key={r.id} className="flex items-center justify-between p-2 bg-gray-50 rounded-lg text-sm">
+              <div key={r.id} className="flex items-center justify-between p-2 bg-sunken rounded-lg text-sm">
                 <div className="flex items-center gap-2">
                   <span className="font-medium">⏰ {r.reminderTime.slice(0, 5)}</span>
-                  <span className="text-gray-500">{r.daysOfWeek.length ? r.daysOfWeek.join(', ') : 'Every day'}</span>
+                  <span className="text-fg-subtle">{r.daysOfWeek.length ? r.daysOfWeek.join(', ') : 'Every day'}</span>
                   {!r.enabled && <Badge variant="gray">disabled</Badge>}
                 </div>
                 <button
                   onClick={() => deleteReminderMut.mutate(r.id)}
-                  className="text-red-500 hover:text-red-700 text-xs font-medium"
+                  className="text-danger-fg hover:underline text-xs font-medium"
                 >
                   Remove
                 </button>
@@ -215,11 +216,11 @@ const UpgradeDetailsPage: React.FC = () => {
         )}
         <form
           onSubmit={(e) => { e.preventDefault(); createReminderMut.mutate(); }}
-          className="flex flex-wrap items-end gap-3 border-t border-gray-100 pt-3"
+          className="flex flex-wrap items-end gap-3 border-t border-line-subtle pt-3"
         >
           <Input label="Time" type="time" value={reminderTime} onChange={(e) => setReminderTime(e.target.value)} />
           <div>
-            <label className="text-sm font-medium text-gray-700 block mb-1">Days <span className="text-gray-400">(none = every day)</span></label>
+            <label className="text-sm font-medium text-fg-muted block mb-1">Days <span className="text-fg-faint">(none = every day)</span></label>
             <div className="flex gap-1">
               {DAYS.map((d) => (
                 <button
@@ -227,7 +228,7 @@ const UpgradeDetailsPage: React.FC = () => {
                   type="button"
                   title={d}
                   onClick={() => toggleDay(d)}
-                  className={`w-9 h-9 rounded-lg text-xs font-medium transition-colors ${reminderDays.includes(d) ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}
+                  className={`w-9 h-9 rounded-lg text-xs font-medium transition-colors ${reminderDays.includes(d) ? 'bg-brand text-fg-inverted' : 'bg-muted text-fg-subtle hover:bg-muted-strong'}`}
                 >
                   {d[0]}
                 </button>
@@ -245,17 +246,17 @@ const UpgradeDetailsPage: React.FC = () => {
         </div>
       }>
         {progress.length === 0 ? (
-          <p className="text-gray-500 text-sm text-center py-4">No progress logged yet.</p>
+          <p className="text-fg-subtle text-sm text-center py-4">No progress logged yet.</p>
         ) : (
           <div className="space-y-2 max-h-64 overflow-y-auto">
             {[...progress].reverse().map((p) => (
-              <div key={p.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg text-sm">
-                <span className="text-gray-500">{new Date(p.date).toLocaleDateString()}</span>
+              <div key={p.id} className="flex items-center justify-between p-3 bg-sunken rounded-lg text-sm">
+                <span className="text-fg-subtle">{new Date(p.date).toLocaleDateString()}</span>
                 <div className="flex items-center gap-3">
                   {p.completed !== undefined && <Badge variant={p.completed ? 'green' : 'red'}>{p.completed ? 'Done' : 'Missed'}</Badge>}
                   {p.numericValue !== undefined && <span className="font-medium">{p.numericValue} {p.unit}</span>}
                   {p.rating !== undefined && <span>⭐ {p.rating}/5</span>}
-                  {p.note && <span className="text-gray-500 italic truncate max-w-32">{p.note}</span>}
+                  {p.note && <span className="text-fg-subtle italic truncate max-w-32">{p.note}</span>}
                 </div>
               </div>
             ))}
@@ -270,12 +271,12 @@ const UpgradeDetailsPage: React.FC = () => {
         </div>
       }>
         {reflections.length === 0 ? (
-          <p className="text-gray-500 text-sm text-center py-4">No reflections yet.</p>
+          <p className="text-fg-subtle text-sm text-center py-4">No reflections yet.</p>
         ) : (
           <div className="space-y-3">
             {[...reflections].reverse().map((r) => (
-              <div key={r.id} className="p-3 bg-gray-50 rounded-lg text-sm space-y-1">
-                <p className="text-gray-400">{new Date(r.date).toLocaleDateString()}</p>
+              <div key={r.id} className="p-3 bg-sunken rounded-lg text-sm space-y-1">
+                <p className="text-fg-faint">{new Date(r.date).toLocaleDateString()}</p>
                 {r.whatWorked && <p><strong>✅ What worked:</strong> {r.whatWorked}</p>}
                 {r.whatDidNotWork && <p><strong>❌ What didn't:</strong> {r.whatDidNotWork}</p>}
                 {r.nextAdjustment && <p><strong>🔄 Next:</strong> {r.nextAdjustment}</p>}
@@ -295,7 +296,7 @@ const UpgradeDetailsPage: React.FC = () => {
           {(!upgrade.trackingConfig || upgrade.trackingConfig.trackingType === 'BOOLEAN') && (
             <label className="flex items-center gap-2 cursor-pointer">
               <input type="checkbox" checked={progressForm.completed ?? false} onChange={(e) => setProgressForm({ ...progressForm, completed: e.target.checked })} className="w-4 h-4 rounded" />
-              <span className="text-sm font-medium text-gray-700">Completed</span>
+              <span className="text-sm font-medium text-fg-muted">Completed</span>
             </label>
           )}
           {upgrade.trackingConfig?.trackingType === 'NUMERIC' && (
@@ -303,10 +304,10 @@ const UpgradeDetailsPage: React.FC = () => {
           )}
           {upgrade.trackingConfig?.trackingType === 'RATING' && (
             <div>
-              <label className="text-sm font-medium text-gray-700">Rating (1-5)</label>
+              <label className="text-sm font-medium text-fg-muted">Rating (1-5)</label>
               <div className="flex gap-2 mt-2">
                 {[1, 2, 3, 4, 5].map((n) => (
-                  <button key={n} type="button" onClick={() => setProgressForm({ ...progressForm, rating: n })} className={`w-10 h-10 rounded-full text-sm font-semibold transition-colors ${progressForm.rating === n ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}>{n}</button>
+                  <button key={n} type="button" onClick={() => setProgressForm({ ...progressForm, rating: n })} className={`w-10 h-10 rounded-full text-sm font-semibold transition-colors ${progressForm.rating === n ? 'bg-brand text-fg-inverted' : 'bg-muted text-fg-muted hover:bg-muted-strong'}`}>{n}</button>
                 ))}
               </div>
             </div>
@@ -323,16 +324,16 @@ const UpgradeDetailsPage: React.FC = () => {
         <form onSubmit={(e) => { e.preventDefault(); reflectionMutation.mutate(reflectionForm); }} className="space-y-4">
           <Input label="Date" type="date" value={reflectionForm.date} onChange={(e) => setReflectionForm({ ...reflectionForm, date: e.target.value })} />
           <div>
-            <label className="text-sm font-medium text-gray-700">What worked?</label>
-            <textarea className="w-full mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" rows={2} value={reflectionForm.whatWorked ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, whatWorked: e.target.value })} />
+            <label className="text-sm font-medium text-fg-muted">What worked?</label>
+            <textarea className="w-full mt-1 rounded-lg border border-line-strong px-3 py-2 text-sm focus:outline-none focus:ring-2" rows={2} value={reflectionForm.whatWorked ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, whatWorked: e.target.value })} />
           </div>
           <div>
-            <label className="text-sm font-medium text-gray-700">What didn't work?</label>
-            <textarea className="w-full mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" rows={2} value={reflectionForm.whatDidNotWork ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, whatDidNotWork: e.target.value })} />
+            <label className="text-sm font-medium text-fg-muted">What didn't work?</label>
+            <textarea className="w-full mt-1 rounded-lg border border-line-strong px-3 py-2 text-sm focus:outline-none focus:ring-2" rows={2} value={reflectionForm.whatDidNotWork ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, whatDidNotWork: e.target.value })} />
           </div>
           <div>
-            <label className="text-sm font-medium text-gray-700">Next adjustment?</label>
-            <textarea className="w-full mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" rows={2} value={reflectionForm.nextAdjustment ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, nextAdjustment: e.target.value })} />
+            <label className="text-sm font-medium text-fg-muted">Next adjustment?</label>
+            <textarea className="w-full mt-1 rounded-lg border border-line-strong px-3 py-2 text-sm focus:outline-none focus:ring-2" rows={2} value={reflectionForm.nextAdjustment ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, nextAdjustment: e.target.value })} />
           </div>
           <div className="grid grid-cols-2 gap-4">
             <Input label="Difficulty (1-5)" type="number" min={1} max={5} value={reflectionForm.difficultyRating ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, difficultyRating: intOrUndef(e.target.value) })} />
@@ -391,7 +392,7 @@ const UpgradeDetailsPage: React.FC = () => {
               onChange={(e) => setTrackingForm({ ...trackingForm, requiredDaily: e.target.checked })}
               className="w-4 h-4 rounded"
             />
-            <span className="text-sm font-medium text-gray-700">Required daily</span>
+            <span className="text-sm font-medium text-fg-muted">Required daily</span>
           </label>
           <div className="flex gap-2 justify-end">
             <Button variant="secondary" type="button" onClick={() => setTrackingOpen(false)}>Cancel</Button>

--- a/frontend/src/router/ProtectedRoute.tsx
+++ b/frontend/src/router/ProtectedRoute.tsx
@@ -16,7 +16,7 @@ interface Props {
  */
 const ProtectedRoute: React.FC<Props> = ({ children }) => {
   const { isAuthenticated, isLoading } = useAuth();
-  if (isLoading) return <div className="min-h-screen flex items-center justify-center"><LoadingSpinner size="lg" /></div>;
+  if (isLoading) return <div className="min-h-screen bg-canvas flex items-center justify-center"><LoadingSpinner size="lg" /></div>;
   if (!isAuthenticated) return <Navigate to="/login" replace />;
   return <>{children}</>;
 };

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,24 @@
+import { afterEach, beforeEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { installMatchMedia } from './test/matchMediaStub';
+
+/**
+ * Per-test isolation.
+ *
+ * `localStorage` and the `dark` class on `<html>` both outlive a test — they live on the jsdom window,
+ * not on the rendered tree — so a test that sets either would otherwise decide the outcome of the next
+ * one. Resetting here rather than in each file is what keeps the suite order-independent.
+ *
+ * `matchMedia` is stubbed for every test, not only the ones that care, so no test silently depends on
+ * whatever jsdom reports by default.
+ */
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.className = '';
+  installMatchMedia(false);
+});
+
+// Testing Library only auto-cleans when Vitest's globals are on. They are off here — see ADR-004.
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/src/test/matchMediaStub.ts
+++ b/frontend/src/test/matchMediaStub.ts
@@ -1,0 +1,60 @@
+/**
+ * A `window.matchMedia` that tests can drive.
+ *
+ * jsdom implements `matchMedia`, but nothing can change what it reports — so the branch that matters
+ * most, the operating system's colour scheme flipping while the tab is open, would be unreachable.
+ * This stub exposes `setMatches`, which updates `matches` and notifies every registered listener, and
+ * `listenerCount`, which is how a test asserts that a subscription was cleaned up rather than leaked.
+ */
+export interface MatchMediaStub {
+  /** Changes what the query reports and fires `change` at every registered listener. */
+  setMatches: (matches: boolean) => void;
+  /** How many listeners are currently registered. Zero after a correct unmount. */
+  listenerCount: () => number;
+}
+
+/**
+ * Replaces `window.matchMedia` with a controllable stub.
+ *
+ * Installed for every test by `setupTests.ts` reporting `false`, so a test that does not care about the
+ * system preference still gets a deterministic one. Call it again with `true` to start dark.
+ */
+export const installMatchMedia = (initialMatches = false): MatchMediaStub => {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  let matches = initialMatches;
+
+  const query = {
+    get matches() {
+      return matches;
+    },
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: (_type: string, listener: EventListener) =>
+      listeners.add(listener as (event: MediaQueryListEvent) => void),
+    removeEventListener: (_type: string, listener: EventListener) =>
+      listeners.delete(listener as (event: MediaQueryListEvent) => void),
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    dispatchEvent: () => true,
+  } as unknown as MediaQueryList;
+
+  window.matchMedia = () => query;
+
+  return {
+    setMatches: (next: boolean) => {
+      matches = next;
+      listeners.forEach((listener) => listener({ matches: next } as MediaQueryListEvent));
+    },
+    listenerCount: () => listeners.size,
+  };
+};
+
+/**
+ * Removes `window.matchMedia` entirely, standing in for the embedded webviews that lack it.
+ *
+ * `Reflect.deleteProperty` rather than `delete window.matchMedia`, which TypeScript rejects on a
+ * non-optional property.
+ */
+export const uninstallMatchMedia = (): void => {
+  Reflect.deleteProperty(window, 'matchMedia');
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,8 +1,99 @@
-/** @type {import('tailwindcss').Config} */
+/**
+ * Every colour in the app is a semantic token, not a palette shade.
+ *
+ * Tokens are declared as `rgb(var(--color-x) / <alpha-value>)` rather than as a hex string because two
+ * call sites need Tailwind's opacity modifier on a colour that must theme: the modal scrim
+ * (`bg-overlay/50`) and the unread notification row (`bg-brand-soft/50`). A hex-valued custom property
+ * cannot take that modifier; space-separated channels can, and Tailwind composes the alpha itself.
+ *
+ * The values live in `src/index.css`, once per theme.
+ *
+ * `darkMode: 'class'` rather than `'selector'`: the declared dependency range is `^3.4.0` and
+ * `'selector'` only landed in 3.4.1, so a fresh install resolving 3.4.0 exactly would break. It also
+ * compiles to a `.dark` descendant selector rather than `:where(.dark, .dark *)`, which has zero
+ * specificity — the higher specificity is what makes a one-off `dark:` override stick.
+ *
+ * @type {import('tailwindcss').Config}
+ */
+
+/** @param {string} name the token's name, without the `--color-` prefix */
+const token = (name) => `rgb(var(--color-${name}) / <alpha-value>)`;
+
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  darkMode: 'class',
   theme: {
     extend: {
+      colors: {
+        canvas: token('canvas'),
+        surface: token('surface'),
+        // Named `sunken` and never `inset`: Tailwind merges a colour named `inset` into its existing
+        // `ring-inset` utility, which would silently recolour any inset ring.
+        sunken: token('sunken'),
+        muted: { DEFAULT: token('muted'), strong: token('muted-strong') },
+        line: { DEFAULT: token('line'), subtle: token('line-subtle'), strong: token('line-strong') },
+        fg: {
+          DEFAULT: token('fg'),
+          muted: token('fg-muted'),
+          subtle: token('fg-subtle'),
+          faint: token('fg-faint'),
+          inverted: token('fg-inverted'),
+        },
+        overlay: token('overlay'),
+        focus: token('focus'),
+
+        brand: {
+          DEFAULT: token('brand'),
+          hover: token('brand-hover'),
+          soft: token('brand-soft'),
+          'soft-hover': token('brand-soft-hover'),
+          line: token('brand-line'),
+          fg: token('brand-fg'),
+        },
+        success: {
+          DEFAULT: token('success'),
+          soft: token('success-soft'),
+          line: token('success-line'),
+          fg: token('success-fg'),
+        },
+        warning: { soft: token('warning-soft'), line: token('warning-line'), fg: token('warning-fg') },
+        danger: {
+          DEFAULT: token('danger'),
+          hover: token('danger-hover'),
+          soft: token('danger-soft'),
+          line: token('danger-line'),
+          fg: token('danger-fg'),
+        },
+        info: { soft: token('info-soft'), line: token('info-line'), fg: token('info-fg') },
+        reminder: { soft: token('reminder-soft'), line: token('reminder-line'), fg: token('reminder-fg') },
+        streak: { soft: token('streak-soft'), line: token('streak-line'), fg: token('streak-fg') },
+        accent: { soft: token('accent-soft'), fg: token('accent-fg') },
+
+        // Decorative category tints, for `Badge` only. Deliberately independent of the semantic families
+        // above: `tint-red` on a MEDICAL_PREVENTIVE badge is a category colour, not a danger signal, and
+        // must not move when the danger hue does. Grey has no hue meaning, so it reuses `muted`.
+        tint: {
+          green: { soft: token('tint-green-soft'), fg: token('tint-green-fg') },
+          yellow: { soft: token('tint-yellow-soft'), fg: token('tint-yellow-fg') },
+          blue: { soft: token('tint-blue-soft'), fg: token('tint-blue-fg') },
+          red: { soft: token('tint-red-soft'), fg: token('tint-red-fg') },
+          purple: { soft: token('tint-purple-soft'), fg: token('tint-purple-fg') },
+        },
+      },
+
+      // Preflight paints every element's default border colour, and out of the box that is gray-200 —
+      // a light rule that would survive into the dark theme on any element carrying `border` with no
+      // colour class of its own.
+      borderColor: { DEFAULT: token('line') },
+
+      // One focus colour for the whole app, so `focus:ring-2` needs no colour class at the call site.
+      // Without the opacity override Tailwind applies `ringOpacity.DEFAULT` of 0.5 to the base ring.
+      ringColor: { DEFAULT: 'rgb(var(--color-focus))' },
+      ringOpacity: { DEFAULT: '1' },
+      // Tailwind's default offset colour is `#fff`. Left alone, every control using `ring-offset-2`
+      // draws a white halo against a near-black page.
+      ringOffsetColor: { DEFAULT: 'rgb(var(--color-surface))' },
+
       // Declared here rather than as an arbitrary `animate-[fadeIn_...]` value at the call site: the
       // arbitrary form emits the `animation` property but no `@keyframes`, so it names a keyframe that
       // does not exist and the element never animates.

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,19 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      // Declared here rather than as an arbitrary `animate-[fadeIn_...]` value at the call site: the
+      // arbitrary form emits the `animation` property but no `@keyframes`, so it names a keyframe that
+      // does not exist and the element never animates.
+      keyframes: {
+        'fade-in': {
+          from: { opacity: '0', transform: 'translateY(-4px)' },
+          to: { opacity: '1', transform: 'none' },
+        },
+      },
+      animation: { 'fade-in': 'fade-in 0.2s ease-out' },
+    },
+  },
   plugins: [],
 }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
+
+/**
+ * Test configuration, layered over the real build configuration rather than restating it.
+ *
+ * Vitest reads this file *instead of* `vite.config.ts` when both exist, so the plugin list is merged in
+ * explicitly — without the merge the tests would run without the React plugin and every `.tsx` file
+ * would fail to transform.
+ *
+ * Kept out of `vite.config.ts` so the production build configuration does not type-depend on a
+ * development-only package. See `docs/ADRs/ADR-004-frontend-test-harness.md`.
+ */
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: 'jsdom',
+      setupFiles: ['./src/setupTests.ts'],
+      include: ['src/**/*.test.{ts,tsx}'],
+      // `describe`/`it`/`expect` are imported explicitly instead, which is what keeps `tsconfig.json`'s
+      // `types` array — and therefore the production type check — untouched.
+      globals: false,
+      restoreMocks: true,
+      css: false,
+    },
+  }),
+);


### PR DESCRIPTION
## Problem

The frontend had no theming layer at all: `tailwind.config.js` was bare, `src/index.css` held only the
three `@tailwind` directives, and there was not one `dark:` variant, `prefers-color-scheme` query or
theme provider anywhere in `src/`. Colour was written as literal Tailwind palette utilities at 247 call
sites across 29 files.

Settles the brainstorm opened in #36. Ticks the `Dark mode` box in the README's future-improvements list.

The audit that preceded this found the existing palette already carried WCAG failures **in light mode**,
before dark mode was considered: `text-gray-400` is **2.54:1** on white, and `border-gray-300` on form
inputs is **1.47:1**. A mechanical `dark:` sweep would have preserved both forever.

## Approach

Every colour becomes a **semantic token** — a role, not a shade. 55 tokens declared in
`tailwind.config.js` as `rgb(var(--color-x) / <alpha-value>)`, given their light and dark values in
`index.css` under `:root` and `.dark`.

Channel triplets rather than hex are forced by two call sites that use Tailwind's opacity modifier on a
colour that must theme — the modal scrim and the unread-notification tint. A hex-valued CSS variable
cannot take that modifier; a channel triplet can.

`darkMode: 'class'`, not `'selector'`: `package.json` declares `^3.4.0` and `'selector'` only landed in
3.4.1, so a fresh install resolving 3.4.0 exactly would break.

Theme state is three-valued — light / dark / **system**, where system follows the OS live rather than
only at boot. Persistence is `localStorage` only: no backend change, no migration, no endpoint.

A classic (non-module) inline script in `<head>` applies the `dark` class before first paint. It must
stay non-module — a `type="module"` inline script gets bundled and deferred, which reintroduces the flash.

## Trade-offs accepted

- **Light mode visibly changes.** Meeting AA moves form-control borders (1.47:1 → 3.73:1), the faintest
  text (2.54:1 → 4.83:1), the progress fill and the unread-count badge. Inputs now read as noticeably
  more outlined. The light text ramp compresses from 17.7/10.3/6.0/2.5 to 17.7/10.3/6.0/4.8 — hierarchy
  survives, the two faintest steps sit 1.24x apart instead of 1.9x. Unavoidable at AA.
- **One deliberate AA exception, stated rather than hidden.** `line` (1.24:1) and `line-subtle` (1.13:1)
  do not meet 3:1. WCAG 1.4.11 covers visual information required to *identify components and states*; a
  card's decorative outline and a list's divider identify nothing, and the card is not a control. Control
  boundaries — `Input`, `Select`, the modal panel, the focus ring — *are* enforced at 3:1 via
  `line-strong`. Changing `line` to `#7C8593` gets 3:1 everywhere and moves nothing else.
- **`system` is the default, so this ships as a visible change for existing users.** Anyone on a dark OS
  gets dark on the next deploy without opting in. Correct semantics, but it is not a silent release.
- **Emoji are the known, unfixable limitation.** Sidebar nav and empty-state glyphs carry their own
  colours and will read as bright specks on dark surfaces. No CSS remedy; `ThemeToggle`'s inline SVG
  establishes the pattern for a follow-up icon set.
- **Tailwind fails silently** — `bg-surfce` emits no CSS and no error. Mitigated by `npm run check:colours`,
  which greps `src/` for any surviving palette class and runs in CI.

## What was done

Twelve commits, each leaving lint, test and build green. The token sweep lands **before** the provider so
commits 5-8 review as "did the class names map correctly?" against a still-light app, and commit 9 reviews
as "does the switch work?" against a fully-swept one.

| # | Commit | Contents |
|---|---|---|
| 1 | `docs: record the frontend test harness decision (ADR-004)` | ADR-002 built a floor under the backend and left the frontend with none |
| 2 | `chore(frontend): add Vitest, jsdom and Testing Library` | Config, setup, CI step |
| 3 | `fix(frontend): define the fadeIn keyframes the toasts animate with` | Pre-existing bug: the arbitrary-value form is exactly what stopped Tailwind emitting the keyframes, so the toast animation had never run |
| 4 | `feat(frontend): define the semantic colour tokens` | Config + CSS. No consumers yet |
| 5-8 | the sweep | 29 files, in four reviewable slices: primitives, shell, notifications, upgrade views and pages |
| 9 | `feat(frontend): add the theme provider and the pre-paint boot script` | Dark mode becomes reachable here |
| 10 | `feat(frontend): add the three-state theme toggle` | Navbar and both auth pages |
| 11-12 | `.gitignore`, docs | Requirements, architecture, `frontend/CLAUDE.md`, README |

Two structural fixes taken while in the neighbourhood, both flagged in the plan: `Sidebar` moves to
`bg-surface` so the rail no longer collides with the page canvas, and the notification categories
separate (WARNING red→amber, INFO brand-blue→cyan, REMINDER orange→violet) so a category colour is no
longer indistinguishable from a severity signal.

## How it was verified

Automated, all of it in CI:

```
cd frontend && npm run lint            # eslint --max-warnings 0 — clean
cd frontend && npm run test            # vitest run — 31 passed
cd frontend && npm run build           # tsc && vite build — 190 modules, built
cd frontend && npm run check:colours   # "No palette colours in src/ — all 63 source files use tokens"
```

Contrast was **computed**, not eyeballed — every token pair checked against WCAG AA with a purpose-written
script. Worst text pair anywhere after the change: **4.63:1**. Worst non-text: **3.29:1**.

Two of the tests were confirmed to bite rather than merely pass: removing the `removeEventListener`
cleanup makes StrictMode register two `matchMedia` listeners and two tests fail. `check:colours` was
likewise confirmed by injecting `bg-white` and `border-t-blue-600`, both caught.

Manual pass in a real browser across login, register, dashboard, daily check-in and a modal, in both
themes: theme persists across reload, `color-scheme: dark` reaches the native controls, the focus ring
offset resolves to the dark surface rather than painting a white halo, and the modal panel is discernible
against the scrim.

**Not verified:** first paint was not frame-captured, so "no flash" rests on the script ordering plus
observed persistence, not on watching it.

## ADRs

- `docs/ADRs/ADR-004-frontend-test-harness.md` — new, records Vitest + jsdom + Testing Library and why
  Vitest 3 rather than 4 (Vitest 4 requires Vite >= 6; this project is on Vite 5.4.21).

## Out of scope, tracked separately

- `aria-pressed` on the four pill groups and `aria-invalid`/`aria-describedby` on `Input`/`Select`. Real
  bugs, equally broken in light mode today, not theming bugs.
- Replacing emoji UI icons with an SVG set.
- Pre-existing, unrelated: health-area cards render `water_drop` / `fitness_center` / `bedtime` as literal
  text — `V2__seed_data.sql` stores Material Symbols names while `HealthAreasPage.tsx:91` renders that
  field as an emoji. Identical in light mode.
