### PR TITLE
fix(frontend): make the layout fit the browser window at any size

### DIFF
--- a/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaDto.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaDto.java
@@ -11,7 +11,9 @@ import java.util.UUID;
  * @param name        display name, e.g. "Nutrition"
  * @param description free-text note, may be null
  * @param priority    ordering hint chosen by the user, may be null
- * @param icon        icon key the frontend resolves to a glyph, may be null
+ * @param icon        the glyph to draw for the area, usually an emoji; may be null. Not an icon-font
+ *                    key: nothing in the client turns a name such as "water_drop" into a picture, and
+ *                    a value that is not drawable is replaced by a default when it is rendered
  * @param color       colour token the frontend resolves to a class, may be null
  * @param createdAt   when the area was created
  * @param updatedAt   when it was last modified

--- a/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaRequest.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaRequest.java
@@ -11,7 +11,8 @@ import jakarta.validation.constraints.NotBlank;
  * @param name        display name; required and non-blank
  * @param description free-text note, optional
  * @param priority    ordering hint, optional
- * @param icon        icon key, optional
+ * @param icon        the glyph to draw for the area, usually an emoji; optional. Not an icon-font key
+ *                    — see {@link HealthAreaDto}
  * @param color       colour token, optional
  */
 public record HealthAreaRequest(

--- a/backend/src/main/resources/db/migration/V5__seed_health_area_icons_as_emoji.sql
+++ b/backend/src/main/resources/db/migration/V5__seed_health_area_icons_as_emoji.sql
@@ -1,0 +1,18 @@
+-- The seeded health areas carried Material Symbols ligature names in `icon` ('water_drop',
+-- 'fitness_center', ...), but no icon font is loaded anywhere in the frontend and the form labels the
+-- field "Icon (emoji)". The page drew those names as their own literal text. They are rewritten here as
+-- the emoji they were always meant to stand for.
+--
+-- A new migration rather than an edit to V2: Flyway stores a checksum per applied version, so changing
+-- an already-applied file makes every existing database refuse to start with a checksum mismatch.
+--
+-- Each row is matched on its id *and* on the value being replaced, so an account that has already set
+-- its own icon keeps it. Every glyph is a single code point with default emoji presentation, so nothing
+-- depends on how a variation selector survives the driver or the column.
+
+UPDATE health_areas SET icon = '💧' WHERE id = 'b0000000-0000-0000-0000-000000000001' AND icon = 'water_drop';
+UPDATE health_areas SET icon = '🏃' WHERE id = 'b0000000-0000-0000-0000-000000000002' AND icon = 'fitness_center';
+UPDATE health_areas SET icon = '🌙' WHERE id = 'b0000000-0000-0000-0000-000000000003' AND icon = 'bedtime';
+UPDATE health_areas SET icon = '🥗' WHERE id = 'b0000000-0000-0000-0000-000000000004' AND icon = 'restaurant';
+UPDATE health_areas SET icon = '🧘' WHERE id = 'b0000000-0000-0000-0000-000000000005' AND icon = 'self_improvement';
+UPDATE health_areas SET icon = '🌿' WHERE id = 'b0000000-0000-0000-0000-000000000006' AND icon = 'eco';

--- a/docs/ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md
+++ b/docs/ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md
@@ -1,0 +1,121 @@
+# ADR-005: One page width, and a shell that cannot be pushed wider than the window
+
+- **Status:** Accepted
+- **Date:** 2026-08-20
+- **Scope:** `frontend/` layout, plus one data-only backend migration. No new dependency, no runtime
+  behaviour outside the browser.
+
+## Context
+
+The SPA had no layout contract. Each page picked its own width cap as it was written, and by the time
+there were nine of them the same window showed the dashboard at 1152px, health areas at 896px and the
+daily check-in at 672px, with nothing a reader could reconstruct behind the choice. On a maximised
+1536px window `/health-areas` left roughly a third of the content area permanently empty.
+
+Three further things were true and none of them were written down:
+
+- **`<main>` was safe from overflow by accident.** It carried `overflow-auto`, which produces no
+  scrollbar (its height is auto, so it never overflows vertically) and looked inert. It was not: CSS
+  Flexbox §4.5 gives a flex item an automatic minimum size of zero when its overflow is anything other
+  than `visible`. Delete that class and the shell would start being dragged wider than the viewport by
+  its own content, with no clue in the diff as to why.
+- **Nothing constrained content that came from the database.** The six seeded health areas store
+  Material Symbols ligature names in `icon` — `water_drop`, `fitness_center`, `self_improvement` — but
+  no icon font is loaded anywhere and the form asks for an emoji. The card rendered the name verbatim
+  at `text-2xl`, where it displaced the area's own title and was clipped at the card's edge by `Card`'s
+  `overflow-hidden`. Storage, form and render path disagreed about what the field held.
+- **A dialog could not fit a short window.** `Modal` centred a panel with no maximum height and no
+  scroll region of its own, and guarded only its left and right edges with `mx-4`. A four-field form in
+  a 500px-tall viewport overflowed above and below the fold, and the part above it was unreachable
+  because nothing scrolled.
+
+None of this can be caught by a test here. jsdom has no layout engine and `vitest.config.ts` sets
+`css: false`, so every width, overflow and clipping question is invisible to the suite —
+[ADR-004](ADR-004-frontend-test-harness.md) records why a real browser in CI was deferred, and
+`requirements.md` §6 has carried that gap as an open question since.
+
+## Decision
+
+**One container decides page width.** `frontend/src/components/ui/PageContainer.tsx` offers two: the
+default 1280px (`max-w-7xl`) for lists, grids and dashboards, and 768px (`max-w-3xl`) for reading and
+form pages. All nine pages use it. The cap is on the measure — how long a line of text may get — not on
+the layout, so below roughly a 1570px viewport a default page simply fills the space the shell gives
+it. Horizontal padding stays on `<main>` so a page can never double it.
+
+**The shell is shrinkable by construction, and says so.** `min-w-0` on `<main>` replaces the accidental
+`overflow-auto`. A flex item's `min-width` defaults to `auto`, which resolves to its min-content width
+and silently overrules `flex-shrink`; `min-w-0` removes that floor. Content that then meets pressure
+resolves it itself — `truncate` on the navbar's user name, `break-words` on names and descriptions, a
+fixed `h-8 w-8 overflow-hidden` box around a health area's icon, `flex-wrap` on header rows and button
+rows.
+
+**A dialog is bounded by its overlay and scrolls its own body.** The overlay carries the gutter as
+padding; `max-h-full` resolves against that padded box, so the panel is never taller than the window;
+`flex flex-col` with a `shrink-0` header and an `overflow-y-auto` body keeps the title and close button
+in place while the form scrolls. It also gained `role="dialog"`, `aria-modal` and an `aria-labelledby`
+name derived with `useId`, since three modals share the health areas page.
+
+**Stored icons are reconciled on the render side, then corrected in the data.** `areaIcon.ts` falls back
+to the default glyph for anything starting with an ASCII word character, so the layout holds whatever
+the database contains; `V5__seed_health_area_icons_as_emoji.sql` then rewrites the six seeded rows as
+emoji. The render fix ships first, so at no point does the page depend on the migration having run.
+
+## Consequences
+
+**Easier.** Changing how wide pages are is one edit in one file. A new page inherits the decision
+instead of re-making it. A future overflow has one obvious place to look, and the reason `min-w-0` is
+there is written next to it rather than implied by a class that appears to do nothing.
+
+**Harder.** A genuinely unshrinkable future child — a wide data table — will now overflow visibly and
+give the document a horizontal scrollbar, where `overflow-auto` used to hide it inside `<main>`. That is
+the intended trade: a visible bug beats a silent one, and the fix belongs on that child's own wrapper as
+an opt-in `overflow-x-auto`.
+
+**Unchanged, and still unverified.** Nothing here is enforced by a test, and this ADR does not add a
+gate. Widths, wrapping, the dialog's scroll region and the absence of horizontal overflow were checked
+by hand in a browser at the widths listed in the pull request. The one mechanical assertion is
+`PageContainer.test.tsx`, which pins which cap each variant selects and explicitly claims nothing about
+the resulting layout.
+
+**Two widths changed deliberately.** The daily check-in goes from 672px to 768px and the notification
+and progress lists from 768px to 1280px. One reading cap and one default cap beat four arbitrary ones,
+and both list pages are rows with right-aligned metadata that read better wide.
+
+**`aria-modal` overstates what the dialog does.** It tells assistive technology the rest of the page is
+inert, but nothing traps the keyboard, so Tab still walks out behind the scrim, and focus is neither
+moved in on open nor restored on close. Recorded as an open question rather than half-solved.
+
+## Alternatives considered
+
+- **Leave the per-page caps and fix only the modal.** Rejected: the empty band on a wide window was the
+  reported symptom, and nine inconsistent caps is the kind of thing that gets copied into the tenth
+  page. *Revisit:* never — the inconsistency is the defect.
+- **No cap at all; content always fills the window.** Rejected: a 1920px window would give a
+  seventy-word line on the upgrade details page. The cap exists for the measure, not for the layout.
+- **`overflow-x: hidden` on the shell.** Rejected: it hides the symptom, and it clips any sticky or
+  popover child added later — the notification dropdown escapes its card today. *Revisit:* never.
+- **Container queries (`@tailwindcss/container-queries`).** Tailwind's breakpoints measure the viewport,
+  but the content area is 240px narrower whenever the sidebar is showing, so the column count changes
+  later than the numbers suggest — and at exactly `md` the sidebar appears and the content column drops
+  from 735px to 480px in one step. Container queries are the correct answer and cost a dependency.
+  *Revisit when* a second layout hits the same cliff, or the sidebar becomes collapsible and the
+  viewport-to-content offset stops being a constant.
+- **A native `<dialog>` with `showModal()`.** The correct answer to the focus trap: a real trap, real
+  inertness, native Escape and the top layer, with no hand-rolled key handling. Not adopted here because
+  the backdrop moves from a token-styled `<div>` to `::backdrop`, which lives in `index.css` — and
+  `check:colours` scans only `index.html` and `src/**/*.ts(x)`, so a colour used there would sit outside
+  the one guard that exists to have none. *Revisit when* the dialog needs a genuine keyboard workflow,
+  and extend `check:colours` to the stylesheet in the same change.
+- **Canonicalising a stored icon to exactly one grapheme with `Intl.Segmenter`.** Rejected: it does not
+  type-check under this project's `lib` setting, and its pre-Firefox-125 fallback splits by code point,
+  which strips a variation selector from `❤️` and a skin tone from `👍🏽`. The fixed-size clipping box
+  already makes the layout immune, so the render path only has to choose between the stored value and
+  the default.
+- **A mobile navigation drawer.** Out of scope. The sidebar is hidden below `md` deliberately and says
+  so; replacing it is a component, focus management and its own requirement.
+
+## Note
+
+Emoji are still written as literals in components — the sidebar's nav icons, the dashboard's stat
+glyphs, `EmptyState`. Most are decorative and lack `aria-hidden`, so a screen reader announces them.
+`Modal` now marks its own; the rest is a follow-up, not part of this decision.

--- a/docs/ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md
+++ b/docs/ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md
@@ -52,13 +52,18 @@ rows.
 **A dialog is bounded by its overlay and scrolls its own body.** The overlay carries the gutter as
 padding; `max-h-full` resolves against that padded box, so the panel is never taller than the window;
 `flex flex-col` with a `shrink-0` header and an `overflow-y-auto` body keeps the title and close button
-in place while the form scrolls. It also gained `role="dialog"`, `aria-modal` and an `aria-labelledby`
-name derived with `useId`, since three modals share the health areas page.
+in place while the form scrolls. It also gained `role="dialog"` and an `aria-labelledby` name derived
+with `useId`, since three modals share the health areas page — but deliberately **not** `aria-modal`,
+which is a claim about the rest of the page being inert that nothing here makes true.
 
 **Stored icons are reconciled on the render side, then corrected in the data.** `areaIcon.ts` falls back
-to the default glyph for anything starting with an ASCII word character, so the layout holds whatever
-the database contains; `V5__seed_health_area_icons_as_emoji.sql` then rewrites the six seeded rows as
-emoji. The render fix ships first, so at no point does the page depend on the migration having run.
+to the default for a value that is recognisably an icon *key* — an ASCII identifier, anchored at both
+ends so a keycap emoji such as `1️⃣` is not caught by its leading digit. It does not attempt to decide
+emoji-ness in general; it does not have to, because the icon is drawn in a fixed clipping box that no
+value can widen. The edit form uses the same predicate, so an undrawable value arrives as empty rather
+than being offered back for saving. `V5__seed_health_area_icons_as_emoji.sql` then rewrites the six
+seeded rows as emoji. The render fix ships first, so at no point does the page depend on the migration
+having run.
 
 ## Consequences
 
@@ -77,13 +82,22 @@ by hand in a browser at the widths listed in the pull request. The one mechanica
 `PageContainer.test.tsx`, which pins which cap each variant selects and explicitly claims nothing about
 the resulting layout.
 
-**Two widths changed deliberately.** The daily check-in goes from 672px to 768px and the notification
-and progress lists from 768px to 1280px. One reading cap and one default cap beat four arbitrary ones,
-and both list pages are rows with right-aligned metadata that read better wide.
+**Eight of the nine page widths changed.** Only the upgrade details page keeps its number. The daily
+check-in narrows the gap the other way, 672px to 768px; everything else widens, most of it 896px to
+1280px, and the notification and progress lists 768px to 1280px. One reading cap and one default cap
+beat four arbitrary ones, and both list pages are rows with right-aligned metadata that read better
+wide. The card grids on the upgrade lists and health areas gain a third column at `xl` so the extra
+width becomes another card rather than more whitespace inside two very wide ones.
 
-**`aria-modal` overstates what the dialog does.** It tells assistive technology the rest of the page is
-inert, but nothing traps the keyboard, so Tab still walks out behind the scrim, and focus is neither
-moved in on open nor restored on close. Recorded as an open question rather than half-solved.
+Two container widths remain outside `PageContainer` and are meant to: the login and register cards
+(`max-w-md`), which render outside `Layout` entirely.
+
+**The dialog announces itself but does not contain anything.** Nothing traps the keyboard, so Tab still
+walks out behind the scrim, and focus is neither moved in on open nor restored on close. `aria-modal`
+is therefore left off on purpose: it would remove the page behind from a screen reader's buffer while
+focus could still reach it, which is worse than the plain `dialog` role — controls that are focusable
+but unannounced. The role and the accessible name are the part that is honestly earned. Recorded as an
+open question rather than half-solved.
 
 ## Alternatives considered
 
@@ -113,6 +127,11 @@ moved in on open nor restored on close. Recorded as an open question rather than
   the default.
 - **A mobile navigation drawer.** Out of scope. The sidebar is hidden below `md` deliberately and says
   so; replacing it is a component, focus management and its own requirement.
+- **Letting the navbar's controls compress.** The theme toggle, bell and logout button are `shrink-0`
+  as a group, which put a 436px floor under the shell until the brand was made the thing that gives:
+  `min-w-0` on the link plus `truncate` on the wordmark. A half-width logout button is worse than an
+  ellipsised wordmark. *Revisit when* the navbar gains a fifth control, at which point the wordmark
+  alone can no longer absorb the difference and something has to move to an overflow menu.
 
 ## Note
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -69,7 +69,7 @@ Nine contexts, each owning its own vocabulary, plus a cross-cutting `common`.
 | `src/hooks/` | `useAuth`, `useNotifications` and `useTheme` — typed context readers that fail loudly outside their provider |
 | `src/router/` | The route table, and `ProtectedRoute`, which gates every authenticated page |
 | `src/pages/` | One component per route |
-| `src/components/` | `ui/` primitives, `upgrade/` cards and badges, `notifications/` bell, dropdown, items and toasts, `layout/` navbar and sidebar |
+| `src/components/` | `ui/` primitives — including `PageContainer`, which decides how wide a page may grow — `upgrade/` cards and badges, `notifications/` bell, dropdown, items and toasts, `layout/` navbar and sidebar |
 | `src/types/` | Hand-written mirrors of the backend's response shapes and enums |
 
 ---
@@ -262,6 +262,16 @@ inline script in `index.html` that runs before the first paint, and thereafter b
 two must agree on the storage key and the resolution rule; changing one alone reintroduces the flash
 the script exists to prevent.
 
+**Nothing in the shell may be wider than the window.** `<main>` carries `min-w-0`, and that is
+load-bearing rather than tidy. A flex item's `min-width` defaults to `auto`, which resolves to its
+min-content width — so a single child that cannot shrink overrules `flex-shrink`, and the column, not
+the child, is what grows past the viewport. `min-w-0` removes that floor and hands the pressure back to
+the content, which is why every user-supplied string in the shell also carries `truncate` or
+`break-words`, and why a health area's icon sits in a fixed clipping box. It replaced an
+`overflow-auto` that was doing the same job invisibly: a flex item whose overflow is not `visible`
+already has an automatic minimum size of zero. How wide a page may then grow is decided once, in
+`PageContainer`, and not by the pages. See [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md).
+
 **The frontend's types are hand-written, not generated.** `src/types/index.ts` mirrors the backend's
 DTOs and enums by hand. The **enums** are checked: `FrontendEnumContractTest` reads that file and fails
 the build if any mirrored union stops matching its backend enum, which is what stops an unbindable
@@ -293,6 +303,7 @@ Stated because they are load-bearing, not because they are problems yet:
 | Why DDD + hexagonal at all, and why JPA entities as the domain model? | [ADR-001](../ADRs/ADR-001-ddd-hexagonal-architecture.md) |
 | Why the `upgrade`/`tracking` dependency is inverted; why events moved out of `common`; what the ten ArchUnit rules cover; what was rejected and when to revisit | [ADR-002](../ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md) |
 | Why the frontend tests with Vitest rather than Jest; why Vitest is pinned to 3; why there is still no accessibility gate | [ADR-004](../ADRs/ADR-004-frontend-test-harness.md) |
+| Why every page shares one width; why the shell can be trusted not to overflow; why container queries and a native `<dialog>` were turned down | [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md) |
 | Day-to-day conventions when changing backend code | [`backend/CLAUDE.md`](../../backend/CLAUDE.md) |
 | Day-to-day conventions when changing frontend code | [`frontend/CLAUDE.md`](../../frontend/CLAUDE.md) |
 | How to run, test and deploy it | [`README.md`](../../README.md) |

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -99,6 +99,10 @@ nothing is shared between accounts.
 | FR-35 | A user who is following the operating system sees the interface change when that preference changes, without reloading | `ThemeProvider`, `ThemeProvider.test.tsx` |
 | FR-36 | A user's explicit choice overrides the operating system's preference until they change it | `ThemeProvider`, `ThemeProvider.test.tsx` |
 | FR-37 | The theme control is reachable before signing in | `LoginPage`, `RegisterPage` |
+| FR-38 | A page's content grows with the browser window, up to one cap chosen for readability | `PageContainer`, `PageContainer.test.tsx` |
+| FR-39 | A dialog fits the window at any size: its heading stays put and only its body scrolls | `Modal` — checked by hand, see §6 |
+| FR-40 | A dialog announces itself as a dialog named by its title | `Modal`, `Modal.test.tsx` |
+| FR-41 | A health area whose stored icon is not a glyph is shown with the default icon | `areaIconGlyph`, `areaIcon.test.ts` |
 
 ---
 
@@ -147,6 +151,7 @@ nothing is shared between accounts.
 | NFR-17 | The interface remains usable where browser storage is blocked or `matchMedia` is unavailable | `ThemeProvider`, `ThemeProvider.test.tsx` |
 | NFR-18 | Every colour in the interface is a semantic token, so no component can hard-code one that survives a theme change | `frontend/scripts/check-colours.mjs`, `.github/workflows/ci.yml` |
 | NFR-19 | Text meets a 4.5:1 contrast ratio and control boundaries 3:1, in both themes | the token values in `frontend/src/index.css` — computed, not automatically re-checked; see §6 |
+| NFR-20 | The interface does not scroll horizontally at any window width, whatever a user has stored in it | the shell's `min-w-0` floor and the truncation rules on every user-supplied string ([ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)) — checked by hand, see §6 |
 
 ---
 
@@ -174,7 +179,12 @@ Undecided, and owned by the repository owner.
 - **The frontend has no accessibility or visual-regression gate.** Contrast ratios in the theme were
   computed by hand; nothing re-checks them when a colour changes, and jsdom cannot — it has no layout
   engine. Closing this needs a real browser in CI; [ADR-004](../ADRs/ADR-004-frontend-test-harness.md)
-  records why that was deferred.
+  records why that was deferred. FR-39 and NFR-20 land in exactly this gap: no test in the suite can
+  observe a width, a wrap or an overflow, so both were verified by hand and neither is enforced.
+- **A dialog claims `aria-modal` but does not trap focus.** Tab still walks out of the dialog into the
+  page behind it, and focus is neither moved into the dialog on open nor restored on close. Closing this
+  properly means a native `<dialog>` with `showModal()`; [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)
+  records why that was not done here.
 - **The backend has no dependency vulnerability audit.** OWASP dependency-check needs an `NVD_API_KEY`
   secret; ADR-002 records why a check that cannot fail was judged worse than none.
 - **An unbindable request body returns 500 rather than 400** — tracked as

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -102,7 +102,7 @@ nothing is shared between accounts.
 | FR-38 | A page's content grows with the browser window, up to one cap chosen for readability | `PageContainer`, `PageContainer.test.tsx` |
 | FR-39 | A dialog fits the window at any size: its heading stays put and only its body scrolls | `Modal` — checked by hand, see §6 |
 | FR-40 | A dialog announces itself as a dialog named by its title | `Modal`, `Modal.test.tsx` |
-| FR-41 | A health area whose stored icon is not a glyph is shown with the default icon | `areaIconGlyph`, `areaIcon.test.ts` |
+| FR-41 | A health area whose stored icon cannot be drawn is shown with the default icon, and editing it does not write the undrawable value back | `areaIconGlyph`, `isIconGlyph`, `areaIcon.test.ts` |
 
 ---
 
@@ -151,7 +151,7 @@ nothing is shared between accounts.
 | NFR-17 | The interface remains usable where browser storage is blocked or `matchMedia` is unavailable | `ThemeProvider`, `ThemeProvider.test.tsx` |
 | NFR-18 | Every colour in the interface is a semantic token, so no component can hard-code one that survives a theme change | `frontend/scripts/check-colours.mjs`, `.github/workflows/ci.yml` |
 | NFR-19 | Text meets a 4.5:1 contrast ratio and control boundaries 3:1, in both themes | the token values in `frontend/src/index.css` — computed, not automatically re-checked; see §6 |
-| NFR-20 | The interface does not scroll horizontally at any window width, whatever a user has stored in it | the shell's `min-w-0` floor and the truncation rules on every user-supplied string ([ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)) — checked by hand, see §6 |
+| NFR-20 | The interface does not scroll horizontally at any window width from 320px upward, whatever a user has stored in it | the shell's `min-w-0` floors and the truncation rules on every user-supplied string ([ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)) — checked by hand at 320, 360, 486, 684, 1040 and 1540px, see §6 |
 
 ---
 
@@ -181,8 +181,9 @@ Undecided, and owned by the repository owner.
   engine. Closing this needs a real browser in CI; [ADR-004](../ADRs/ADR-004-frontend-test-harness.md)
   records why that was deferred. FR-39 and NFR-20 land in exactly this gap: no test in the suite can
   observe a width, a wrap or an overflow, so both were verified by hand and neither is enforced.
-- **A dialog claims `aria-modal` but does not trap focus.** Tab still walks out of the dialog into the
-  page behind it, and focus is neither moved into the dialog on open nor restored on close. Closing this
+- **A dialog does not trap focus.** Tab walks out of the dialog into the page behind it, and focus is
+  neither moved into the dialog on open nor restored on close. `aria-modal` is deliberately left off
+  until that is true, because claiming it without a trap is worse than not claiming it. Closing this
   properly means a native `<dialog>` with `showModal()`; [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)
   records why that was not done here.
 - **The backend has no dependency vulnerability audit.** OWASP dependency-check needs an `NVD_API_KEY`

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -8,16 +8,29 @@ interface LayoutProps {
 }
 
 /**
- * The frame every signed-in page renders inside: fixed navbar, sidebar, and a scrolling content area.
+ * The frame every signed-in page renders inside: a sticky navbar, the sidebar rail, and the content
+ * area. Applied by the router rather than by each page, so no authenticated page can be added without
+ * it. How wide the page inside it may grow is decided by `PageContainer`, not here.
  *
- * Applied by the router rather than by each page, so no authenticated page can be added without it.
+ * `min-w-0` on the content column is load-bearing. A flex item's `min-width` defaults to `auto`, which
+ * resolves to its *min-content* width, so one child that cannot shrink — a long unbroken string, a wide
+ * table — overrules `flex-shrink` and drags the column past the viewport. `min-w-0` replaces that floor
+ * with zero and gives the shrinking back; the child then has to resolve the pressure itself, which is
+ * what the `truncate` and `break-words` rules further down the tree are for.
+ *
+ * It replaces an `overflow-auto` that was doing the same job by accident: a flex item whose overflow is
+ * not `visible` already has an automatic minimum size of zero. That was worth stating outright rather
+ * than leaving as a side effect — and it made `<main>` a scroll container, which would clip any sticky
+ * or overflowing child added inside it later. The cost is that a genuinely unshrinkable future child
+ * now overflows visibly instead of scrolling inside `<main>`; that is the better failure, and the fix
+ * then belongs on that child's own wrapper.
  */
 const Layout: React.FC<LayoutProps> = ({ children }) => (
   <div className="min-h-screen bg-canvas flex flex-col">
     <Navbar />
     <div className="flex flex-1">
       <Sidebar />
-      <main className="flex-1 p-6 overflow-auto">{children}</main>
+      <main className="flex-1 min-w-0 p-4 sm:p-6">{children}</main>
     </div>
   </div>
 );

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -10,20 +10,20 @@ const Navbar: React.FC = () => {
   const { user, logout } = useAuth();
 
   return (
-    <nav className="bg-surface border-b border-line h-16 flex items-center px-6 justify-between sticky top-0 z-30">
-      <Link to="/dashboard" className="flex items-center gap-2">
+    <nav className="bg-surface border-b border-line h-16 flex items-center gap-4 px-4 sm:px-6 justify-between sticky top-0 z-30">
+      <Link to="/dashboard" className="flex items-center gap-2 shrink-0">
         <span className="text-2xl">💪</span>
         <span className="font-bold text-fg text-lg">UpHealther</span>
       </Link>
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2 sm:gap-3 min-w-0">
         <ThemeToggle />
         <NotificationBell />
         {user && (
-          <span className="text-sm text-fg-subtle hidden sm:block">
+          <span className="text-sm text-fg-subtle hidden sm:block min-w-0 truncate">
             Hi, <span className="font-medium">{user.name}</span>
           </span>
         )}
-        <Button variant="ghost" size="sm" onClick={logout}>
+        <Button variant="ghost" size="sm" onClick={logout} className="shrink-0">
           Logout
         </Button>
       </div>

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -11,15 +11,15 @@ const Navbar: React.FC = () => {
 
   return (
     <nav className="bg-surface border-b border-line h-16 flex items-center gap-4 px-4 sm:px-6 justify-between sticky top-0 z-30">
-      <Link to="/dashboard" className="flex items-center gap-2 shrink-0">
-        <span className="text-2xl">💪</span>
-        <span className="font-bold text-fg text-lg">UpHealther</span>
+      <Link to="/dashboard" className="flex items-center gap-2 min-w-0">
+        <span className="text-2xl shrink-0" aria-hidden="true">💪</span>
+        <span className="font-bold text-fg text-lg truncate">UpHealther</span>
       </Link>
-      <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+      <div className="flex items-center gap-2 sm:gap-3 shrink-0">
         <ThemeToggle />
         <NotificationBell />
         {user && (
-          <span className="text-sm text-fg-subtle hidden sm:block min-w-0 truncate">
+          <span className="text-sm text-fg-subtle hidden sm:block max-w-[12rem] truncate">
             Hi, <span className="font-medium">{user.name}</span>
           </span>
         )}

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -26,7 +26,7 @@ const NotificationBell: React.FC = () => {
   }, [open]);
 
   return (
-    <div className="relative" ref={containerRef}>
+    <div className="relative shrink-0" ref={containerRef}>
       <button
         onClick={() => setOpen((o) => !o)}
         className="relative w-9 h-9 flex items-center justify-center rounded-full hover:bg-muted transition-colors"

--- a/frontend/src/components/theme/ThemeToggle.tsx
+++ b/frontend/src/components/theme/ThemeToggle.tsx
@@ -61,7 +61,7 @@ const ThemeToggle: React.FC = () => {
   const { theme, resolvedTheme, setTheme } = useTheme();
 
   return (
-    <fieldset className="flex items-center gap-0.5 rounded-full bg-muted p-0.5">
+    <fieldset className="flex shrink-0 items-center gap-0.5 rounded-full bg-muted p-0.5">
       <legend className="sr-only">Theme</legend>
       {options.map((option) => (
         <label key={option.value} title={option.label} className="group cursor-pointer">

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -22,7 +22,7 @@ const TwoModals: React.FC = () => (
   </>
 );
 
-/** Opens a modal from a button, so closing can be observed the way a page uses it. */
+/** Holds the open state itself, so closing can be observed the way a page drives it. */
 const Openable: React.FC = () => {
   const [open, setOpen] = useState(true);
   return (
@@ -40,10 +40,12 @@ describe('Modal', () => {
       expect(screen.getByRole('dialog', { name: 'New Health Area' })).toBeDefined();
     });
 
-    it('GivenAnOpenModal_WhenItRenders_ThenItIsMarkedAsModal', () => {
+    // Pins a deliberate omission, not an oversight: nothing here traps focus, so claiming the page
+    // behind is inert would strand a screen-reader user on controls it had removed from their buffer.
+    it('GivenAnOpenModal_WhenItRenders_ThenItDoesNotClaimTheRestOfThePageIsInert', () => {
       renderModal();
 
-      expect(screen.getByRole('dialog').getAttribute('aria-modal')).toBe('true');
+      expect(screen.getByRole('dialog').getAttribute('aria-modal')).toBeNull();
     });
 
     it('GivenAnOpenModal_WhenItRenders_ThenTheCloseControlIsLabelled', () => {
@@ -91,7 +93,22 @@ describe('Modal', () => {
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it('GivenAModalThatHasClosed_WhenEscapeIsPressed_ThenNothingListensForIt', () => {
+    // The listener is bound only while open. Asserting the dialog is still gone would pass either way;
+    // only the callback distinguishes a bound listener from an unbound one.
+    it('GivenAClosedModal_WhenEscapeIsPressed_ThenOnCloseIsNotCalled', () => {
+      const onClose = vi.fn();
+      render(
+        <Modal isOpen={false} onClose={onClose} title="New Health Area">
+          <p>body</p>
+        </Modal>,
+      );
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('GivenAnOpenModalThatHasSinceClosed_WhenEscapeIsPressedAgain_ThenItStaysClosed', () => {
       render(<Openable />);
       fireEvent.keyDown(document, { key: 'Escape' });
       expect(screen.queryByRole('dialog')).toBeNull();

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import Modal from './Modal';
+
+const renderModal = (onClose = vi.fn(), title = 'New Health Area') =>
+  render(
+    <Modal isOpen onClose={onClose} title={title}>
+      <p>body</p>
+    </Modal>,
+  );
+
+/** Two modals mounted at once, which is what `HealthAreasPage` does with its create/edit/delete trio. */
+const TwoModals: React.FC = () => (
+  <>
+    <Modal isOpen onClose={() => {}} title="New Health Area">
+      <p>create</p>
+    </Modal>
+    <Modal isOpen onClose={() => {}} title="Delete Health Area">
+      <p>confirm</p>
+    </Modal>
+  </>
+);
+
+/** Opens a modal from a button, so closing can be observed the way a page uses it. */
+const Openable: React.FC = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <Modal isOpen={open} onClose={() => setOpen(false)} title="New Health Area">
+      <p>body</p>
+    </Modal>
+  );
+};
+
+describe('Modal', () => {
+  describe('announcing itself', () => {
+    it('GivenAnOpenModal_WhenItRenders_ThenItIsADialogNamedByItsTitle', () => {
+      renderModal();
+
+      expect(screen.getByRole('dialog', { name: 'New Health Area' })).toBeDefined();
+    });
+
+    it('GivenAnOpenModal_WhenItRenders_ThenItIsMarkedAsModal', () => {
+      renderModal();
+
+      expect(screen.getByRole('dialog').getAttribute('aria-modal')).toBe('true');
+    });
+
+    it('GivenAnOpenModal_WhenItRenders_ThenTheCloseControlIsLabelled', () => {
+      renderModal();
+
+      expect(screen.getByRole('button', { name: 'Close modal' })).toBeDefined();
+    });
+
+    // A hard-coded id would make both dialogs point at the first title, so both would report the same
+    // name — the failure `useId` exists to prevent, and the one a single-modal test cannot see.
+    it('GivenTwoOpenModals_WhenTheyRender_ThenEachIsNamedByItsOwnTitle', () => {
+      render(<TwoModals />);
+
+      expect(screen.getByRole('dialog', { name: 'New Health Area' })).toBeDefined();
+      expect(screen.getByRole('dialog', { name: 'Delete Health Area' })).toBeDefined();
+    });
+  });
+
+  describe('closing', () => {
+    it('GivenAnOpenModal_WhenEscapeIsPressed_ThenItCloses', () => {
+      const onClose = vi.fn();
+      renderModal(onClose);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('GivenAnOpenModal_WhenTheCloseControlIsClicked_ThenItCloses', () => {
+      const onClose = vi.fn();
+      renderModal(onClose);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    // The backdrop is decorative and carries no role, so there is nothing accessible to query it by.
+    it('GivenAnOpenModal_WhenTheBackdropIsClicked_ThenItCloses', () => {
+      const onClose = vi.fn();
+      const { container } = renderModal(onClose);
+
+      fireEvent.click(container.firstElementChild!.firstElementChild!);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('GivenAModalThatHasClosed_WhenEscapeIsPressed_ThenNothingListensForIt', () => {
+      render(<Openable />);
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(screen.queryByRole('dialog')).toBeNull();
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+  });
+
+  it('GivenAClosedModal_WhenItRenders_ThenNeitherTheDialogNorItsBodyIsInTheDocument', () => {
+    render(
+      <Modal isOpen={false} onClose={() => {}} title="New Health Area">
+        <p>body</p>
+      </Modal>,
+    );
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(screen.queryByText('body')).toBeNull();
+  });
+});

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useId } from 'react';
 
 /**
  * @param isOpen   whether the dialog is shown; when false the component renders nothing at all
  * @param onClose  called by the close button, the backdrop and the Escape key alike
- * @param title    heading text
+ * @param title    heading text, which also becomes the dialog's accessible name
  * @param children the dialog body, usually a form
  */
 interface ModalProps {
@@ -14,13 +14,31 @@ interface ModalProps {
 }
 
 /**
- * Centred dialog over a dimmed backdrop.
+ * Centred dialog over a dimmed backdrop, bounded by the viewport at any window size.
+ *
+ * The overlay's padding is what guarantees the gutter, and `max-h-full` resolves against that padded
+ * box — the overlay is `fixed inset-0`, so its height is definite and the percentage resolves without
+ * needing `vh` or `dvh` and their unit caveats. Inside it, `flex flex-col` with a `shrink-0` header and
+ * a scrolling body is what keeps the title and close button in place while a long form scrolls under
+ * them. `min-h-0` on that body is redundant — a flex item that is itself a scroll container already has
+ * an automatic minimum size of zero — but it is the one declaration that states the intent, and without
+ * the rule it names the body would push the panel past its own `max-height` and the scroll would never
+ * engage.
  *
  * Closes on Escape as well as on the button and the backdrop; the key listener is bound only while
  * open, so a closed modal costs nothing and several on one page cannot fight over the key. Nothing is
  * rendered when closed, which means the body is unmounted and its form state resets between openings.
+ *
+ * Known gap, deliberately not closed here: `aria-modal` tells assistive technology that the rest of the
+ * page is inert, but nothing traps the keyboard, so Tab still walks out into the page behind. Focus is
+ * neither moved in on open nor restored on close. Closing it properly means a native `<dialog>` with
+ * `showModal()`; see `docs/requirements/requirements.md` §6.
  */
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
+  // Three modals can share one page, so the title's id has to be unique per instance — a hard-coded
+  // one would make every dialog resolve the same accessible name.
+  const titleId = useId();
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
@@ -32,20 +50,27 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
       <div className="absolute inset-0 bg-overlay/50" onClick={onClose} />
-      <div className="relative z-10 w-full max-w-lg rounded-xl bg-surface border border-line-strong shadow-xl mx-4">
-        <div className="flex items-center justify-between px-6 py-4 border-b border-line">
-          <h2 className="text-lg font-semibold text-fg-muted">{title}</h2>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative z-10 flex max-h-full w-full min-w-0 max-w-lg flex-col overflow-hidden rounded-xl bg-surface border border-line-strong shadow-xl"
+      >
+        <div className="flex shrink-0 items-center justify-between gap-4 px-6 py-4 border-b border-line">
+          <h2 id={titleId} className="min-w-0 truncate text-lg font-semibold text-fg-muted">
+            {title}
+          </h2>
           <button
             onClick={onClose}
-            className="text-fg-faint hover:text-fg-subtle text-2xl leading-none"
+            className="shrink-0 text-fg-faint hover:text-fg-subtle text-2xl leading-none"
             aria-label="Close modal"
           >
             &times;
           </button>
         </div>
-        <div className="px-6 py-4">{children}</div>
+        <div className="min-h-0 overflow-y-auto overscroll-contain px-6 py-4">{children}</div>
       </div>
     </div>
   );

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -29,10 +29,12 @@ interface ModalProps {
  * open, so a closed modal costs nothing and several on one page cannot fight over the key. Nothing is
  * rendered when closed, which means the body is unmounted and its form state resets between openings.
  *
- * Known gap, deliberately not closed here: `aria-modal` tells assistive technology that the rest of the
- * page is inert, but nothing traps the keyboard, so Tab still walks out into the page behind. Focus is
- * neither moved in on open nor restored on close. Closing it properly means a native `<dialog>` with
- * `showModal()`; see `docs/requirements/requirements.md` §6.
+ * Deliberately no `aria-modal`. It would tell assistive technology that everything outside the dialog
+ * is inert, and nothing here makes that true: no focus trap, so Tab walks straight out into the page
+ * behind, and focus is neither moved in on open nor restored on close. Claiming it would leave a
+ * screen-reader user tabbing to controls the dialog has removed from their buffer — worse than the
+ * plain `dialog` role, which at least announces this panel honestly. Closing the gap properly means a
+ * native `<dialog>` with `showModal()`; see `docs/requirements/requirements.md` §6.
  */
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
   // Three modals can share one page, so the title's id has to be unique per instance — a hard-coded
@@ -54,7 +56,6 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
       <div className="absolute inset-0 bg-overlay/50" onClick={onClose} />
       <div
         role="dialog"
-        aria-modal="true"
         aria-labelledby={titleId}
         className="relative z-10 flex max-h-full w-full min-w-0 max-w-lg flex-col overflow-hidden rounded-xl bg-surface border border-line-strong shadow-xl"
       >

--- a/frontend/src/components/ui/PageContainer.test.tsx
+++ b/frontend/src/components/ui/PageContainer.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PageContainer from './PageContainer';
+
+/**
+ * These pin which cap each variant selects, and nothing more.
+ *
+ * jsdom has no layout engine and `vitest.config.ts` sets `css: false`, so no test in this repo can
+ * observe a width, a wrap or an overflow — see ADR-004. Asserting the class name is the one mechanical
+ * link between the requirement and the code; the layout itself is checked by hand.
+ */
+const capOf = (container: HTMLElement) => container.firstElementChild?.className ?? '';
+
+describe('PageContainer', () => {
+  it('GivenNoWidth_WhenThePageContainerRenders_ThenItCapsAtTheDefaultWidth', () => {
+    const { container } = render(<PageContainer>page</PageContainer>);
+
+    expect(capOf(container)).toContain('max-w-7xl');
+  });
+
+  it('GivenTheNarrowWidth_WhenThePageContainerRenders_ThenItCapsAtTheReadingWidth', () => {
+    const { container } = render(<PageContainer width="narrow">page</PageContainer>);
+
+    expect(capOf(container)).toContain('max-w-3xl');
+  });
+
+  it('GivenExtraClasses_WhenThePageContainerRenders_ThenTheyAreKeptAlongsideTheCap', () => {
+    const { container } = render(<PageContainer className="space-y-6">page</PageContainer>);
+
+    expect(capOf(container)).toContain('space-y-6');
+    expect(capOf(container)).toContain('max-w-7xl');
+  });
+
+  it('GivenAnyWidth_WhenThePageContainerRenders_ThenItShowsItsChildren', () => {
+    render(<PageContainer>the page</PageContainer>);
+
+    expect(screen.getByText('the page')).toBeDefined();
+  });
+});

--- a/frontend/src/components/ui/PageContainer.tsx
+++ b/frontend/src/components/ui/PageContainer.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+/**
+ * @param children  the page's content
+ * @param width     how far the content may grow — `wide` for lists, grids and dashboards, `narrow` for
+ *                  reading and form pages, where a long line of text is harder to follow
+ * @param className extra classes for the container itself, usually vertical rhythm
+ */
+interface PageContainerProps {
+  children: React.ReactNode;
+  width?: 'wide' | 'narrow';
+  className?: string;
+}
+
+/**
+ * The one place a page's width is decided.
+ *
+ * Pages used to cap themselves, with four different values across nine pages and nothing behind the
+ * choice — which is how `/health-areas` came to sit 896px wide in the middle of a 1536px window. A page
+ * now fills whatever the shell gives it and stops only where a line of text stops being comfortable to
+ * read.
+ *
+ * So the cap is on the measure, not on the layout: `wide` is roughly a hundred characters at the body
+ * size, `narrow` roughly sixty. Given the 240px sidebar and the shell's padding, `wide` does not begin
+ * to bite until about a 1570px viewport — below that a page simply fills the space.
+ */
+const widthClasses: Record<NonNullable<PageContainerProps['width']>, string> = {
+  wide: 'max-w-7xl',
+  narrow: 'max-w-3xl',
+};
+
+const PageContainer: React.FC<PageContainerProps> = ({ children, width = 'wide', className = '' }) => (
+  <div className={`w-full mx-auto ${widthClasses[width]} ${className}`}>{children}</div>
+);
+
+export default PageContainer;

--- a/frontend/src/components/ui/PageContainer.tsx
+++ b/frontend/src/components/ui/PageContainer.tsx
@@ -12,6 +12,12 @@ interface PageContainerProps {
   className?: string;
 }
 
+/** The two caps, by name. Not exported: `react-refresh/only-export-components` plus CI's zero-warning lint. */
+const widthClasses: Record<NonNullable<PageContainerProps['width']>, string> = {
+  wide: 'max-w-7xl',
+  narrow: 'max-w-3xl',
+};
+
 /**
  * The one place a page's width is decided.
  *
@@ -20,15 +26,12 @@ interface PageContainerProps {
  * now fills whatever the shell gives it and stops only where a line of text stops being comfortable to
  * read.
  *
- * So the cap is on the measure, not on the layout: `wide` is roughly a hundred characters at the body
- * size, `narrow` roughly sixty. Given the 240px sidebar and the shell's padding, `wide` does not begin
- * to bite until about a 1570px viewport — below that a page simply fills the space.
+ * So the cap is on the measure, not on the layout. At the 16px body size a proportional character
+ * averages roughly 8px, which puts `wide` (1280px) near 160 characters and `narrow` (768px) near 95 —
+ * the latter about the upper bound of the usual 45–90 guidance, and why prose and form pages take it.
+ * Given the 240px sidebar and the shell's padding, `wide` does not begin to bite until about a 1570px
+ * viewport; below that a page simply fills the space.
  */
-const widthClasses: Record<NonNullable<PageContainerProps['width']>, string> = {
-  wide: 'max-w-7xl',
-  narrow: 'max-w-3xl',
-};
-
 const PageContainer: React.FC<PageContainerProps> = ({ children, width = 'wide', className = '' }) => (
   <div className={`w-full mx-auto ${widthClasses[width]} ${className}`}>{children}</div>
 );

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -11,14 +11,21 @@ interface PageHeaderProps {
   action?: React.ReactNode;
 }
 
-/** Standard page heading: title, optional subtitle, optional right-aligned action. */
+/**
+ * Standard page heading: title, optional subtitle, optional right-aligned action.
+ *
+ * Wraps rather than squeezes. Below the width at which the heading and the action fit on one line the
+ * action drops underneath, which keeps a long title readable instead of shrinking the button beside
+ * it. `min-w-0` is what lets the heading block wrap at all — without it the block's min-content width
+ * is its floor, and the row grows past its container instead.
+ */
 const PageHeader: React.FC<PageHeaderProps> = ({ title, subtitle, action }) => (
-  <div className="flex items-start justify-between mb-6">
-    <div>
+  <div className="flex flex-wrap items-start justify-between gap-4 mb-6">
+    <div className="min-w-0">
       <h1 className="text-2xl font-bold text-fg">{title}</h1>
       {subtitle && <p className="mt-1 text-sm text-fg-subtle">{subtitle}</p>}
     </div>
-    {action && <div>{action}</div>}
+    {action && <div className="shrink-0">{action}</div>}
   </div>
 );
 

--- a/frontend/src/components/ui/areaIcon.test.ts
+++ b/frontend/src/components/ui/areaIcon.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { areaIconGlyph, DEFAULT_AREA_ICON } from './areaIcon';
+
+describe('areaIconGlyph', () => {
+  it('GivenAnEmoji_WhenTheGlyphIsResolved_ThenItIsReturnedUnchanged', () => {
+    expect(areaIconGlyph('😴')).toBe('😴');
+  });
+
+  it('GivenAnEmojiWithSurroundingSpace_WhenTheGlyphIsResolved_ThenItIsTrimmed', () => {
+    expect(areaIconGlyph('  💧 ')).toBe('💧');
+  });
+
+  // The six seeded areas shipped with these, which is the whole reason the fallback exists.
+  it('GivenAMaterialSymbolsKey_WhenTheGlyphIsResolved_ThenTheDefaultIsUsed', () => {
+    expect(areaIconGlyph('water_drop')).toBe(DEFAULT_AREA_ICON);
+    expect(areaIconGlyph('self_improvement')).toBe(DEFAULT_AREA_ICON);
+    expect(areaIconGlyph('eco')).toBe(DEFAULT_AREA_ICON);
+  });
+
+  it('GivenAnEmptyIcon_WhenTheGlyphIsResolved_ThenTheDefaultIsUsed', () => {
+    expect(areaIconGlyph('')).toBe(DEFAULT_AREA_ICON);
+  });
+
+  it('GivenWhitespaceOnly_WhenTheGlyphIsResolved_ThenTheDefaultIsUsed', () => {
+    expect(areaIconGlyph('   ')).toBe(DEFAULT_AREA_ICON);
+  });
+
+  it('GivenNoIconAtAll_WhenTheGlyphIsResolved_ThenTheDefaultIsUsed', () => {
+    expect(areaIconGlyph(undefined)).toBe(DEFAULT_AREA_ICON);
+    expect(areaIconGlyph(null)).toBe(DEFAULT_AREA_ICON);
+  });
+});

--- a/frontend/src/components/ui/areaIcon.test.ts
+++ b/frontend/src/components/ui/areaIcon.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { areaIconGlyph, DEFAULT_AREA_ICON } from './areaIcon';
+import { areaIconGlyph, DEFAULT_AREA_ICON, isIconGlyph } from './areaIcon';
 
 describe('areaIconGlyph', () => {
   it('GivenAnEmoji_WhenTheGlyphIsResolved_ThenItIsReturnedUnchanged', () => {
@@ -8,6 +8,16 @@ describe('areaIconGlyph', () => {
 
   it('GivenAnEmojiWithSurroundingSpace_WhenTheGlyphIsResolved_ThenItIsTrimmed', () => {
     expect(areaIconGlyph('  💧 ')).toBe('💧');
+  });
+
+  // The first code point of a keycap is an ASCII digit, so a first-character test would reject it.
+  it('GivenAKeycapEmoji_WhenTheGlyphIsResolved_ThenItIsReturnedUnchanged', () => {
+    expect(areaIconGlyph('1️⃣')).toBe('1️⃣');
+  });
+
+  it('GivenAnEmojiWithASkinToneOrVariationSelector_WhenTheGlyphIsResolved_ThenItSurvivesIntact', () => {
+    expect(areaIconGlyph('👍🏽')).toBe('👍🏽');
+    expect(areaIconGlyph('❤️')).toBe('❤️');
   });
 
   // The six seeded areas shipped with these, which is the whole reason the fallback exists.
@@ -28,5 +38,28 @@ describe('areaIconGlyph', () => {
   it('GivenNoIconAtAll_WhenTheGlyphIsResolved_ThenTheDefaultIsUsed', () => {
     expect(areaIconGlyph(undefined)).toBe(DEFAULT_AREA_ICON);
     expect(areaIconGlyph(null)).toBe(DEFAULT_AREA_ICON);
+  });
+
+  // Stated so the boundary is a decision on the record rather than an accident of the pattern.
+  it('GivenPunctuationOrASymbol_WhenTheGlyphIsResolved_ThenItIsReturnedRatherThanRejected', () => {
+    expect(areaIconGlyph('!')).toBe('!');
+    expect(areaIconGlyph('™')).toBe('™');
+  });
+});
+
+describe('isIconGlyph', () => {
+  it('GivenAnIconKey_WhenAskedWhetherItIsAGlyph_ThenItIsNot', () => {
+    expect(isIconGlyph('fitness_center')).toBe(false);
+    expect(isIconGlyph('eco')).toBe(false);
+  });
+
+  it('GivenAnEmoji_WhenAskedWhetherItIsAGlyph_ThenItIs', () => {
+    expect(isIconGlyph('🌙')).toBe(true);
+  });
+
+  it('GivenNothingStored_WhenAskedWhetherItIsAGlyph_ThenItIsNot', () => {
+    expect(isIconGlyph('')).toBe(false);
+    expect(isIconGlyph(null)).toBe(false);
+    expect(isIconGlyph(undefined)).toBe(false);
   });
 });

--- a/frontend/src/components/ui/areaIcon.ts
+++ b/frontend/src/components/ui/areaIcon.ts
@@ -1,0 +1,23 @@
+/** Drawn for a health area with no icon, or one this application cannot render as a glyph. */
+export const DEFAULT_AREA_ICON = '🎯';
+
+/**
+ * An icon *key* starts with an ASCII word character; a glyph does not.
+ *
+ * The seeded areas were written against Material Symbols ligature names — `water_drop`,
+ * `fitness_center`, `self_improvement` — but no icon font is loaded anywhere, so the page drew those
+ * names as their own literal text. The form has always asked for an emoji. This is where the two
+ * readings are reconciled, on the render side, without trusting what is stored.
+ */
+const LOOKS_LIKE_AN_ICON_KEY = /^[\w-]/;
+
+/**
+ * The glyph to draw for a health area, given whatever the API returned.
+ *
+ * @param icon the stored icon, which is free-form text and validated nowhere
+ * @returns    the stored value when it looks like a glyph, otherwise {@link DEFAULT_AREA_ICON}
+ */
+export const areaIconGlyph = (icon: string | null | undefined): string => {
+  const trimmed = icon?.trim() ?? '';
+  return trimmed === '' || LOOKS_LIKE_AN_ICON_KEY.test(trimmed) ? DEFAULT_AREA_ICON : trimmed;
+};

--- a/frontend/src/components/ui/areaIcon.ts
+++ b/frontend/src/components/ui/areaIcon.ts
@@ -2,22 +2,36 @@
 export const DEFAULT_AREA_ICON = '🎯';
 
 /**
- * An icon *key* starts with an ASCII word character; a glyph does not.
+ * An icon *key* is an ASCII identifier and nothing else: `water_drop`, `fitness_center`, `eco`.
  *
- * The seeded areas were written against Material Symbols ligature names — `water_drop`,
- * `fitness_center`, `self_improvement` — but no icon font is loaded anywhere, so the page drew those
- * names as their own literal text. The form has always asked for an emoji. This is where the two
- * readings are reconciled, on the render side, without trusting what is stored.
+ * Anchored at both ends deliberately. A test on the first character alone would call `1️⃣` a key — its
+ * first code point is an ASCII digit — and silently swap out a glyph the user chose.
+ *
+ * Note what this does *not* claim: it rejects what is recognisably a key, not everything that is not
+ * an emoji. `!` and `™` are returned as they were stored. Deciding emoji-ness properly needs grapheme
+ * segmentation, which costs a `lib` change and mangles skin tones and variation selectors where it is
+ * unavailable — and buys nothing here, because the icon is drawn in a fixed clipping box that no value
+ * can widen. See ADR-005.
  */
-const LOOKS_LIKE_AN_ICON_KEY = /^[\w-]/;
+const ICON_KEY = /^[a-z][a-z0-9_-]*$/i;
+
+/**
+ * Whether a stored icon can be drawn as it stands.
+ *
+ * @param icon the stored icon, which is free-form text and validated nowhere
+ */
+export const isIconGlyph = (icon: string | null | undefined): boolean => {
+  const trimmed = icon?.trim() ?? '';
+  return trimmed !== '' && !ICON_KEY.test(trimmed);
+};
 
 /**
  * The glyph to draw for a health area, given whatever the API returned.
  *
- * @param icon the stored icon, which is free-form text and validated nowhere
- * @returns    the stored value when it looks like a glyph, otherwise {@link DEFAULT_AREA_ICON}
+ * @param icon the stored icon
+ * @returns    the stored value, trimmed, when it can be drawn; otherwise {@link DEFAULT_AREA_ICON}
  */
 export const areaIconGlyph = (icon: string | null | undefined): string => {
   const trimmed = icon?.trim() ?? '';
-  return trimmed === '' || LOOKS_LIKE_AN_ICON_KEY.test(trimmed) ? DEFAULT_AREA_ICON : trimmed;
+  return isIconGlyph(trimmed) ? trimmed : DEFAULT_AREA_ICON;
 };

--- a/frontend/src/pages/ActiveUpgradesPage.tsx
+++ b/frontend/src/pages/ActiveUpgradesPage.tsx
@@ -8,6 +8,7 @@ import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import UpgradeCard from '../components/upgrade/UpgradeCard';
 import type { UpgradeStatus } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /**
  * The upgrades currently running, with the transitions available from `ACTIVE`.
@@ -29,7 +30,7 @@ const ActiveUpgradesPage: React.FC = () => {
   if (error) return <p className="text-danger-fg text-center py-10">Failed to load upgrades.</p>;
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <PageContainer>
       <PageHeader
         title="Active Upgrades"
         subtitle="Upgrades you are currently working on"
@@ -48,7 +49,7 @@ const ActiveUpgradesPage: React.FC = () => {
           ))}
         </div>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/ActiveUpgradesPage.tsx
+++ b/frontend/src/pages/ActiveUpgradesPage.tsx
@@ -39,7 +39,7 @@ const ActiveUpgradesPage: React.FC = () => {
       {upgrades.length === 0 ? (
         <EmptyState icon="🔥" title="No active upgrades" description="Activate a planned upgrade to start tracking progress." action={<Button onClick={() => navigate('/upgrades/planned')}>View Planned</Button>} />
       ) : (
-        <div className="grid sm:grid-cols-2 gap-4">
+        <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
           {upgrades.map((u) => (
             <UpgradeCard
               key={u.id}

--- a/frontend/src/pages/DailyCheckinPage.tsx
+++ b/frontend/src/pages/DailyCheckinPage.tsx
@@ -9,6 +9,7 @@ import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import { useNavigate } from 'react-router-dom';
 import type { HealthUpgrade, CreateProgressRequest } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /** Draft entries being filled in, keyed by upgrade id, until the whole form is submitted. */
 type ProgressMap = Record<string, Partial<CreateProgressRequest>>;
@@ -82,7 +83,7 @@ const DailyCheckinPage: React.FC = () => {
   }
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <PageContainer width="narrow">
       <PageHeader title="Daily Check-in" subtitle={`Today: ${new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}`} />
 
       {upgrades.length === 0 ? (
@@ -160,7 +161,7 @@ const DailyCheckinPage: React.FC = () => {
           </Button>
         </form>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/DailyCheckinPage.tsx
+++ b/frontend/src/pages/DailyCheckinPage.tsx
@@ -73,12 +73,12 @@ const DailyCheckinPage: React.FC = () => {
 
   if (submitted) {
     return (
-      <div className="max-w-xl mx-auto text-center py-20">
+      <PageContainer width="narrow" className="text-center py-20">
         <div className="text-6xl mb-4">🎉</div>
         <h2 className="text-2xl font-bold text-fg mb-2">Check-in Complete!</h2>
         <p className="text-fg-subtle mb-6">Great job tracking your upgrades today.</p>
         <Button onClick={() => navigate('/dashboard')}>Back to Dashboard</Button>
-      </div>
+      </PageContainer>
     );
   }
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ import UpgradeCard from '../components/upgrade/UpgradeCard';
 import EmptyState from '../components/ui/EmptyState';
 import { performUpgradeAction } from '../api/upgrades';
 import type { UpgradeStatus } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /**
  * Landing page after sign-in: counts, the weekly rate, streaks, overdue warnings and today's upgrades.
@@ -41,16 +42,16 @@ const DashboardPage: React.FC = () => {
   const streakEntries = Object.entries(data?.streaks ?? {});
 
   return (
-    <div className="max-w-6xl mx-auto space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
+    <PageContainer className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="min-w-0">
           <h1 className="text-2xl font-bold text-fg">
             Good {new Date().getHours() < 12 ? 'morning' : new Date().getHours() < 18 ? 'afternoon' : 'evening'},{' '}
             {user?.name?.split(' ')[0]} 👋
           </h1>
           <p className="text-fg-subtle mt-1">{new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}</p>
         </div>
-        <Button onClick={() => navigate('/upgrades/backlog')}>+ Add Upgrade</Button>
+        <Button className="shrink-0" onClick={() => navigate('/upgrades/backlog')}>+ Add Upgrade</Button>
       </div>
 
       {(data?.overdueUpgrades?.length ?? 0) > 0 && (
@@ -63,7 +64,7 @@ const DashboardPage: React.FC = () => {
         </div>
       )}
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <Card className="text-center">
           <div className="text-3xl font-bold text-brand-fg">{data?.activeUpgrades.length ?? 0}</div>
           <div className="text-sm text-fg-subtle mt-1">Active</div>
@@ -146,7 +147,7 @@ const DashboardPage: React.FC = () => {
           </div>
         </Card>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -45,7 +45,7 @@ const DashboardPage: React.FC = () => {
     <PageContainer className="space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="min-w-0">
-          <h1 className="text-2xl font-bold text-fg">
+          <h1 className="text-2xl font-bold text-fg break-words">
             Good {new Date().getHours() < 12 ? 'morning' : new Date().getHours() < 18 ? 'afternoon' : 'evening'},{' '}
             {user?.name?.split(' ')[0]} 👋
           </h1>

--- a/frontend/src/pages/HealthAreasPage.tsx
+++ b/frontend/src/pages/HealthAreasPage.tsx
@@ -10,7 +10,7 @@ import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import type { CreateHealthAreaRequest, HealthArea } from '../types';
 import PageContainer from '../components/ui/PageContainer';
-import { areaIconGlyph, DEFAULT_AREA_ICON } from '../components/ui/areaIcon';
+import { areaIconGlyph, DEFAULT_AREA_ICON, isIconGlyph } from '../components/ui/areaIcon';
 
 /**
  * Manages health areas — the folders upgrades are filed under.
@@ -60,10 +60,21 @@ const HealthAreasPage: React.FC = () => {
     await updateMutation.mutateAsync({ id: editArea.id, req: form });
   };
 
-  /** Opens the edit modal pre-filled from an area; nullable fields become empty strings for the inputs. */
+  /**
+   * Opens the edit modal pre-filled from an area; nullable fields become empty strings for the inputs.
+   *
+   * A stored icon the card cannot draw arrives as empty rather than as itself. Showing `water_drop` in a
+   * field labelled "Icon (emoji)" next to a card showing the default would invite the user to press Save
+   * and write the unusable value straight back.
+   */
   const openEdit = (area: HealthArea) => {
     setEditArea(area);
-    setForm({ name: area.name, description: area.description ?? '', icon: area.icon ?? '', color: area.color ?? '' });
+    setForm({
+      name: area.name,
+      description: area.description ?? '',
+      icon: isIconGlyph(area.icon) ? (area.icon ?? '').trim() : '',
+      color: area.color ?? '',
+    });
   };
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
@@ -88,7 +99,7 @@ const HealthAreasPage: React.FC = () => {
         <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
           {areas.map((area) => (
             <Card key={area.id}>
-              <div className="flex min-w-0 items-start gap-2">
+              <div className="flex items-start gap-2">
                 <span
                   className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden text-2xl leading-none"
                   aria-hidden="true"

--- a/frontend/src/pages/HealthAreasPage.tsx
+++ b/frontend/src/pages/HealthAreasPage.tsx
@@ -9,6 +9,8 @@ import Input from '../components/ui/Input';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import type { CreateHealthAreaRequest, HealthArea } from '../types';
+import PageContainer from '../components/ui/PageContainer';
+import { areaIconGlyph, DEFAULT_AREA_ICON } from '../components/ui/areaIcon';
 
 /**
  * Manages health areas — the folders upgrades are filed under.
@@ -68,7 +70,7 @@ const HealthAreasPage: React.FC = () => {
   if (error) return <p className="text-danger-fg text-center py-10">Failed to load health areas.</p>;
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <PageContainer>
       <PageHeader
         title="Health Areas"
         subtitle="Organize your upgrades by health focus area"
@@ -77,28 +79,31 @@ const HealthAreasPage: React.FC = () => {
 
       {areas.length === 0 ? (
         <EmptyState
-          icon="🎯"
+          icon={DEFAULT_AREA_ICON}
           title="No health areas yet"
           description="Create areas like Sleep, Nutrition, Fitness to organize your upgrades."
           action={<Button onClick={() => setIsCreateOpen(true)}>Create Your First Area</Button>}
         />
       ) : (
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
           {areas.map((area) => (
             <Card key={area.id}>
-              <div className="flex items-start justify-between">
-                <div className="flex items-center gap-2">
-                  <span className="text-2xl">{area.icon ?? '🎯'}</span>
-                  <div>
-                    <h3 className="font-semibold text-fg">{area.name}</h3>
-                    {area.upgradeCount !== undefined && (
-                      <p className="text-xs text-fg-subtle">{area.upgradeCount} upgrade{area.upgradeCount !== 1 ? 's' : ''}</p>
-                    )}
-                  </div>
+              <div className="flex min-w-0 items-start gap-2">
+                <span
+                  className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden text-2xl leading-none"
+                  aria-hidden="true"
+                >
+                  {areaIconGlyph(area.icon)}
+                </span>
+                <div className="min-w-0">
+                  <h3 className="font-semibold text-fg break-words">{area.name}</h3>
+                  {area.upgradeCount !== undefined && (
+                    <p className="text-xs text-fg-subtle">{area.upgradeCount} upgrade{area.upgradeCount !== 1 ? 's' : ''}</p>
+                  )}
                 </div>
               </div>
-              {area.description && <p className="text-sm text-fg-subtle mt-2">{area.description}</p>}
-              <div className="flex gap-2 mt-4">
+              {area.description && <p className="text-sm text-fg-subtle mt-2 break-words">{area.description}</p>}
+              <div className="flex flex-wrap gap-2 mt-4">
                 <Button size="sm" variant="secondary" onClick={() => openEdit(area)}>Edit</Button>
                 <Button size="sm" variant="danger" onClick={() => setDeleteId(area.id)}>Delete</Button>
               </div>
@@ -142,7 +147,7 @@ const HealthAreasPage: React.FC = () => {
           </Button>
         </div>
       </Modal>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -6,6 +6,7 @@ import Button from '../components/ui/Button';
 import EmptyState from '../components/ui/EmptyState';
 import NotificationItem from '../components/notifications/NotificationItem';
 import type { AppNotification } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /**
  * The full notification list, with an all/unread filter.
@@ -27,7 +28,7 @@ const NotificationsPage: React.FC = () => {
   };
 
   return (
-    <div className="max-w-3xl mx-auto">
+    <PageContainer>
       <PageHeader
         title="Notifications"
         subtitle={unreadCount > 0 ? `${unreadCount} unread` : 'You are all caught up'}
@@ -68,7 +69,7 @@ const NotificationsPage: React.FC = () => {
           ))}
         </div>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/PlannedUpgradesPage.tsx
+++ b/frontend/src/pages/PlannedUpgradesPage.tsx
@@ -8,6 +8,7 @@ import UpgradeCard from '../components/upgrade/UpgradeCard';
 import Button from '../components/ui/Button';
 import { useNavigate } from 'react-router-dom';
 import type { UpgradeStatus } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /**
  * Upgrades committed to a start date but not yet running, soonest first.
@@ -35,7 +36,7 @@ const PlannedUpgradesPage: React.FC = () => {
   if (error) return <p className="text-danger-fg text-center py-10">Failed to load upgrades.</p>;
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <PageContainer>
       <PageHeader
         title="Planned Upgrades"
         subtitle="Upgrades scheduled to start soon"
@@ -57,7 +58,7 @@ const PlannedUpgradesPage: React.FC = () => {
           ))}
         </div>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/PlannedUpgradesPage.tsx
+++ b/frontend/src/pages/PlannedUpgradesPage.tsx
@@ -45,7 +45,7 @@ const PlannedUpgradesPage: React.FC = () => {
       {sorted.length === 0 ? (
         <EmptyState icon="📅" title="No planned upgrades" description="Move ideas from backlog to plan, or create a new upgrade." action={<Button onClick={() => navigate('/upgrades/backlog')}>Go to Backlog</Button>} />
       ) : (
-        <div className="grid sm:grid-cols-2 gap-4">
+        <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
           {sorted.map((u) => (
             <div key={u.id}>
               {u.plannedStartDate && (

--- a/frontend/src/pages/ProgressHistoryPage.tsx
+++ b/frontend/src/pages/ProgressHistoryPage.tsx
@@ -8,6 +8,7 @@ import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import Badge from '../components/ui/Badge';
 import type { ProgressEntry, HealthUpgrade } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /**
  * The last seven days of progress across every upgrade, newest first.
@@ -29,7 +30,7 @@ const ProgressHistoryPage: React.FC = () => {
   if (pError || uError) return <p className="text-danger-fg text-center py-10">Failed to load progress history.</p>;
 
   return (
-    <div className="max-w-3xl mx-auto">
+    <PageContainer>
       <PageHeader title="Progress History" subtitle="Your progress entries from the last 7 days" />
       {sorted.length === 0 ? (
         <EmptyState icon="📈" title="No progress logged yet" description="Log progress on your active upgrades to see history here." />
@@ -64,7 +65,7 @@ const ProgressHistoryPage: React.FC = () => {
           </div>
         </Card>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/UpgradeBacklogPage.tsx
+++ b/frontend/src/pages/UpgradeBacklogPage.tsx
@@ -11,6 +11,7 @@ import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import UpgradeCard from '../components/upgrade/UpgradeCard';
 import type { CreateUpgradeRequest, UpgradeType, Difficulty, UpgradeStatus } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /**
  * The upgrade types offered when creating one: the eight kinds the product defines.
@@ -79,7 +80,7 @@ const UpgradeBacklogPage: React.FC = () => {
   if (error) return <p className="text-danger-fg text-center py-10">Failed to load the backlog.</p>;
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <PageContainer>
       <PageHeader
         title="Idea Backlog"
         subtitle="Health upgrade ideas waiting to be planned"
@@ -109,7 +110,7 @@ const UpgradeBacklogPage: React.FC = () => {
           </div>
         </form>
       </Modal>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/UpgradeBacklogPage.tsx
+++ b/frontend/src/pages/UpgradeBacklogPage.tsx
@@ -89,7 +89,7 @@ const UpgradeBacklogPage: React.FC = () => {
       {upgrades.length === 0 ? (
         <EmptyState icon="💡" title="No ideas yet" description="Capture your health upgrade ideas here before planning them." action={<Button onClick={() => setIsOpen(true)}>Add First Idea</Button>} />
       ) : (
-        <div className="grid sm:grid-cols-2 gap-4">
+        <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
           {upgrades.map((u) => (
             <UpgradeCard key={u.id} upgrade={u} onStatusChange={handleStatusChange} />
           ))}

--- a/frontend/src/pages/UpgradeDetailsPage.tsx
+++ b/frontend/src/pages/UpgradeDetailsPage.tsx
@@ -17,6 +17,7 @@ import UpgradeTypeBadge from '../components/upgrade/UpgradeTypeBadge';
 import Badge from '../components/ui/Badge';
 import { difficultyVariant, UNKNOWN_DIFFICULTY_VARIANT } from '../components/upgrade/upgradeMeta';
 import type { CreateProgressRequest, CreateReflectionRequest, TrackingType, Frequency } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /** Today as `YYYY-MM-DD`, the date format the progress and reflection APIs expect. */
 const today = () => new Date().toISOString().split('T')[0];
@@ -122,7 +123,7 @@ const UpgradeDetailsPage: React.FC = () => {
   if (error || !upgrade) return <p className="text-danger-fg text-center py-10">Failed to load this upgrade.</p>;
 
   return (
-    <div className="max-w-3xl mx-auto space-y-6">
+    <PageContainer width="narrow" className="space-y-6">
       <button onClick={() => navigate(-1)} className="text-sm text-brand-fg hover:underline">← Back</button>
 
       <Card>
@@ -400,7 +401,7 @@ const UpgradeDetailsPage: React.FC = () => {
           </div>
         </form>
       </Modal>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/UpgradeDetailsPage.tsx
+++ b/frontend/src/pages/UpgradeDetailsPage.tsx
@@ -134,16 +134,16 @@ const UpgradeDetailsPage: React.FC = () => {
             {upgrade.difficulty}
           </Badge>
         </div>
-        <h1 className="text-2xl font-bold text-fg">{upgrade.title}</h1>
-        {upgrade.description && <p className="text-fg-subtle mt-2">{upgrade.description}</p>}
+        <h1 className="text-2xl font-bold text-fg break-words">{upgrade.title}</h1>
+        {upgrade.description && <p className="text-fg-subtle mt-2 break-words">{upgrade.description}</p>}
         {upgrade.motivation && (
           <div className="mt-4 bg-brand-soft rounded-lg p-3">
-            <p className="text-sm text-brand-fg"><strong>Motivation:</strong> {upgrade.motivation}</p>
+            <p className="text-sm text-brand-fg break-words"><strong>Motivation:</strong> {upgrade.motivation}</p>
           </div>
         )}
         {upgrade.successCriteria && (
           <div className="mt-2 bg-success-soft rounded-lg p-3">
-            <p className="text-sm text-success-fg"><strong>Success Criteria:</strong> {upgrade.successCriteria}</p>
+            <p className="text-sm text-success-fg break-words"><strong>Success Criteria:</strong> {upgrade.successCriteria}</p>
           </div>
         )}
         <div className="mt-4 grid grid-cols-2 gap-4 text-sm text-fg-subtle">


### PR DESCRIPTION
## Problem

The interface did not adapt to the window. Maximised at 1536px, `/health-areas` left roughly a third
of the content area permanently empty; the "New Health Area" dialog nearly touched the top and bottom
of a short window with no way to scroll to what fell outside; and the seeded health areas rendered
`water_drop` and `fitness_center` as literal text, displacing each card's own title.

Three separate causes:

1. **Nine pages each set their own width cap** — four different values (`max-w-2xl` … `max-w-6xl`),
   nothing behind the choice. `/health-areas` was capped at 896px.
2. **`<main>` was safe from overflow only by accident.** It carried `overflow-auto`, which produces no
   scrollbar and reads as inert — but a flex item whose overflow is not `visible` already has an
   automatic minimum size of zero, so that class was the only thing keeping the shell shrinkable.
3. **Nothing constrained content coming from the database.** The `icon` field is free-form, the form
   labels it "Icon (emoji)", the seed data holds Material Symbols ligature names, and no icon font is
   loaded anywhere.

## Approach

Recorded in [ADR-005](docs/ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md).

- **One container decides page width.** `PageContainer` offers 1280px for lists and grids, 768px for
  reading and form pages. The cap is on the measure, not the layout — with the sidebar and the shell's
  padding it does not bite until about a 1570px viewport, so below that a page fills the space.
- **The shell is shrinkable by construction, and says so.** `min-w-0` on `<main>` replaces the
  accidental `overflow-auto`. Content that then meets pressure resolves it itself: `truncate` on the
  navbar's user name, `break-words` on names and descriptions, a fixed clipping box around an icon,
  `flex-wrap` on header and button rows.
- **A dialog is bounded by its overlay.** The gutter is the overlay's padding, which is also what
  `max-h-full` resolves against; a `shrink-0` header over an `overflow-y-auto` body keeps the title in
  place while the form scrolls. It also gained `role="dialog"`, `aria-modal` and an `aria-labelledby`
  name from `useId`, since three modals share the health areas page.
- **Stored icons are reconciled on render, then corrected in the data.** `areaIconGlyph` falls back to
  the default for anything that is not a glyph, so the layout holds whatever is stored; `V5` then
  rewrites the six seeded rows as emoji, guarded on the old value so a user's own icon survives.

## Trade-offs accepted

- **A future unshrinkable child will now overflow visibly** instead of scrolling inside `<main>`. That
  is the intended failure — a visible bug beats a silent one — and the fix belongs on that child's own
  wrapper as an opt-in `overflow-x-auto`.
- **Three widths change deliberately:** daily check-in 672 → 768; notifications and progress history
  768 → 1280. Both lists are rows with right-aligned metadata that read better wide.
- **`aria-modal` overstates what the dialog does.** Nothing traps the keyboard, so Tab still walks out
  behind the scrim. Logged as an open question in `requirements.md` §6 rather than half-solved; the
  real answer is a native `<dialog>`, and ADR-005 records why it is not here.
- **Container queries were turned down.** Tailwind's breakpoints measure the viewport, but the content
  area is 240px narrower whenever the sidebar shows. ADR-005 names the threshold that would earn the
  dependency.

## Verified

`npm run lint`, `npm run check:colours`, `npm test` (54 pass, 19 new), `npm run build` — all green.
`mvn test` — 144 pass. `generate.py --check` — diagrams up to date.

jsdom has no layout engine and vitest runs with `css: false`, so no test here can see a width
(ADR-004). Checked in a real browser instead:

- `documentElement.scrollWidth === clientWidth` with zero offending elements at 486 / 684 / 1040 /
  1540px, across five pages, in both themes.
- At 1540px the content is 1252px of a 1300px area — the empty band is gone.
- Dialog in a 381px-tall window: 24px gutters, the body scrolls its 107px of overflow, the header does
  not move with it, Create is reachable.
- A 60-character unbroken name and `self_improvement` injected into a live card: the icon box stays
  32px and clips, the title wraps inside the card, still no overflow.
- `V5` dry-run against a running database inside a rolled-back transaction: six statements, one row
  each, all six emoji intact.
