### PR TITLE
release: promote dev to main — dark mode, responsive layout, architecture diagrams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,11 @@ jobs:
       - name: Lint frontend
         run: cd frontend && npm run lint
 
+      # Tailwind emits nothing for an unknown class and raises no error, so a mistyped or missed colour
+      # renders as no colour at all rather than failing. This is the only check that catches it.
+      - name: Check no palette colours bypass the theme tokens
+        run: cd frontend && npm run check:colours
+
       # After the lint, so a failure here is a behaviour failure rather than a style one. `npm run test`
       # is `vitest run` and not the watcher — a bare `vitest` would hold the runner until the job times
       # out. See ADR-004 for why the frontend has a test harness at all.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,19 @@ jobs:
       # its database without an NVD API key and fails outright without one. See the known gaps in
       # ADR-002 for what enabling it requires.
 
+  diagrams:
+    name: Diagrams - Drift check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Three of the diagrams in docs/architecture/arch-diagrams/ are derived from the imports, the
+      # package layout and the migrations. Regenerating here and failing on a difference is what stops
+      # them describing an architecture the code no longer has — the failure ADR-002 was written about.
+      - name: Check the generated diagrams still match the source
+        run: python3 docs/architecture/arch-diagrams/generate.py --check
+
   frontend:
     name: Frontend - Build & Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,12 @@ jobs:
       - name: Lint frontend
         run: cd frontend && npm run lint
 
+      # After the lint, so a failure here is a behaviour failure rather than a style one. `npm run test`
+      # is `vitest run` and not the watcher — a bare `vitest` would hold the runner until the job times
+      # out. See ADR-004 for why the frontend has a test harness at all.
+      - name: Test frontend
+        run: cd frontend && npm run test
+
       # Scoped to what ships. Auditing the dev tree here would redden every unrelated PR whenever an
       # advisory lands against the Vite or ESLint toolchain, none of which reaches a user's browser.
       - name: Audit shipped frontend dependencies for known vulnerabilities

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ backend/.mvn/wrapper/maven-wrapper.jar
 frontend/node_modules/
 frontend/dist/
 frontend/.vite/
+# Vitest and npx write a cache here when a command is run from the repo root by mistake.
+node_modules/
 
 # Environment
 .env

--- a/README.md
+++ b/README.md
@@ -269,11 +269,19 @@ mvn verify    # the above plus integration tests — needs a running PostgreSQL
 bean graph or a missing Flyway migration — neither of which a unit test can see. Start a database first
 with `docker-compose up -d postgres`.
 
-### Frontend Build (includes type check)
+### Frontend Tests
 ```bash
 cd frontend
-npm run build
+npm run test           # Vitest + jsdom + Testing Library
+npm run build          # type check and production build
+npm run lint           # ESLint, zero warnings tolerated
+npm run check:colours  # fails on any Tailwind palette colour used outside the theme tokens
 ```
+
+`npm run test` covers the theme provider — that an explicit choice beats the operating system, that
+`system` follows it live, that the media-query listener is cleaned up under `React.StrictMode`, and that
+a browser with storage blocked still boots. See
+[ADR-004](docs/ADRs/ADR-004-frontend-test-harness.md) for why the harness exists and what it cannot do.
 
 ## Environment Variables
 
@@ -297,7 +305,7 @@ npm run build
 - [ ] Gamification: achievements, badges, levels
 - [ ] Integration with wearables (steps, sleep data)
 - [ ] Weekly/monthly progress email reports
-- [ ] Dark mode
+- [x] Dark mode
 - [ ] Internationalization (i18n)
 
 ## Screenshots

--- a/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaDto.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaDto.java
@@ -11,7 +11,9 @@ import java.util.UUID;
  * @param name        display name, e.g. "Nutrition"
  * @param description free-text note, may be null
  * @param priority    ordering hint chosen by the user, may be null
- * @param icon        icon key the frontend resolves to a glyph, may be null
+ * @param icon        the glyph to draw for the area, usually an emoji; may be null. Not an icon-font
+ *                    key: nothing in the client turns a name such as "water_drop" into a picture, and
+ *                    a value that is not drawable is replaced by a default when it is rendered
  * @param color       colour token the frontend resolves to a class, may be null
  * @param createdAt   when the area was created
  * @param updatedAt   when it was last modified

--- a/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaRequest.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaRequest.java
@@ -11,7 +11,8 @@ import jakarta.validation.constraints.NotBlank;
  * @param name        display name; required and non-blank
  * @param description free-text note, optional
  * @param priority    ordering hint, optional
- * @param icon        icon key, optional
+ * @param icon        the glyph to draw for the area, usually an emoji; optional. Not an icon-font key
+ *                    — see {@link HealthAreaDto}
  * @param color       colour token, optional
  */
 public record HealthAreaRequest(

--- a/backend/src/main/resources/db/migration/V5__seed_health_area_icons_as_emoji.sql
+++ b/backend/src/main/resources/db/migration/V5__seed_health_area_icons_as_emoji.sql
@@ -1,0 +1,18 @@
+-- The seeded health areas carried Material Symbols ligature names in `icon` ('water_drop',
+-- 'fitness_center', ...), but no icon font is loaded anywhere in the frontend and the form labels the
+-- field "Icon (emoji)". The page drew those names as their own literal text. They are rewritten here as
+-- the emoji they were always meant to stand for.
+--
+-- A new migration rather than an edit to V2: Flyway stores a checksum per applied version, so changing
+-- an already-applied file makes every existing database refuse to start with a checksum mismatch.
+--
+-- Each row is matched on its id *and* on the value being replaced, so an account that has already set
+-- its own icon keeps it. Every glyph is a single code point with default emoji presentation, so nothing
+-- depends on how a variation selector survives the driver or the column.
+
+UPDATE health_areas SET icon = '💧' WHERE id = 'b0000000-0000-0000-0000-000000000001' AND icon = 'water_drop';
+UPDATE health_areas SET icon = '🏃' WHERE id = 'b0000000-0000-0000-0000-000000000002' AND icon = 'fitness_center';
+UPDATE health_areas SET icon = '🌙' WHERE id = 'b0000000-0000-0000-0000-000000000003' AND icon = 'bedtime';
+UPDATE health_areas SET icon = '🥗' WHERE id = 'b0000000-0000-0000-0000-000000000004' AND icon = 'restaurant';
+UPDATE health_areas SET icon = '🧘' WHERE id = 'b0000000-0000-0000-0000-000000000005' AND icon = 'self_improvement';
+UPDATE health_areas SET icon = '🌿' WHERE id = 'b0000000-0000-0000-0000-000000000006' AND icon = 'eco';

--- a/docs/ADRs/ADR-004-frontend-test-harness.md
+++ b/docs/ADRs/ADR-004-frontend-test-harness.md
@@ -1,0 +1,134 @@
+# ADR-004: Test the frontend with Vitest, jsdom and Testing Library
+
+- **Status:** Accepted
+- **Date:** 2026-08-19
+- **Scope:** `frontend/` only. No effect on the backend, the runtime, or anything that ships to a
+  browser — every package added here is a development dependency.
+
+## Context
+
+[ADR-002](ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md) built a floor under
+the backend: an integration test that boots the application against a real PostgreSQL, ArchUnit rules
+that fail on a layering violation, and tests for the two services that had none. It left the frontend
+without an equivalent, and `docs/requirements/requirements.md` §6 has recorded that gap as an open
+question ever since:
+
+> **The frontend has no test runner.** No vitest, no jest. Frontend logic is currently verified only by
+> the type checker, the linter and inspection. Introducing one is a dependency decision that deserves
+> an ADR.
+
+This is that record.
+
+Until now the gap was tolerable because the frontend held almost no logic worth testing. Its
+components render server state that TanStack Query fetches, and the one piece of real behaviour —
+that the mirrored enums cannot drift from the backend's — is already enforced from the backend by
+`FrontendEnumContractTest`. Type checking and a zero-warning lint genuinely covered the rest.
+
+Dark mode changes that. `ThemeProvider` holds branching logic that no type can express and no reviewer
+can reliably eyeball:
+
+- an explicit choice must beat the operating system's preference, but only when it is explicit;
+- `system` must follow the OS **while the tab is open**, which means a `matchMedia` subscription with a
+  cleanup that `React.StrictMode` will exercise twice on every mount;
+- reading `localStorage` throws outright where site data is blocked, and there is no error boundary
+  above this provider, so an unguarded read blanks the whole application.
+
+Each of those is a small, pure, deterministic assertion. Each is also the kind of defect that ships
+green and surfaces months later on somebody else's machine.
+
+## Decision
+
+Add **Vitest** with **jsdom** and **Testing Library** as development dependencies, and run them in CI
+between the lint and the audit.
+
+Four packages, all `devDependencies`: `vitest`, `jsdom`, `@testing-library/react`,
+`@testing-library/dom`. Nothing reaches a user's browser, so `npm audit --omit=dev` — the audit scope
+ADR-002 chose deliberately — is unaffected.
+
+Four choices inside that decision are worth stating, because each has a failure mode:
+
+- **Vitest is pinned to `^3.2.7`, not `^4`.** Vitest 4 declares a peer dependency on Vite `^6 || ^7 ||
+  ^8`; this project is on Vite 5. Taking Vitest 4 would mean a Vite major upgrade riding along inside a
+  styling change. Vitest 3 depends on Vite `^5.0.0 || ^6.0.0 || ^7.0.0-0` and needs nothing moved.
+- **Configuration lives in `vitest.config.ts`, merged over `vite.config.ts` with `mergeConfig`.** A
+  `test` key inside `vite.config.ts` would make the production build configuration type-depend on a
+  development-only package. Keeping them separate without the merge is worse: Vitest reads
+  `vitest.config.ts` *instead of* `vite.config.ts` when both exist, so the React plugin and the dev
+  proxy would silently stop applying to tests. The merge is what keeps one source of truth.
+- **No globals.** `describe`, `it` and `expect` are imported in each test file rather than injected
+  ambiently. This leaves `tsconfig.json`'s `types` array — and therefore the production type check —
+  untouched, at the cost of one import line per file.
+- **Tests are colocated under `src/`, not in a separate tree.** `tsconfig.json` includes `src`, so
+  `tsc` type-checks the tests as part of `npm run build`. A test that no longer compiles is a broken
+  test and should redden the build.
+
+## Consequences
+
+**What this makes easy**
+
+- Frontend behaviour can be asserted rather than inspected. `requirements.md` entries covering the SPA
+  can now name a real test in their "Enforced by" column instead of naming a component and asking the
+  reader to trust it.
+- The provider's failure paths — blocked storage, absent `matchMedia`, an unrecognised stored value —
+  are exercised. None of them are reachable by clicking through the application.
+- StrictMode double-invocation is caught by a test that counts live media-query listeners, which is the
+  only practical way to notice a dropped effect cleanup.
+- The open question in `requirements.md` §6 closes.
+
+**What this makes hard**
+
+- **CI gains a step that can fail, and a slow one relative to the others.** That is the point, but the
+  frontend job is no longer "lint and build" and a flaky test would now block merges. There are none
+  today; keeping it that way is a standing obligation.
+- **Four more development dependencies to keep current**, and Vitest moves quickly. The pin to `^3`
+  will eventually need revisiting — see below.
+- **Type errors in test files redden the production build**, because `tsc` sees `src/**`. This is
+  deliberate, but it means a broken test cannot be left in the tree over a weekend.
+- **jsdom is not a browser.** It has no layout engine and no real rendering, so it cannot verify that a
+  colour meets a contrast ratio, that a focus ring is visible, or that anything is positioned where it
+  should be. Everything visual in this project still rests on inspection.
+
+**Neutral**
+
+- Nothing ships to the browser and no runtime behaviour changes.
+- `npm run build` is unchanged; the test run is a separate script and a separate CI step.
+
+## Alternatives considered
+
+- **No test runner — keep relying on `tsc`, ESLint and inspection.** The status quo, and defensible
+  right up until the frontend held logic. It does not survive `ThemeProvider`: no type expresses "an
+  explicit choice beats the OS preference", and no linter notices a missing `removeEventListener`.
+  **Revisit if** the frontend is ever reduced back to pure presentation, which is not a plausible
+  direction.
+
+- **Jest.** The most widely used option, and the one most contributors would recognise. Rejected
+  because it needs its own transform pipeline — `babel-jest` or `ts-jest` plus a module-resolution
+  configuration — duplicating what Vite already does, and that duplicate can drift from the real build
+  until a test passes against code that would not ship. Vitest reuses the project's actual Vite
+  configuration, so there is exactly one transform. **Revisit if** Vitest is abandoned upstream or the
+  project leaves Vite.
+
+- **Playwright, or any real-browser end-to-end runner.** Would catch what jsdom cannot: real rendering,
+  real `prefers-color-scheme` emulation, and therefore real contrast and focus-ring verification. Not
+  a substitute — it tests a different level, needs the backend and a database running, and is far too
+  slow to gate every push. **Revisit when** there is a user-visible regression that a unit test could
+  not have caught, or when the manual pass before each release becomes the bottleneck. At that point it
+  is an addition to this decision, not a replacement for it.
+
+- **Vitest browser mode** (`@vitest/browser` driving a real Chromium). Removes the jsdom caveat above
+  while keeping one runner. Rejected as premature: it needs a browser binary in CI, is materially
+  slower, and buys nothing for the pure-logic assertions this harness exists to make. **Revisit when**
+  a test genuinely needs layout or computed styles — the contrast checks are the obvious candidate.
+
+- **`@testing-library/jest-dom` for its matchers** (`toHaveClass`, `toBeInTheDocument`). Convenient and
+  near-universal. Rejected to keep the dependency count honest: the assertions this harness makes are
+  about `classList` and `localStorage`, which plain `expect` states just as clearly. **Revisit if**
+  component tests grow to the point where the matchers measurably improve their readability.
+
+## Note
+
+There is no accessibility or visual-regression gate in CI, and this ADR does not add one. Contrast
+ratios in the theme were computed by hand and are recorded in the pull request that introduced them;
+nothing re-checks them when a colour changes. That is a known gap, and the honest reason it stays open
+is that the tooling to close it (a real browser in CI) is the same tooling the browser-mode alternative
+above defers.

--- a/docs/ADRs/ADR-004-frontend-test-harness.md
+++ b/docs/ADRs/ADR-004-frontend-test-harness.md
@@ -50,6 +50,18 @@ Four choices inside that decision are worth stating, because each has a failure 
 - **Vitest is pinned to `^3.2.7`, not `^4`.** Vitest 4 declares a peer dependency on Vite `^6 || ^7 ||
   ^8`; this project is on Vite 5. Taking Vitest 4 would mean a Vite major upgrade riding along inside a
   styling change. Vitest 3 depends on Vite `^5.0.0 || ^6.0.0 || ^7.0.0-0` and needs nothing moved.
+- **jsdom is pinned to `^29`, not `^30`.** jsdom 30 declares `engines: ^22.22.2 || ^24.15.0 || >=26.0.0`
+  and pulls `undici@8`, which needs Node `>=22.19.0`. CI and the frontend Dockerfile both run Node 20,
+  so jsdom 30 installs with an `EBADENGINE` warning and then dies at import with
+  `webidl.util.markAsUncloneable is not a function` — an error that names nothing in this project and
+  appears only on the CI runner, never on a developer machine running a newer Node. jsdom 29 accepts
+  `^20.19.0 || ^22.13.0 || >=24.0.0`, which covers both. Same principle as the Vitest pin: the harness
+  bends to the project's runtime, not the other way round.
+
+  This one bit before it was understood — the CI test step was added and merged without ever running,
+  so the mismatch stayed invisible until the first pull request. **Node 20 reached end of life in April
+  2026**, so the real resolution is to move the whole toolchain, including `frontend/Dockerfile`, off
+  it; that is a deployment change and belongs in its own ADR rather than riding along here.
 - **Configuration lives in `vitest.config.ts`, merged over `vite.config.ts` with `mergeConfig`.** A
   `test` key inside `vite.config.ts` would make the production build configuration type-depend on a
   development-only package. Keeping them separate without the merge is worse: Vitest reads

--- a/docs/ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md
+++ b/docs/ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md
@@ -1,0 +1,121 @@
+# ADR-005: One page width, and a shell that cannot be pushed wider than the window
+
+- **Status:** Accepted
+- **Date:** 2026-08-20
+- **Scope:** `frontend/` layout, plus one data-only backend migration. No new dependency, no runtime
+  behaviour outside the browser.
+
+## Context
+
+The SPA had no layout contract. Each page picked its own width cap as it was written, and by the time
+there were nine of them the same window showed the dashboard at 1152px, health areas at 896px and the
+daily check-in at 672px, with nothing a reader could reconstruct behind the choice. On a maximised
+1536px window `/health-areas` left roughly a third of the content area permanently empty.
+
+Three further things were true and none of them were written down:
+
+- **`<main>` was safe from overflow by accident.** It carried `overflow-auto`, which produces no
+  scrollbar (its height is auto, so it never overflows vertically) and looked inert. It was not: CSS
+  Flexbox §4.5 gives a flex item an automatic minimum size of zero when its overflow is anything other
+  than `visible`. Delete that class and the shell would start being dragged wider than the viewport by
+  its own content, with no clue in the diff as to why.
+- **Nothing constrained content that came from the database.** The six seeded health areas store
+  Material Symbols ligature names in `icon` — `water_drop`, `fitness_center`, `self_improvement` — but
+  no icon font is loaded anywhere and the form asks for an emoji. The card rendered the name verbatim
+  at `text-2xl`, where it displaced the area's own title and was clipped at the card's edge by `Card`'s
+  `overflow-hidden`. Storage, form and render path disagreed about what the field held.
+- **A dialog could not fit a short window.** `Modal` centred a panel with no maximum height and no
+  scroll region of its own, and guarded only its left and right edges with `mx-4`. A four-field form in
+  a 500px-tall viewport overflowed above and below the fold, and the part above it was unreachable
+  because nothing scrolled.
+
+None of this can be caught by a test here. jsdom has no layout engine and `vitest.config.ts` sets
+`css: false`, so every width, overflow and clipping question is invisible to the suite —
+[ADR-004](ADR-004-frontend-test-harness.md) records why a real browser in CI was deferred, and
+`requirements.md` §6 has carried that gap as an open question since.
+
+## Decision
+
+**One container decides page width.** `frontend/src/components/ui/PageContainer.tsx` offers two: the
+default 1280px (`max-w-7xl`) for lists, grids and dashboards, and 768px (`max-w-3xl`) for reading and
+form pages. All nine pages use it. The cap is on the measure — how long a line of text may get — not on
+the layout, so below roughly a 1570px viewport a default page simply fills the space the shell gives
+it. Horizontal padding stays on `<main>` so a page can never double it.
+
+**The shell is shrinkable by construction, and says so.** `min-w-0` on `<main>` replaces the accidental
+`overflow-auto`. A flex item's `min-width` defaults to `auto`, which resolves to its min-content width
+and silently overrules `flex-shrink`; `min-w-0` removes that floor. Content that then meets pressure
+resolves it itself — `truncate` on the navbar's user name, `break-words` on names and descriptions, a
+fixed `h-8 w-8 overflow-hidden` box around a health area's icon, `flex-wrap` on header rows and button
+rows.
+
+**A dialog is bounded by its overlay and scrolls its own body.** The overlay carries the gutter as
+padding; `max-h-full` resolves against that padded box, so the panel is never taller than the window;
+`flex flex-col` with a `shrink-0` header and an `overflow-y-auto` body keeps the title and close button
+in place while the form scrolls. It also gained `role="dialog"`, `aria-modal` and an `aria-labelledby`
+name derived with `useId`, since three modals share the health areas page.
+
+**Stored icons are reconciled on the render side, then corrected in the data.** `areaIcon.ts` falls back
+to the default glyph for anything starting with an ASCII word character, so the layout holds whatever
+the database contains; `V5__seed_health_area_icons_as_emoji.sql` then rewrites the six seeded rows as
+emoji. The render fix ships first, so at no point does the page depend on the migration having run.
+
+## Consequences
+
+**Easier.** Changing how wide pages are is one edit in one file. A new page inherits the decision
+instead of re-making it. A future overflow has one obvious place to look, and the reason `min-w-0` is
+there is written next to it rather than implied by a class that appears to do nothing.
+
+**Harder.** A genuinely unshrinkable future child — a wide data table — will now overflow visibly and
+give the document a horizontal scrollbar, where `overflow-auto` used to hide it inside `<main>`. That is
+the intended trade: a visible bug beats a silent one, and the fix belongs on that child's own wrapper as
+an opt-in `overflow-x-auto`.
+
+**Unchanged, and still unverified.** Nothing here is enforced by a test, and this ADR does not add a
+gate. Widths, wrapping, the dialog's scroll region and the absence of horizontal overflow were checked
+by hand in a browser at the widths listed in the pull request. The one mechanical assertion is
+`PageContainer.test.tsx`, which pins which cap each variant selects and explicitly claims nothing about
+the resulting layout.
+
+**Two widths changed deliberately.** The daily check-in goes from 672px to 768px and the notification
+and progress lists from 768px to 1280px. One reading cap and one default cap beat four arbitrary ones,
+and both list pages are rows with right-aligned metadata that read better wide.
+
+**`aria-modal` overstates what the dialog does.** It tells assistive technology the rest of the page is
+inert, but nothing traps the keyboard, so Tab still walks out behind the scrim, and focus is neither
+moved in on open nor restored on close. Recorded as an open question rather than half-solved.
+
+## Alternatives considered
+
+- **Leave the per-page caps and fix only the modal.** Rejected: the empty band on a wide window was the
+  reported symptom, and nine inconsistent caps is the kind of thing that gets copied into the tenth
+  page. *Revisit:* never — the inconsistency is the defect.
+- **No cap at all; content always fills the window.** Rejected: a 1920px window would give a
+  seventy-word line on the upgrade details page. The cap exists for the measure, not for the layout.
+- **`overflow-x: hidden` on the shell.** Rejected: it hides the symptom, and it clips any sticky or
+  popover child added later — the notification dropdown escapes its card today. *Revisit:* never.
+- **Container queries (`@tailwindcss/container-queries`).** Tailwind's breakpoints measure the viewport,
+  but the content area is 240px narrower whenever the sidebar is showing, so the column count changes
+  later than the numbers suggest — and at exactly `md` the sidebar appears and the content column drops
+  from 735px to 480px in one step. Container queries are the correct answer and cost a dependency.
+  *Revisit when* a second layout hits the same cliff, or the sidebar becomes collapsible and the
+  viewport-to-content offset stops being a constant.
+- **A native `<dialog>` with `showModal()`.** The correct answer to the focus trap: a real trap, real
+  inertness, native Escape and the top layer, with no hand-rolled key handling. Not adopted here because
+  the backdrop moves from a token-styled `<div>` to `::backdrop`, which lives in `index.css` — and
+  `check:colours` scans only `index.html` and `src/**/*.ts(x)`, so a colour used there would sit outside
+  the one guard that exists to have none. *Revisit when* the dialog needs a genuine keyboard workflow,
+  and extend `check:colours` to the stylesheet in the same change.
+- **Canonicalising a stored icon to exactly one grapheme with `Intl.Segmenter`.** Rejected: it does not
+  type-check under this project's `lib` setting, and its pre-Firefox-125 fallback splits by code point,
+  which strips a variation selector from `❤️` and a skin tone from `👍🏽`. The fixed-size clipping box
+  already makes the layout immune, so the render path only has to choose between the stored value and
+  the default.
+- **A mobile navigation drawer.** Out of scope. The sidebar is hidden below `md` deliberately and says
+  so; replacing it is a component, focus management and its own requirement.
+
+## Note
+
+Emoji are still written as literals in components — the sidebar's nav icons, the dashboard's stat
+glyphs, `EmptyState`. Most are decorative and lack `aria-hidden`, so a screen reader announces them.
+`Modal` now marks its own; the rest is a follow-up, not part of this decision.

--- a/docs/ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md
+++ b/docs/ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md
@@ -52,13 +52,18 @@ rows.
 **A dialog is bounded by its overlay and scrolls its own body.** The overlay carries the gutter as
 padding; `max-h-full` resolves against that padded box, so the panel is never taller than the window;
 `flex flex-col` with a `shrink-0` header and an `overflow-y-auto` body keeps the title and close button
-in place while the form scrolls. It also gained `role="dialog"`, `aria-modal` and an `aria-labelledby`
-name derived with `useId`, since three modals share the health areas page.
+in place while the form scrolls. It also gained `role="dialog"` and an `aria-labelledby` name derived
+with `useId`, since three modals share the health areas page — but deliberately **not** `aria-modal`,
+which is a claim about the rest of the page being inert that nothing here makes true.
 
 **Stored icons are reconciled on the render side, then corrected in the data.** `areaIcon.ts` falls back
-to the default glyph for anything starting with an ASCII word character, so the layout holds whatever
-the database contains; `V5__seed_health_area_icons_as_emoji.sql` then rewrites the six seeded rows as
-emoji. The render fix ships first, so at no point does the page depend on the migration having run.
+to the default for a value that is recognisably an icon *key* — an ASCII identifier, anchored at both
+ends so a keycap emoji such as `1️⃣` is not caught by its leading digit. It does not attempt to decide
+emoji-ness in general; it does not have to, because the icon is drawn in a fixed clipping box that no
+value can widen. The edit form uses the same predicate, so an undrawable value arrives as empty rather
+than being offered back for saving. `V5__seed_health_area_icons_as_emoji.sql` then rewrites the six
+seeded rows as emoji. The render fix ships first, so at no point does the page depend on the migration
+having run.
 
 ## Consequences
 
@@ -77,13 +82,22 @@ by hand in a browser at the widths listed in the pull request. The one mechanica
 `PageContainer.test.tsx`, which pins which cap each variant selects and explicitly claims nothing about
 the resulting layout.
 
-**Two widths changed deliberately.** The daily check-in goes from 672px to 768px and the notification
-and progress lists from 768px to 1280px. One reading cap and one default cap beat four arbitrary ones,
-and both list pages are rows with right-aligned metadata that read better wide.
+**Eight of the nine page widths changed.** Only the upgrade details page keeps its number. The daily
+check-in narrows the gap the other way, 672px to 768px; everything else widens, most of it 896px to
+1280px, and the notification and progress lists 768px to 1280px. One reading cap and one default cap
+beat four arbitrary ones, and both list pages are rows with right-aligned metadata that read better
+wide. The card grids on the upgrade lists and health areas gain a third column at `xl` so the extra
+width becomes another card rather than more whitespace inside two very wide ones.
 
-**`aria-modal` overstates what the dialog does.** It tells assistive technology the rest of the page is
-inert, but nothing traps the keyboard, so Tab still walks out behind the scrim, and focus is neither
-moved in on open nor restored on close. Recorded as an open question rather than half-solved.
+Two container widths remain outside `PageContainer` and are meant to: the login and register cards
+(`max-w-md`), which render outside `Layout` entirely.
+
+**The dialog announces itself but does not contain anything.** Nothing traps the keyboard, so Tab still
+walks out behind the scrim, and focus is neither moved in on open nor restored on close. `aria-modal`
+is therefore left off on purpose: it would remove the page behind from a screen reader's buffer while
+focus could still reach it, which is worse than the plain `dialog` role — controls that are focusable
+but unannounced. The role and the accessible name are the part that is honestly earned. Recorded as an
+open question rather than half-solved.
 
 ## Alternatives considered
 
@@ -113,6 +127,11 @@ moved in on open nor restored on close. Recorded as an open question rather than
   the default.
 - **A mobile navigation drawer.** Out of scope. The sidebar is hidden below `md` deliberately and says
   so; replacing it is a component, focus management and its own requirement.
+- **Letting the navbar's controls compress.** The theme toggle, bell and logout button are `shrink-0`
+  as a group, which put a 436px floor under the shell until the brand was made the thing that gives:
+  `min-w-0` on the link plus `truncate` on the wordmark. A half-width logout button is worse than an
+  ellipsised wordmark. *Revisit when* the navbar gains a fifth control, at which point the wordmark
+  alone can no longer absorb the difference and something has to move to an overflow menu.
 
 ## Note
 

--- a/docs/architecture/arch-diagrams/README.md
+++ b/docs/architecture/arch-diagrams/README.md
@@ -150,8 +150,11 @@ Relations shown are **implements**, **extends**, and *holds a field of this type
 that reveals the wiring. Accessors and framework plumbing are left out on purpose; the interesting
 content is which layer a type sits in and which way its arrows point.
 
-Scoped to this context's own types, so dependencies on `common` and on Spring do not appear —
-`UpgradeService` also holds a `DomainEventPublisher` and a `Clock`, neither of which is drawn here.
+Two things are therefore absent by construction, and neither means what it looks like. Dependencies on
+`common` and on Spring are out of scope — `UpgradeService` also holds a `DomainEventPublisher` and a
+`Clock`. And a type *constructed in a method* rather than held as a field draws no arrow, which is why
+nothing connects `UpgradeBeansConfig` to `UpgradeSchedulingService` even though wiring that bean is the
+only reason the class exists.
 
 <!-- generated:class-diagram -->
 ```mermaid
@@ -208,17 +211,29 @@ classDiagram
         <<outbound port>>
     }
 
-    %% ---- application ----
-    class UpgradeBeansConfig {
-        <<application>>
+    %% ---- port record ----
+    class UpgradeTrackingSummary {
+        <<port record>>
     }
+
+    %% ---- application ----
     class UpgradeService {
         <<application>>
+    }
+
+    %% ---- bean wiring ----
+    class UpgradeBeansConfig {
+        <<bean wiring>>
     }
 
     %% ---- inbound port ----
     class UpgradeQuery {
         <<inbound port>>
+    }
+
+    %% ---- use-case record ----
+    class UpgradeDetails {
+        <<use-case record>>
     }
 
     %% ---- web adapter ----
@@ -258,16 +273,6 @@ classDiagram
     }
     class UpgradeRepositoryAdapter {
         <<persistence adapter>>
-    }
-
-    %% ---- port record ----
-    class UpgradeTrackingSummary {
-        <<port record>>
-    }
-
-    %% ---- use-case record ----
-    class UpgradeDetails {
-        <<use-case record>>
     }
 
     %% ---- relations: implements, extends, and fields typed by another type ----

--- a/docs/architecture/arch-diagrams/README.md
+++ b/docs/architecture/arch-diagrams/README.md
@@ -1,0 +1,506 @@
+# Architecture diagrams
+
+Seven views of UpHealther, ordered from the outside in: what the moving parts are, how the backend
+is divided, how one division is shaped, what one of them contains, how its core object moves through
+its life, how a request travels, and what is stored.
+
+Read them in order and you have the system. For the prose that goes with them see
+[`../architecture.md`](../architecture.md); for why any of it is shaped this way, see
+[`../../ADRs/`](../../ADRs/).
+
+> **Three of these are generated, not drawn.** The context map, the class diagram and the ER diagram
+> are derived from the imports, the package layout and the Flyway migrations respectively, by
+> [`generate.py`](generate.py). CI fails if the committed output stops matching the source, so a
+> diagram here cannot quietly go out of date. The other three describe intent rather than structure,
+> do not rot, and are written by hand.
+
+---
+
+## 1. System context
+
+Three processes and a browser. There is no message broker, no cache and no third-party service —
+every piece of state is in the one database, and every side effect is either a write to it or a
+message pushed to a connected browser.
+
+```mermaid
+flowchart LR
+    user(["User's browser"])
+
+    subgraph frontend["Frontend container · nginx :80 → :3000"]
+        spa["React SPA<br/>static bundle"]
+        proxy["reverse proxy<br/>/api · /ws"]
+    end
+
+    subgraph backend["Backend container · Spring Boot :8080"]
+        rest["REST controllers"]
+        stomp["STOMP endpoint /ws"]
+        jobs["Scheduled jobs<br/>overdue · check-in · reminders"]
+        core["Domain + application core"]
+    end
+
+    db[("PostgreSQL 15<br/>schema owned by Flyway")]
+
+    user -->|"HTTP"| spa
+    user -->|"/api/**"| proxy
+    user -->|"WebSocket /ws"| proxy
+    proxy -->|"proxy_pass"| rest
+    proxy -->|"proxy_pass, upgraded"| stomp
+    rest --> core
+    jobs --> core
+    core -->|"push"| stomp
+    core -->|"JDBC"| db
+```
+
+Same-origin by design: the browser only ever talks to the frontend's origin, and the proxy forwards
+`/api` and `/ws` onward. In development the Vite dev server does the same job, so both sides behave
+identically.
+
+---
+
+## 2. Bounded-context map
+
+The backend is nine bounded contexts over a shared kernel. This graph is read off the `import`
+statements — it is what the code does, not what anyone intended.
+
+<!-- generated:context-map -->
+```mermaid
+flowchart TD
+    auth["auth"]
+    user["user"]
+    healtharea["healtharea"]
+    upgrade["upgrade"]
+    tracking["tracking"]
+    reflection["reflection"]
+    reminder["reminder"]
+    dashboard["dashboard"]
+    notification["notification"]
+
+    auth --> user
+    tracking --> upgrade
+    reflection --> upgrade
+    reminder --> upgrade
+    dashboard --> healtharea
+    dashboard --> tracking
+    dashboard --> upgrade
+    notification --> reflection
+    notification --> reminder
+    notification --> tracking
+    notification --> upgrade
+
+    %% depends on nothing: healtharea, upgrade, user — the graph is acyclic,
+    %% which HexagonalArchitectureTest fails the build over if it stops being true.
+```
+<!-- /generated:context-map -->
+
+`common` is excluded: every context depends on it by definition, so drawing it would add ten edges
+that say nothing. The absent edge is the interesting one — `upgrade` points at nothing, even though
+an upgrade's response carries its tracking configuration. That inversion is
+[ADR-002](../../ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md).
+
+---
+
+## 3. How to read a context
+
+Every context is the same shape, so learning it once is enough. Arrows run **inward**: adapters
+depend on the core, and the core depends on nothing outside itself. The driven side is inverted —
+persistence and messaging *implement* ports the core declares, rather than the core calling them.
+
+```mermaid
+flowchart LR
+    subgraph driving["driving side — what starts work"]
+        web["adapter/in/web<br/>controllers · DTOs · mappers"]
+        sched["adapter/in/scheduling<br/>cron jobs"]
+        evt["adapter/in/event<br/>event listeners"]
+    end
+
+    subgraph core["the core — no Spring, no JPA queries, no HTTP"]
+        portIn["application/port/in<br/>inbound ports · command records"]
+        app["application<br/>transactional services"]
+        domain["domain/model · domain/service<br/>aggregates · invariants"]
+        portOut["domain/port/out<br/>outbound ports"]
+    end
+
+    subgraph driven["driven side — what work reaches out to"]
+        persistence["adapter/out/persistence<br/>JPA repositories"]
+        messaging["adapter/out/messaging<br/>STOMP push"]
+    end
+
+    web --> portIn
+    sched --> portIn
+    evt --> portIn
+    portIn --> app
+    app --> domain
+    app --> portOut
+    persistence -. implements .-> portOut
+    messaging -. implements .-> portOut
+```
+
+This is not a convention anyone has to remember — `HexagonalArchitectureTest` fails the build on
+every arrow that runs the wrong way. Two contexts are deliberately smaller than this: `auth`
+orchestrates over `user` and owns no aggregate, and `dashboard` is a read model with no driven side.
+
+---
+
+## 4. Inside one context — `upgrade`
+
+The core context, and the one worth reading in full: it owns `HealthUpgrade`, the aggregate whose
+state machine the whole product is built around. Every other context follows the shape from §3.
+
+Relations shown are **implements**, **extends**, and *holds a field of this type* — the composition
+that reveals the wiring. Accessors and framework plumbing are left out on purpose; the interesting
+content is which layer a type sits in and which way its arrows point.
+
+Scoped to this context's own types, so dependencies on `common` and on Spring do not appear —
+`UpgradeService` also holds a `DomainEventPublisher` and a `Clock`, neither of which is drawn here.
+
+<!-- generated:class-diagram -->
+```mermaid
+classDiagram
+    direction LR
+
+    %% ---- domain model ----
+    class Difficulty {
+        <<domain model · enum>>
+    }
+    class HealthUpgrade {
+        <<domain model>>
+    }
+    class UpgradeStatus {
+        <<domain model · enum>>
+    }
+    class UpgradeType {
+        <<domain model · enum>>
+    }
+
+    %% ---- domain event ----
+    class HealthUpgradeAbandoned {
+        <<domain event>>
+    }
+    class HealthUpgradeActivated {
+        <<domain event>>
+    }
+    class HealthUpgradeCompleted {
+        <<domain event>>
+    }
+    class HealthUpgradeCreated {
+        <<domain event>>
+    }
+    class HealthUpgradePaused {
+        <<domain event>>
+    }
+    class HealthUpgradePlanned {
+        <<domain event>>
+    }
+    class UpgradeOverdueDetected {
+        <<domain event>>
+    }
+
+    %% ---- domain service ----
+    class UpgradeSchedulingService {
+        <<domain service>>
+    }
+
+    %% ---- outbound port ----
+    class UpgradeRepositoryPort {
+        <<outbound port>>
+    }
+    class UpgradeTrackingSummaryPort {
+        <<outbound port>>
+    }
+
+    %% ---- application ----
+    class UpgradeBeansConfig {
+        <<application>>
+    }
+    class UpgradeService {
+        <<application>>
+    }
+
+    %% ---- inbound port ----
+    class UpgradeQuery {
+        <<inbound port>>
+    }
+
+    %% ---- web adapter ----
+    class ActivateRequest {
+        <<web adapter>>
+    }
+    class PlanRequest {
+        <<web adapter>>
+    }
+    class RescheduleRequest {
+        <<web adapter>>
+    }
+    class UpgradeController {
+        <<web adapter>>
+    }
+    class UpgradeDto {
+        <<web adapter>>
+    }
+    class UpgradeRequest {
+        <<web adapter>>
+    }
+    class UpgradeTrackingConfigDto {
+        <<web adapter>>
+    }
+    class UpgradeWebMapper {
+        <<web adapter>>
+    }
+
+    %% ---- scheduling adapter ----
+    class UpgradeOverdueScheduler {
+        <<scheduling adapter>>
+    }
+
+    %% ---- persistence adapter ----
+    class UpgradeJpaRepository {
+        <<persistence adapter>>
+    }
+    class UpgradeRepositoryAdapter {
+        <<persistence adapter>>
+    }
+
+    %% ---- port record ----
+    class UpgradeTrackingSummary {
+        <<port record>>
+    }
+
+    %% ---- use-case record ----
+    class UpgradeDetails {
+        <<use-case record>>
+    }
+
+    %% ---- relations: implements, extends, and fields typed by another type ----
+    HealthUpgrade --> Difficulty
+    HealthUpgrade --> UpgradeStatus
+    HealthUpgrade --> UpgradeType
+    UpgradeController --> UpgradeService
+    UpgradeController --> UpgradeWebMapper
+    UpgradeDetails --> Difficulty
+    UpgradeDetails --> UpgradeType
+    UpgradeDto --> Difficulty
+    UpgradeDto --> UpgradeStatus
+    UpgradeDto --> UpgradeTrackingConfigDto
+    UpgradeDto --> UpgradeType
+    UpgradeOverdueScheduler --> UpgradeQuery
+    UpgradeRepositoryAdapter --> UpgradeJpaRepository
+    UpgradeRepositoryAdapter ..|> UpgradeRepositoryPort : implements
+    UpgradeRequest --> Difficulty
+    UpgradeRequest --> UpgradeType
+    UpgradeService --> UpgradeRepositoryPort
+    UpgradeService --> UpgradeSchedulingService
+    UpgradeService ..|> UpgradeQuery : implements
+    UpgradeWebMapper --> UpgradeTrackingSummaryPort
+```
+<!-- /generated:class-diagram -->
+
+Read the stereotypes as layers. Note that `UpgradeService` holds `UpgradeRepositoryPort` — an
+interface in the domain — and never the adapter that implements it, which is the whole point.
+
+---
+
+## 5. The upgrade lifecycle
+
+The state machine `HealthUpgrade` owns. Status changes only through these named transitions — the
+aggregate has no setter for it — and each one guards itself, so an illegal move is a 422 with a reason
+rather than a silently accepted write.
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDEA: create
+    IDEA --> PLANNED: plan
+    PLANNED --> ACTIVE: activate
+    ACTIVE --> PAUSED: pause
+    PAUSED --> ACTIVE: activate
+    ACTIVE --> COMPLETED: complete
+    IDEA --> ABANDONED: abandon
+    PLANNED --> ABANDONED: abandon
+    ACTIVE --> ABANDONED: abandon
+    PAUSED --> ABANDONED: abandon
+    ABANDONED --> PLANNED: reschedule
+    COMPLETED --> [*]
+```
+
+`COMPLETED` is terminal; `ABANDONED` is not — rescheduling revives it, which is the one transition not
+named after its destination. An upgrade occupies one of the three concurrent `HARD` slots only while
+`ACTIVE`, which is why that limit is checked both when activating one and when promoting a running one
+to `HARD`. Every transition here is pinned by `HealthUpgradeTest`.
+
+---
+
+## 6. Request lifecycle
+
+Logging a day's progress, end to end. Chosen because it touches almost everything: authentication,
+cross-context ownership checks, a domain invariant, an event, and both delivery transports.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant N as nginx
+    participant F as JwtAuthenticationFilter
+    participant C as ProgressController
+    participant S as TrackingService
+    participant U as UpgradeQuery
+    participant R as ProgressEntryRepositoryPort
+    participant DB as PostgreSQL
+    participant L as NotificationEventListener
+    participant W as StompNotificationPushAdapter
+
+    B->>N: POST /api/upgrades/{id}/progress
+    N->>F: proxied
+    F->>F: validate JWT, load user, set security context
+    F->>C: request
+    C->>S: recordProgress(userId, upgradeId, details)
+    S->>U: getOwnedUpgrade(userId, upgradeId)
+    U->>DB: SELECT … WHERE id = ? AND user_id = ?
+    S->>R: existsByUpgradeIdAndDate — duplicate guard
+    S->>S: score the entry against the tracking config
+    S->>R: save(entry)
+    R->>DB: INSERT
+    S-->>L: ProgressEntryRecorded · StreakAchieved
+    Note over L: AFTER_COMMIT — nothing fires if the transaction rolls back
+    L->>DB: INSERT notification
+    L->>W: push
+    W-->>B: STOMP frame on /user/queue/notifications
+    C-->>B: 201 with the stored entry
+```
+
+Three things worth noticing: ownership is enforced by the *query* being user-scoped rather than by a
+guard, so a foreign row is indistinguishable from a missing one; the server scores the entry rather
+than trusting the client's `completed` flag; and the push happens only after commit, while the
+notification is persisted either way so an offline client still sees it.
+
+---
+
+## 7. Data model
+
+Tables, keys and foreign keys, read from the Flyway migrations. The schema is owned by Flyway and
+Hibernate runs with `ddl-auto: validate`, so this is authoritative — the application refuses to start
+against a schema that does not match it.
+
+<!-- generated:er-diagram -->
+```mermaid
+erDiagram
+    health_areas |o--o{ health_upgrades : ""
+    health_upgrades |o--o{ notifications : ""
+    health_upgrades ||--o{ progress_entries : ""
+    health_upgrades ||--o{ reflections : ""
+    health_upgrades ||--o{ reminders : ""
+    health_upgrades ||--o{ tracking_configs : ""
+    users ||--o{ health_areas : ""
+    users ||--o{ health_upgrades : ""
+    users ||--o{ notifications : ""
+    users ||--o{ progress_entries : ""
+    users ||--o{ reflections : ""
+
+    users {
+        uuid id PK
+        varchar name
+        varchar email UK
+        varchar password_hash
+        timestamp created_at
+        timestamp updated_at
+    }
+    health_areas {
+        uuid id PK
+        uuid user_id
+        varchar name
+        text description
+        integer priority
+        varchar icon
+        varchar color
+        timestamp created_at
+        timestamp updated_at
+    }
+    health_upgrades {
+        uuid id PK
+        uuid user_id
+        uuid area_id
+        varchar title
+        text description
+        varchar type
+        varchar status
+        varchar difficulty
+        date planned_start_date
+        date actual_start_date
+        date target_end_date
+        text motivation
+        text success_criteria
+        bigint version
+        timestamp created_at
+        timestamp updated_at
+    }
+    tracking_configs {
+        uuid id PK
+        uuid upgrade_id UK
+        varchar tracking_type
+        varchar frequency
+        double target_numeric_value
+        varchar target_unit
+        boolean required_daily
+    }
+    progress_entries {
+        uuid id PK
+        uuid upgrade_id
+        uuid user_id
+        date date
+        boolean completed
+        double numeric_value
+        varchar unit
+        integer rating
+        text note
+        timestamp created_at
+        timestamp updated_at
+    }
+    reminders {
+        uuid id PK
+        uuid upgrade_id
+        time reminder_time
+        varchar days_of_week
+        boolean enabled
+        timestamp created_at
+        timestamp updated_at
+    }
+    reflections {
+        uuid id PK
+        uuid upgrade_id
+        uuid user_id
+        date date
+        integer difficulty_rating
+        integer benefit_rating
+        text what_worked
+        text what_did_not_work
+        text next_adjustment
+        timestamp created_at
+        timestamp updated_at
+    }
+    notifications {
+        uuid id PK
+        uuid user_id
+        varchar type
+        varchar category
+        varchar title
+        text message
+        uuid related_upgrade_id
+        boolean is_read
+        timestamp created_at
+    }
+```
+<!-- /generated:er-diagram -->
+
+The two constraints doing real work: `progress_entries` is unique on `(upgrade_id, date)`, which is
+what makes "one entry per upgrade per day" survive a race the application-level check would miss; and
+`tracking_configs.upgrade_id` is unique, so an upgrade has at most one configuration.
+
+---
+
+## Regenerating
+
+```bash
+python docs/architecture/arch-diagrams/generate.py           # rewrite the generated diagrams
+python docs/architecture/arch-diagrams/generate.py --check   # fail if they are out of date (CI runs this)
+```
+
+Editing a generated region by hand is pointless — the next run overwrites it, and CI will fail before
+then. Change the code, then regenerate.

--- a/docs/architecture/arch-diagrams/generate.py
+++ b/docs/architecture/arch-diagrams/generate.py
@@ -85,11 +85,13 @@ def code_only(source: str) -> str:
     return STRING_LITERAL.sub('""', LINE_COMMENT.sub("", BLOCK_COMMENT.sub("", source)))
 
 
-def stereotype_for(relative_package: str, kind: str) -> str:
-    """The layer and role to stamp on a type, from where it sits and what kind of type it is.
+def stereotype_for(relative_package: str, kind: str, name: str) -> str:
+    """The layer and role to stamp on a type, from where it sits, what kind it is, and what it is called.
 
-    A port package holds two different things — the port interface and the records passed across it —
-    and calling both "port" would hide the distinction the hexagonal layering exists to make.
+    Two distinctions the package path alone would flatten, both of which the hexagonal layering exists
+    to make visible: a port package holds the port interface *and* the records passed across it, and
+    the application package holds use cases *and* the configuration that hand-wires the domain
+    services — which carry no stereotype annotation precisely so the domain stays framework-free.
     """
     best, label = "", "type"
     for prefix, candidate in STEREOTYPES:
@@ -98,6 +100,8 @@ def stereotype_for(relative_package: str, kind: str) -> str:
 
     if label in ("inbound port", "outbound port") and kind != "interface":
         return "use-case record" if "port/in" in relative_package else "port record"
+    if label == "application" and name.endswith("Config"):
+        return "bean wiring"
     return label
 
 
@@ -123,7 +127,7 @@ def discover_types() -> dict:
             "context": context,
             "package": package,
             "kind": kind,
-            "stereotype": stereotype_for(package, kind),
+            "stereotype": stereotype_for(package, kind, name),
             "body": body,
             "source": source,
         }
@@ -231,9 +235,10 @@ def class_diagram(types: dict, context: str) -> str:
     for name, meta in sorted(members.items()):
         by_stereotype.setdefault(meta["stereotype"], []).append((name, meta))
 
-    layer_order = ["domain model", "domain event", "domain service", "outbound port",
-                   "application", "inbound port", "web adapter", "scheduling adapter",
-                   "persistence adapter", "composition adapter", "messaging adapter", "event adapter"]
+    layer_order = ["domain model", "domain event", "domain service", "outbound port", "port record",
+                   "application", "bean wiring", "inbound port", "use-case record",
+                   "web adapter", "scheduling adapter", "persistence adapter",
+                   "composition adapter", "messaging adapter", "event adapter"]
     ordered = sorted(by_stereotype, key=lambda s: (layer_order.index(s) if s in layer_order else 99, s))
 
     for stereotype in ordered:

--- a/docs/architecture/arch-diagrams/generate.py
+++ b/docs/architecture/arch-diagrams/generate.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Regenerates the mechanical diagrams in this folder's README from the source they describe.
+
+Three of the six diagrams are derived rather than drawn, because they restate something the code
+already states and would otherwise drift the moment anyone adds an import, a field or a column:
+
+    context-map    the cross-context dependency graph, from the import statements
+    class-diagram  one bounded context's types and their relations, from the package layout
+    er-diagram     the database schema, from the Flyway migrations
+
+The other three are conceptual, do not rot, and are written by hand in the README.
+
+Usage:
+    python generate.py            rewrite the generated regions of README.md
+    python generate.py --check    exit 1 if the committed README is out of date
+
+The generated regions are delimited by <!-- generated:NAME --> ... <!-- /generated:NAME --> markers;
+everything outside them is left untouched.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# The context whose internals the class diagram shows. `upgrade` owns the core aggregate and its
+# state machine, so it is the one worth reading in full; every other context follows the same shape.
+CLASS_DIAGRAM_CONTEXT = "upgrade"
+
+CONTEXTS = [
+    "auth", "user", "healtharea", "upgrade", "tracking",
+    "reflection", "reminder", "dashboard", "notification",
+]
+
+# Package path (relative to a context root) → the layer and role shown as a Mermaid stereotype.
+# Longest match wins, so `domain/port/out` beats `domain`.
+STEREOTYPES = [
+    ("adapter/in/web", "web adapter"),
+    ("adapter/in/scheduling", "scheduling adapter"),
+    ("adapter/in/composition", "composition adapter"),
+    ("adapter/in/event", "event adapter"),
+    ("adapter/out/persistence", "persistence adapter"),
+    ("adapter/out/messaging", "messaging adapter"),
+    ("application/port/in", "inbound port"),
+    ("application/port/out", "outbound port"),
+    ("application", "application"),
+    ("domain/model", "domain model"),
+    ("domain/event", "domain event"),
+    ("domain/port/out", "outbound port"),
+    ("domain/service", "domain service"),
+]
+
+SQL_TYPE_TOKENS = {
+    "UUID": "uuid", "TEXT": "text", "DATE": "date", "BOOLEAN": "boolean",
+    "INTEGER": "integer", "BIGINT": "bigint", "TIMESTAMP": "timestamp",
+    "DOUBLE": "double", "VARCHAR": "varchar", "NUMERIC": "numeric",
+}
+
+
+# --------------------------------------------------------------------------- source discovery
+
+def repo_root() -> Path:
+    for candidate in [Path(__file__).resolve()] + list(Path(__file__).resolve().parents):
+        if (candidate / ".git").exists():
+            return candidate
+    raise SystemExit("could not locate the repository root (no .git found above this file)")
+
+
+ROOT = repo_root()
+JAVA_ROOT = ROOT / "backend" / "src" / "main" / "java" / "com" / "healthupgrades"
+MIGRATIONS = ROOT / "backend" / "src" / "main" / "resources" / "db" / "migration"
+README = Path(__file__).resolve().parent / "README.md"
+
+BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+LINE_COMMENT = re.compile(r"//[^\n]*")
+STRING_LITERAL = re.compile(r'"(?:\\.|[^"\\])*"')
+
+
+def code_only(source: str) -> str:
+    """Strips comments and string literals, so documentation references are not read as dependencies.
+
+    This matters here: the codebase is heavily javadoc'd and nearly every class names several others
+    in prose. Scanning the raw text would report those mentions as relations.
+    """
+    return STRING_LITERAL.sub('""', LINE_COMMENT.sub("", BLOCK_COMMENT.sub("", source)))
+
+
+def stereotype_for(relative_package: str, kind: str) -> str:
+    """The layer and role to stamp on a type, from where it sits and what kind of type it is.
+
+    A port package holds two different things — the port interface and the records passed across it —
+    and calling both "port" would hide the distinction the hexagonal layering exists to make.
+    """
+    best, label = "", "type"
+    for prefix, candidate in STEREOTYPES:
+        if relative_package.startswith(prefix) and len(prefix) > len(best):
+            best, label = prefix, candidate
+
+    if label in ("inbound port", "outbound port") and kind != "interface":
+        return "use-case record" if "port/in" in relative_package else "port record"
+    return label
+
+
+def discover_types() -> dict:
+    """Every type in the backend's main sources, keyed by simple name."""
+    types = {}
+    for path in sorted(JAVA_ROOT.rglob("*.java")):
+        relative = path.relative_to(JAVA_ROOT)
+        parts = relative.parts
+        context = parts[0]
+        package = "/".join(parts[1:-1])
+        name = path.stem
+        source = path.read_text(encoding="utf-8")
+        body = code_only(source)
+
+        kind = "class"
+        for candidate in ("interface", "record", "enum"):
+            if re.search(r"\b%s\s+%s\b" % (candidate, re.escape(name)), body):
+                kind = candidate
+                break
+
+        types[name] = {
+            "context": context,
+            "package": package,
+            "kind": kind,
+            "stereotype": stereotype_for(package, kind),
+            "body": body,
+            "source": source,
+        }
+    return types
+
+
+# --------------------------------------------------------------------------- 1. context map
+
+def context_map() -> str:
+    """The cross-context dependency graph, read off the imports rather than off intent."""
+    edges = {}
+    for path in sorted(JAVA_ROOT.rglob("*.java")):
+        source_context = path.relative_to(JAVA_ROOT).parts[0]
+        if source_context not in CONTEXTS:
+            continue
+        for match in re.finditer(r"^import\s+(?:static\s+)?com\.healthupgrades\.(\w+)\.",
+                                 path.read_text(encoding="utf-8"), re.MULTILINE):
+            target = match.group(1)
+            if target in CONTEXTS and target != source_context:
+                edges.setdefault(source_context, set()).add(target)
+
+    depended_on = {t for targets in edges.values() for t in targets}
+    lines = ["flowchart TD"]
+    for context in CONTEXTS:
+        if context in edges or context in depended_on:
+            shape = f'    {context}["{context}"]'
+            lines.append(shape)
+    lines.append("")
+    for source in CONTEXTS:
+        for target in sorted(edges.get(source, ())):
+            lines.append(f"    {source} --> {target}")
+    lines.append("")
+    sinks = sorted(c for c in depended_on if c not in edges)
+    lines.append(f"    %% depends on nothing: {', '.join(sinks)} — the graph is acyclic,")
+    lines.append("    %% which HexagonalArchitectureTest fails the build over if it stops being true.")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- 2. class diagram
+
+FIELD = re.compile(
+    r"^\s*(?:private|protected|public)\s+(?:static\s+|final\s+|transient\s+|volatile\s+)*"
+    r"([A-Za-z_][\w.]*(?:\s*<[^;=]*?>)?)\s+([a-z]\w*)\s*[;=]",
+    re.MULTILINE,
+)
+IMPLEMENTS = re.compile(r"\b(?:class|record|enum)\s+\w+[^{]*?\bimplements\s+([\w\s,<>.]+?)\s*\{", re.DOTALL)
+EXTENDS = re.compile(r"\b(?:class|interface)\s+\w+[^{]*?\bextends\s+([\w\s,<>.]+?)(?:\s+implements|\s*\{)", re.DOTALL)
+
+
+def record_components(body: str, name: str) -> str:
+    """The parameter list of a record declaration, or an empty string for anything else."""
+    start = body.find(f"record {name}")
+    if start == -1:
+        return ""
+    open_paren = body.find("(", start)
+    if open_paren == -1:
+        return ""
+    depth, index = 0, open_paren
+    while index < len(body):
+        if body[index] == "(":
+            depth += 1
+        elif body[index] == ")":
+            depth -= 1
+            if depth == 0:
+                return body[open_paren + 1:index]
+        index += 1
+    return ""
+
+
+def referenced_types(text: str, known: set, exclude: str) -> set:
+    """Project types named in a fragment of code — generic arguments included."""
+    return {token for token in re.findall(r"\b([A-Z]\w+)\b", text) if token in known and token != exclude}
+
+
+def supertype_names(clause: str, known: set, exclude: str) -> set:
+    """The base types in an extends/implements clause, ignoring their type arguments.
+
+    `extends JpaRepository<HealthUpgrade, UUID>` names one supertype, not two: reading the type
+    argument as a supertype would draw an inheritance arrow that does not exist.
+    """
+    parts, depth, current = [], 0, ""
+    for character in clause:
+        if character == "<":
+            depth += 1
+        elif character == ">":
+            depth -= 1
+        if character == "," and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += character
+    parts.append(current)
+
+    names = {part.split("<")[0].strip().split(".")[-1] for part in parts}
+    return {name for name in names if name in known and name != exclude}
+
+
+def class_diagram(types: dict, context: str) -> str:
+    members = {name: meta for name, meta in types.items() if meta["context"] == context}
+    known = set(members)
+
+    lines = ["classDiagram", "    direction LR", ""]
+
+    by_stereotype = {}
+    for name, meta in sorted(members.items()):
+        by_stereotype.setdefault(meta["stereotype"], []).append((name, meta))
+
+    layer_order = ["domain model", "domain event", "domain service", "outbound port",
+                   "application", "inbound port", "web adapter", "scheduling adapter",
+                   "persistence adapter", "composition adapter", "messaging adapter", "event adapter"]
+    ordered = sorted(by_stereotype, key=lambda s: (layer_order.index(s) if s in layer_order else 99, s))
+
+    for stereotype in ordered:
+        lines.append(f"    %% ---- {stereotype} ----")
+        for name, meta in by_stereotype[stereotype]:
+            label = meta["stereotype"] if meta["kind"] != "enum" else f"{meta['stereotype']} · enum"
+            lines.append(f"    class {name} {{")
+            lines.append(f"        <<{label}>>")
+            lines.append("    }")
+        lines.append("")
+
+    relations = []
+    for name, meta in sorted(members.items()):
+        body = meta["body"]
+
+        for match in IMPLEMENTS.finditer(body):
+            for target in supertype_names(match.group(1), known, name):
+                relations.append(f"    {name} ..|> {target} : implements")
+        for match in EXTENDS.finditer(body):
+            for target in supertype_names(match.group(1), known, name):
+                relations.append(f"    {name} --|> {target} : extends")
+
+        holds = set()
+        for match in FIELD.finditer(body):
+            holds |= referenced_types(match.group(1), known, name)
+        holds |= referenced_types(record_components(body, name), known, name)
+        for target in sorted(holds):
+            relations.append(f"    {name} --> {target}")
+
+    lines.append("    %% ---- relations: implements, extends, and fields typed by another type ----")
+    lines.extend(sorted(set(relations)))
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- 3. ER diagram
+
+CREATE_TABLE = re.compile(r"CREATE TABLE (\w+)\s*\((.*?)\n\);", re.DOTALL | re.IGNORECASE)
+
+
+def sql_type_token(column_definition: str) -> str:
+    head = column_definition.strip().split()
+    if len(head) < 2:
+        return "unknown"
+    raw = head[1].upper().split("(")[0]
+    return SQL_TYPE_TOKENS.get(raw, raw.lower())
+
+
+def er_diagram() -> str:
+    tables, relations = {}, []
+    for migration in sorted(MIGRATIONS.glob("V*.sql")):
+        sql = migration.read_text(encoding="utf-8")
+        for table, block in CREATE_TABLE.findall(sql):
+            columns = []
+            for line in block.splitlines():
+                line = line.strip().rstrip(",")
+                if not line or line.upper().startswith("CONSTRAINT"):
+                    # A single-column UNIQUE is a property of that column and is marked on it. A
+                    # composite one is a property of the pair, and Mermaid has no notation for that —
+                    # marking each column UK would claim each is independently unique, which is false.
+                    # Composite constraints are described in the prose beside the diagram instead.
+                    inner = re.search(r"UNIQUE\s*\(([^)]*)\)", line, re.IGNORECASE)
+                    if inner and "," not in inner.group(1):
+                        columns.append((inner.group(1).strip(), None, "UK"))
+                    continue
+                name = line.split()[0]
+                if name.upper() in ("PRIMARY", "FOREIGN", "UNIQUE", "CHECK"):
+                    continue
+                key = "PK" if "PRIMARY KEY" in line.upper() else ("UK" if " UNIQUE" in line.upper() else "")
+                columns.append((name, sql_type_token(line), key))
+
+                reference = re.search(r"REFERENCES\s+(\w+)", line, re.IGNORECASE)
+                if reference:
+                    optional = "NOT NULL" not in line.upper()
+                    cardinality = "||--o{" if not optional else "|o--o{"
+                    relations.append(f"    {reference.group(1)} {cardinality} {table} : \"\"")
+
+            merged = {}
+            for name, type_token, key in columns:
+                if name in merged:
+                    existing_type, existing_key = merged[name]
+                    merged[name] = (existing_type or type_token, existing_key or key)
+                else:
+                    merged[name] = (type_token, key)
+            tables[table] = merged
+
+    lines = ["erDiagram"]
+    lines.extend(sorted(set(relations)))
+    lines.append("")
+    for table, columns in tables.items():
+        lines.append(f"    {table} {{")
+        for name, (type_token, key) in columns.items():
+            lines.append(f"        {type_token or 'unknown'} {name}{(' ' + key) if key else ''}")
+        lines.append("    }")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- rendering
+
+def replace_region(text: str, marker: str, body: str) -> str:
+    """Replaces the content between a pair of markers, which may be empty on a first run."""
+    open_marker = f"<!-- generated:{marker} -->"
+    close_marker = f"<!-- /generated:{marker} -->"
+    pattern = re.compile(
+        "%s.*?%s" % (re.escape(open_marker), re.escape(close_marker)), re.DOTALL,
+    )
+    if not pattern.search(text):
+        raise SystemExit(f"marker {open_marker} not found in {README}")
+    replacement = f"{open_marker}\n```mermaid\n{body}\n```\n{close_marker}"
+    return pattern.sub(lambda _: replacement, text)
+
+
+def render(existing: str, types: dict) -> str:
+    updated = replace_region(existing, "context-map", context_map())
+    updated = replace_region(updated, "class-diagram", class_diagram(types, CLASS_DIAGRAM_CONTEXT))
+    return replace_region(updated, "er-diagram", er_diagram())
+
+
+def main() -> int:
+    check_only = "--check" in sys.argv
+    existing = README.read_text(encoding="utf-8")
+    updated = render(existing, discover_types())
+
+    if updated == existing:
+        print("diagrams are up to date")
+        return 0
+    if check_only:
+        print("ERROR: the generated diagrams in README.md no longer match the source they describe.")
+        print("Run: python docs/architecture/arch-diagrams/generate.py")
+        return 1
+    README.write_text(updated, encoding="utf-8")
+    print(f"regenerated the diagrams in {README.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -69,7 +69,7 @@ Nine contexts, each owning its own vocabulary, plus a cross-cutting `common`.
 | `src/hooks/` | `useAuth`, `useNotifications` and `useTheme` — typed context readers that fail loudly outside their provider |
 | `src/router/` | The route table, and `ProtectedRoute`, which gates every authenticated page |
 | `src/pages/` | One component per route |
-| `src/components/` | `ui/` primitives, `upgrade/` cards and badges, `notifications/` bell, dropdown, items and toasts, `layout/` navbar and sidebar |
+| `src/components/` | `ui/` primitives — including `PageContainer`, which decides how wide a page may grow — `upgrade/` cards and badges, `notifications/` bell, dropdown, items and toasts, `layout/` navbar and sidebar |
 | `src/types/` | Hand-written mirrors of the backend's response shapes and enums |
 
 ---
@@ -262,6 +262,16 @@ inline script in `index.html` that runs before the first paint, and thereafter b
 two must agree on the storage key and the resolution rule; changing one alone reintroduces the flash
 the script exists to prevent.
 
+**Nothing in the shell may be wider than the window.** `<main>` carries `min-w-0`, and that is
+load-bearing rather than tidy. A flex item's `min-width` defaults to `auto`, which resolves to its
+min-content width — so a single child that cannot shrink overrules `flex-shrink`, and the column, not
+the child, is what grows past the viewport. `min-w-0` removes that floor and hands the pressure back to
+the content, which is why every user-supplied string in the shell also carries `truncate` or
+`break-words`, and why a health area's icon sits in a fixed clipping box. It replaced an
+`overflow-auto` that was doing the same job invisibly: a flex item whose overflow is not `visible`
+already has an automatic minimum size of zero. How wide a page may then grow is decided once, in
+`PageContainer`, and not by the pages. See [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md).
+
 **The frontend's types are hand-written, not generated.** `src/types/index.ts` mirrors the backend's
 DTOs and enums by hand. The **enums** are checked: `FrontendEnumContractTest` reads that file and fails
 the build if any mirrored union stops matching its backend enum, which is what stops an unbindable
@@ -293,6 +303,7 @@ Stated because they are load-bearing, not because they are problems yet:
 | Why DDD + hexagonal at all, and why JPA entities as the domain model? | [ADR-001](../ADRs/ADR-001-ddd-hexagonal-architecture.md) |
 | Why the `upgrade`/`tracking` dependency is inverted; why events moved out of `common`; what the ten ArchUnit rules cover; what was rejected and when to revisit | [ADR-002](../ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md) |
 | Why the frontend tests with Vitest rather than Jest; why Vitest is pinned to 3; why there is still no accessibility gate | [ADR-004](../ADRs/ADR-004-frontend-test-harness.md) |
+| Why every page shares one width; why the shell can be trusted not to overflow; why container queries and a native `<dialog>` were turned down | [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md) |
 | Day-to-day conventions when changing backend code | [`backend/CLAUDE.md`](../../backend/CLAUDE.md) |
 | Day-to-day conventions when changing frontend code | [`frontend/CLAUDE.md`](../../frontend/CLAUDE.md) |
 | How to run, test and deploy it | [`README.md`](../../README.md) |

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -202,8 +202,8 @@ Integration points a maintainer will need:
   different origins. The cron expressions are overridable per environment. `.env.example` lists them
   all with safe values.
 - **CI** — GitHub Actions on every push and PR to `main` and `dev`: the backend runs `mvn verify`
-  against a PostgreSQL service container, the frontend lints, audits its shipped dependencies and
-  builds.
+  against a PostgreSQL service container, the frontend lints, tests, audits its shipped dependencies
+  and builds.
 
 ---
 
@@ -277,6 +277,7 @@ Stated because they are load-bearing, not because they are problems yet:
 | What is the system supposed to do, and what is it deliberately not doing? | [`docs/requirements/requirements.md`](../requirements/requirements.md) |
 | Why DDD + hexagonal at all, and why JPA entities as the domain model? | [ADR-001](../ADRs/ADR-001-ddd-hexagonal-architecture.md) |
 | Why the `upgrade`/`tracking` dependency is inverted; why events moved out of `common`; what the ten ArchUnit rules cover; what was rejected and when to revisit | [ADR-002](../ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md) |
+| Why the frontend tests with Vitest rather than Jest; why Vitest is pinned to 3; why there is still no accessibility gate | [ADR-004](../ADRs/ADR-004-frontend-test-harness.md) |
 | Day-to-day conventions when changing backend code | [`backend/CLAUDE.md`](../../backend/CLAUDE.md) |
 | Day-to-day conventions when changing frontend code | [`frontend/CLAUDE.md`](../../frontend/CLAUDE.md) |
 | How to run, test and deploy it | [`README.md`](../../README.md) |

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -65,8 +65,8 @@ Nine contexts, each owning its own vocabulary, plus a cross-cutting `common`.
 | Module | Responsible for |
 |---|---|
 | `src/api/` | One axios instance and a thin function per endpoint. The instance attaches the JWT and turns a 401 into a logout; every call goes through it |
-| `src/contexts/` | `AuthProvider` owns the session; `NotificationProvider` owns the notification list, the STOMP connection and the toasts |
-| `src/hooks/` | `useAuth` and `useNotifications` — typed context readers that fail loudly outside their provider |
+| `src/contexts/` | `AuthProvider` owns the session; `NotificationProvider` owns the notification list, the STOMP connection and the toasts; `ThemeProvider` owns the light/dark/system choice and the `dark` class on `<html>` |
+| `src/hooks/` | `useAuth`, `useNotifications` and `useTheme` — typed context readers that fail loudly outside their provider |
 | `src/router/` | The route table, and `ProtectedRoute`, which gates every authenticated page |
 | `src/pages/` | One component per route |
 | `src/components/` | `ui/` primitives, `upgrade/` cards and badges, `notifications/` bell, dropdown, items and toasts, `layout/` navbar and sidebar |
@@ -246,6 +246,21 @@ returns 409. Nothing else is version-checked, because nothing else is edited fro
 
 **Exception to HTTP status is decided in exactly one class.** Controllers and services throw domain
 exceptions and never build a status by hand. The mapping is pinned by a test.
+
+**No component names a colour.** Every colour in the SPA is a semantic token — `bg-surface`,
+`text-fg-subtle`, `border-line-strong` — declared in `frontend/tailwind.config.js` and given its two
+values, once per theme, in `frontend/src/index.css`. Components name the *role*; the theme decides the
+value. The indirection is not decoration: Tailwind emits nothing for a class it does not recognise and
+raises no error, so a component that reached for a palette shade would render correctly in one theme
+and be invisible in the other, silently. `npm run check:colours` fails the build on any direct palette
+use, and is the only thing that catches it.
+
+Two consequences a maintainer would otherwise have to rediscover. Tokens hold **space-separated RGB
+channels**, not hex, because Tailwind's opacity modifier (`bg-overlay/50`) can only compose an alpha
+onto a variable in that form. And the `dark` class on `<html>` is set **twice** — once by a classic
+inline script in `index.html` that runs before the first paint, and thereafter by `ThemeProvider`. The
+two must agree on the storage key and the resolution rule; changing one alone reintroduces the flash
+the script exists to prevent.
 
 **The frontend's types are hand-written, not generated.** `src/types/index.ts` mirrors the backend's
 DTOs and enums by hand. The **enums** are checked: `FrontendEnumContractTest` reads that file and fails

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -23,34 +23,8 @@ domain and application layers know nothing about HTTP, JPA or Spring's event bus
 arrives through an adapter. The boundaries are not a convention — they are checked on every build by
 an ArchUnit suite, which is the authority on what the layering permits.
 
-```mermaid
-flowchart LR
-    subgraph browser["Browser"]
-        spa["React SPA"]
-    end
-
-    subgraph edge["Frontend container"]
-        nginx["nginx<br/>static files + proxy"]
-    end
-
-    subgraph api["Backend container"]
-        rest["REST controllers"]
-        stomp["STOMP endpoint /ws"]
-        jobs["Scheduled jobs"]
-        core["Domain + application core"]
-    end
-
-    db[("PostgreSQL")]
-
-    spa -->|"HTTPS /api/**"| nginx
-    spa -->|"WebSocket /ws"| nginx
-    nginx -->|"proxy_pass"| rest
-    nginx -->|"proxy_pass, upgraded"| stomp
-    rest --> core
-    jobs --> core
-    core --> stomp
-    core -->|"JDBC"| db
-```
+> **Diagram:** [System context](arch-diagrams/README.md#1-system-context) — the three
+> processes, the browser, and what each connection carries.
 
 ---
 
@@ -139,20 +113,8 @@ overdue sweep, the daily check-in nudge, and the per-minute reminder dispatch.
 
 Derived from the imports, not from intent:
 
-```mermaid
-flowchart TD
-    auth --> user
-    tracking --> upgrade
-    reflection --> upgrade
-    reminder --> upgrade
-    dashboard --> upgrade
-    dashboard --> tracking
-    dashboard --> healtharea
-    notification --> upgrade
-    notification --> tracking
-    notification --> reflection
-    notification --> reminder
-```
+> **Diagram:** [Bounded-context map](arch-diagrams/README.md#2-bounded-context-map) —
+> generated from the imports, so it is what the code does rather than what was intended.
 
 `upgrade`, `user` and `healtharea` depend on no other context. The graph is acyclic, and ArchUnit
 fails the build if that stops being true.
@@ -171,38 +133,8 @@ way. ADR-002 records why.
 
 Recording a day's progress, which touches most of the machinery:
 
-```mermaid
-sequenceDiagram
-    participant B as Browser
-    participant N as nginx
-    participant F as JWT filter
-    participant C as ProgressController
-    participant S as TrackingService
-    participant U as UpgradeQuery (upgrade)
-    participant R as Repository port
-    participant DB as PostgreSQL
-    participant L as NotificationEventListener
-    participant W as STOMP adapter
-
-    B->>N: POST /api/upgrades/{id}/progress
-    N->>F: proxied
-    F->>F: validate JWT, load user, set security context
-    F->>C: request
-    C->>C: map request record to use-case input
-    C->>S: recordProgress(userId, upgradeId, details)
-    S->>U: getOwnedUpgrade(userId, upgradeId)
-    U->>DB: SELECT ... WHERE id = ? AND user_id = ?
-    S->>R: existsByUpgradeIdAndDate → duplicate guard
-    S->>S: evaluate entry against tracking config
-    S->>R: save(entry)
-    R->>DB: INSERT
-    S-->>L: ProgressEntryRecorded, StreakAchieved (on milestone)
-    Note over L: AFTER_COMMIT — nothing fires if the transaction rolls back
-    L->>DB: INSERT notification
-    L->>W: push
-    W-->>B: STOMP frame on /user/queue/notifications
-    C-->>B: 201 with the stored entry
-```
+> **Diagram:** [Request lifecycle](arch-diagrams/README.md#6-request-lifecycle) —
+> logging progress, from the browser through to the pushed notification.
 
 Three things in that flow are easy to miss:
 
@@ -229,21 +161,8 @@ every tracking configuration rather than one per upgrade.
 A `HealthUpgrade` is created as an `IDEA` and moves only through methods on the aggregate, each of
 which guards its transition:
 
-```mermaid
-stateDiagram-v2
-    [*] --> IDEA: create
-    IDEA --> PLANNED: plan
-    PLANNED --> ACTIVE: activate
-    ACTIVE --> PAUSED: pause
-    PAUSED --> ACTIVE: activate
-    ACTIVE --> COMPLETED: complete
-    IDEA --> ABANDONED: abandon
-    PLANNED --> ABANDONED: abandon
-    ACTIVE --> ABANDONED: abandon
-    PAUSED --> ABANDONED: abandon
-    ABANDONED --> PLANNED: reschedule
-    COMPLETED --> [*]
-```
+> **Diagram:** [The upgrade lifecycle](arch-diagrams/README.md#5-the-upgrade-lifecycle) —
+> every legal transition of the aggregate's state machine.
 
 `COMPLETED` is terminal. `ABANDONED` is not — rescheduling revives it. An upgrade occupies one of the
 three concurrent HARD slots only while `ACTIVE`, which is why the limit is checked both when activating
@@ -354,6 +273,7 @@ Stated because they are load-bearing, not because they are problems yet:
 
 | Question | Record |
 |---|---|
+| What does all of this look like? | [`arch-diagrams/`](arch-diagrams/README.md) — seven diagrams, outside in |
 | What is the system supposed to do, and what is it deliberately not doing? | [`docs/requirements/requirements.md`](../requirements/requirements.md) |
 | Why DDD + hexagonal at all, and why JPA entities as the domain model? | [ADR-001](../ADRs/ADR-001-ddd-hexagonal-architecture.md) |
 | Why the `upgrade`/`tracking` dependency is inverted; why events moved out of `common`; what the ten ArchUnit rules cover; what was rejected and when to revisit | [ADR-002](../ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md) |

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -99,6 +99,10 @@ nothing is shared between accounts.
 | FR-35 | A user who is following the operating system sees the interface change when that preference changes, without reloading | `ThemeProvider`, `ThemeProvider.test.tsx` |
 | FR-36 | A user's explicit choice overrides the operating system's preference until they change it | `ThemeProvider`, `ThemeProvider.test.tsx` |
 | FR-37 | The theme control is reachable before signing in | `LoginPage`, `RegisterPage` |
+| FR-38 | A page's content grows with the browser window, up to one cap chosen for readability | `PageContainer`, `PageContainer.test.tsx` |
+| FR-39 | A dialog fits the window at any size: its heading stays put and only its body scrolls | `Modal` — checked by hand, see §6 |
+| FR-40 | A dialog announces itself as a dialog named by its title | `Modal`, `Modal.test.tsx` |
+| FR-41 | A health area whose stored icon is not a glyph is shown with the default icon | `areaIconGlyph`, `areaIcon.test.ts` |
 
 ---
 
@@ -147,6 +151,7 @@ nothing is shared between accounts.
 | NFR-17 | The interface remains usable where browser storage is blocked or `matchMedia` is unavailable | `ThemeProvider`, `ThemeProvider.test.tsx` |
 | NFR-18 | Every colour in the interface is a semantic token, so no component can hard-code one that survives a theme change | `frontend/scripts/check-colours.mjs`, `.github/workflows/ci.yml` |
 | NFR-19 | Text meets a 4.5:1 contrast ratio and control boundaries 3:1, in both themes | the token values in `frontend/src/index.css` — computed, not automatically re-checked; see §6 |
+| NFR-20 | The interface does not scroll horizontally at any window width, whatever a user has stored in it | the shell's `min-w-0` floor and the truncation rules on every user-supplied string ([ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)) — checked by hand, see §6 |
 
 ---
 
@@ -174,7 +179,12 @@ Undecided, and owned by the repository owner.
 - **The frontend has no accessibility or visual-regression gate.** Contrast ratios in the theme were
   computed by hand; nothing re-checks them when a colour changes, and jsdom cannot — it has no layout
   engine. Closing this needs a real browser in CI; [ADR-004](../ADRs/ADR-004-frontend-test-harness.md)
-  records why that was deferred.
+  records why that was deferred. FR-39 and NFR-20 land in exactly this gap: no test in the suite can
+  observe a width, a wrap or an overflow, so both were verified by hand and neither is enforced.
+- **A dialog claims `aria-modal` but does not trap focus.** Tab still walks out of the dialog into the
+  page behind it, and focus is neither moved into the dialog on open nor restored on close. Closing this
+  properly means a native `<dialog>` with `showModal()`; [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)
+  records why that was not done here.
 - **The backend has no dependency vulnerability audit.** OWASP dependency-check needs an `NVD_API_KEY`
   secret; ADR-002 records why a check that cannot fail was judged worse than none.
 - **An unbindable request body returns 500 rather than 400** — tracked as

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -102,7 +102,7 @@ nothing is shared between accounts.
 | FR-38 | A page's content grows with the browser window, up to one cap chosen for readability | `PageContainer`, `PageContainer.test.tsx` |
 | FR-39 | A dialog fits the window at any size: its heading stays put and only its body scrolls | `Modal` — checked by hand, see §6 |
 | FR-40 | A dialog announces itself as a dialog named by its title | `Modal`, `Modal.test.tsx` |
-| FR-41 | A health area whose stored icon is not a glyph is shown with the default icon | `areaIconGlyph`, `areaIcon.test.ts` |
+| FR-41 | A health area whose stored icon cannot be drawn is shown with the default icon, and editing it does not write the undrawable value back | `areaIconGlyph`, `isIconGlyph`, `areaIcon.test.ts` |
 
 ---
 
@@ -151,7 +151,7 @@ nothing is shared between accounts.
 | NFR-17 | The interface remains usable where browser storage is blocked or `matchMedia` is unavailable | `ThemeProvider`, `ThemeProvider.test.tsx` |
 | NFR-18 | Every colour in the interface is a semantic token, so no component can hard-code one that survives a theme change | `frontend/scripts/check-colours.mjs`, `.github/workflows/ci.yml` |
 | NFR-19 | Text meets a 4.5:1 contrast ratio and control boundaries 3:1, in both themes | the token values in `frontend/src/index.css` — computed, not automatically re-checked; see §6 |
-| NFR-20 | The interface does not scroll horizontally at any window width, whatever a user has stored in it | the shell's `min-w-0` floor and the truncation rules on every user-supplied string ([ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)) — checked by hand, see §6 |
+| NFR-20 | The interface does not scroll horizontally at any window width from 320px upward, whatever a user has stored in it | the shell's `min-w-0` floors and the truncation rules on every user-supplied string ([ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)) — checked by hand at 320, 360, 486, 684, 1040 and 1540px, see §6 |
 
 ---
 
@@ -181,8 +181,9 @@ Undecided, and owned by the repository owner.
   engine. Closing this needs a real browser in CI; [ADR-004](../ADRs/ADR-004-frontend-test-harness.md)
   records why that was deferred. FR-39 and NFR-20 land in exactly this gap: no test in the suite can
   observe a width, a wrap or an overflow, so both were verified by hand and neither is enforced.
-- **A dialog claims `aria-modal` but does not trap focus.** Tab still walks out of the dialog into the
-  page behind it, and focus is neither moved into the dialog on open nor restored on close. Closing this
+- **A dialog does not trap focus.** Tab walks out of the dialog into the page behind it, and focus is
+  neither moved into the dialog on open nor restored on close. `aria-modal` is deliberately left off
+  until that is true, because claiming it without a trap is worse than not claiming it. Closing this
   properly means a native `<dialog>` with `showModal()`; [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)
   records why that was not done here.
 - **The backend has no dependency vulnerability audit.** OWASP dependency-check needs an `NVD_API_KEY`

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -91,6 +91,15 @@ nothing is shared between accounts.
 | FR-32 | Notifications arrive in real time on a connected client, and are readable afterwards regardless | `StompNotificationPushAdapter`, `NotificationService` |
 | FR-33 | A user can read their fifty most recent notifications, see an unread count, and mark one or all as read | `NotificationService` |
 
+### 2.7 Appearance
+
+| ID | Requirement | Enforced by |
+|---|---|---|
+| FR-34 | A user can set the interface to a light theme, a dark theme, or to follow the operating system | `ThemeToggle`, `ThemeToggle.test.tsx` |
+| FR-35 | A user who is following the operating system sees the interface change when that preference changes, without reloading | `ThemeProvider`, `ThemeProvider.test.tsx` |
+| FR-36 | A user's explicit choice overrides the operating system's preference until they change it | `ThemeProvider`, `ThemeProvider.test.tsx` |
+| FR-37 | The theme control is reachable before signing in | `LoginPage`, `RegisterPage` |
+
 ---
 
 ## 3. Business rules and invariants
@@ -134,6 +143,10 @@ nothing is shared between accounts.
 | NFR-13 | The whole stack starts with one command | `docker-compose up --build` |
 | NFR-14 | List endpoints resolve related data in batch rather than per row | `UpgradeWebMapper.toDtos`, `TrackingConfigQuery.findByUpgradeIds` |
 | NFR-15 | Time-dependent behaviour reads an injected clock, so it is testable and timezone-explicit | `Clock` bean, scheduler tests |
+| NFR-16 | A user's theme choice survives a reload and is applied before the first paint, so the page never flashes the wrong theme | the boot script in `frontend/index.html`, `ThemeProvider` |
+| NFR-17 | The interface remains usable where browser storage is blocked or `matchMedia` is unavailable | `ThemeProvider`, `ThemeProvider.test.tsx` |
+| NFR-18 | Every colour in the interface is a semantic token, so no component can hard-code one that survives a theme change | `frontend/scripts/check-colours.mjs`, `.github/workflows/ci.yml` |
+| NFR-19 | Text meets a 4.5:1 contrast ratio and control boundaries 3:1, in both themes | the token values in `frontend/src/index.css` — computed, not automatically re-checked; see §6 |
 
 ---
 

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -158,9 +158,10 @@ These are deliberate. Re-proposing one needs a reason that has changed.
 
 Undecided, and owned by the repository owner.
 
-- **The frontend has no test runner.** No vitest, no jest. Frontend logic is currently verified only by
-  the type checker, the linter and inspection. Introducing one is a dependency decision that deserves
-  an ADR.
+- **The frontend has no accessibility or visual-regression gate.** Contrast ratios in the theme were
+  computed by hand; nothing re-checks them when a colour changes, and jsdom cannot — it has no layout
+  engine. Closing this needs a real browser in CI; [ADR-004](../ADRs/ADR-004-frontend-test-harness.md)
+  records why that was deferred.
 - **The backend has no dependency vulnerability audit.** OWASP dependency-check needs an `NVD_API_KEY`
   secret; ADR-002 records why a check that cannot fail was judged worse than none.
 - **An unbindable request body returns 500 rather than 400** — tracked as

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -27,11 +27,16 @@ conventions to follow inside `frontend/`.
   `text-fg-subtle`, not `text-gray-500`. The tokens are declared in `tailwind.config.js` and given
   their light and dark values in `src/index.css`. `npm run check:colours` fails on any direct palette
   use and runs in CI — Tailwind itself emits nothing and reports nothing for an unrecognised class, so
-  a mistyped token renders as *no colour at all* rather than as an error.
+  a mistyped token renders as *no colour at all* rather than as an error. It covers everything in
+  Tailwind's `content` glob, `index.html` included, and matches named utilities only: an arbitrary
+  value like `bg-[#fff]` slips past it.
   - Adding a colour means adding a **role**, with both values, not reaching for a shade. If no existing
     role fits, the role is what is missing.
   - Check contrast when you add one: 4.5:1 for text, 3:1 for control boundaries, in both themes.
     Nothing re-checks this automatically.
   - The `dark` class on `<html>` is set by the inline boot script in `index.html` *and* by
     `ThemeProvider`. They must agree on the storage key (`theme`) and the resolution rule; changing one
-    alone brings back the flash of wrong theme on load.
+    alone brings back the flash of wrong theme on load. `src/contexts/bootScript.test.tsx` enforces
+    that agreement — it runs the shipped script verbatim and compares it against the provider across
+    every combination of stored choice and system preference, so drift fails the build instead of
+    shipping. Change the rule in both places, and the test will tell you if you missed one.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -16,5 +16,22 @@ conventions to follow inside `frontend/`.
   local React state.
 - **Auth** flows through `contexts/AuthContext.tsx` (the context object lives in `contexts/authContextValue.ts`)
   + `hooks/useAuth.ts`; routes are gated by `router/ProtectedRoute.tsx`. Routing is React Router 6.
+- **Theme** flows through `contexts/ThemeProvider.tsx` (context object in `contexts/themeContextValue.ts`)
+  + `hooks/useTheme.ts`, mounted outermost in `App.tsx` so the auth pages get it too. That split of the
+  `createContext` call into its own module is not stylistic: `react-refresh/only-export-components`
+  warns when a `.tsx` file exports a non-component value, and `npm run lint` runs `--max-warnings 0` in
+  CI. Follow it for any new context.
 - Shared TypeScript types (mirroring backend DTOs/enums, e.g. `UpgradeStatus`) live in `src/types/index.ts`.
 - Styling is Tailwind CSS; reusable primitives are in `src/components/ui/`.
+- **Colours are semantic tokens, never palette shades.** Write `bg-surface`, not `bg-white`;
+  `text-fg-subtle`, not `text-gray-500`. The tokens are declared in `tailwind.config.js` and given
+  their light and dark values in `src/index.css`. `npm run check:colours` fails on any direct palette
+  use and runs in CI — Tailwind itself emits nothing and reports nothing for an unrecognised class, so
+  a mistyped token renders as *no colour at all* rather than as an error.
+  - Adding a colour means adding a **role**, with both values, not reaching for a shade. If no existing
+    role fits, the role is what is missing.
+  - Check contrast when you add one: 4.5:1 for text, 3:1 for control boundaries, in both themes.
+    Nothing re-checks this automatically.
+  - The `dark` class on `<html>` is set by the inline boot script in `index.html` *and* by
+    `ThemeProvider`. They must agree on the storage key (`theme`) and the resolution rule; changing one
+    alone brings back the flash of wrong theme on load.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,31 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UpHealther</title>
+    <!--
+      Applies the saved theme before the first paint.
+
+      Deliberately a classic (non-module) inline script: Vite leaves it alone and the browser runs it
+      synchronously while parsing the head, so the `dark` class is on <html> before any pixel is drawn.
+      A type="module" script would be bundled and deferred until after parsing, and the page would
+      flash light before React could correct it.
+
+      Kept in step with ThemeProvider: same storage key, same three states, same resolution rule.
+    -->
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('theme');
+          var dark =
+            stored === 'dark' ||
+            (stored !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          document.documentElement.classList.toggle('dark', dark);
+        } catch (e) {
+          // Reading localStorage throws outright where storage is blocked, and matchMedia is absent in
+          // a few embedded webviews. Either way the page boots light and ThemeProvider applies the
+          // system preference on mount, one frame later — a flash, not a failure.
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,7 @@
         "eslint": "^8.55.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
-        "jsdom": "^30.0.1",
+        "jsdom": "^29.1.1",
         "postcss": "^8.4.32",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.2.2",
@@ -49,57 +49,55 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
-      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.3.0",
-        "@csstools/css-color-parser": "^4.1.10",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.5.2"
+        "@csstools/css-tokenizer": "^4.0.0"
       },
       "engines": {
-        "node": "^22.13.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
-      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.5.2"
+        "is-potential-custom-element-name": "^1.0.1"
       },
       "engines": {
-        "node": "^22.13.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -2720,21 +2718,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3834,39 +3817,39 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
-      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^6.0.5",
-        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
-        "@exodus/bytes": "^1.15.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.5.2",
+        "lru-cache": "^11.3.5",
         "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.2",
-        "undici": "^8.9.0",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^17.1.0",
+        "whatwg-url": "^16.0.1",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "canvas": "^3.2.3"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -5353,13 +5336,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=22.19.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -5613,18 +5596,18 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
-      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.15.1",
+        "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
         "webidl-conversions": "^8.0.1"
       },
       "engines": {
-        "node": "^22.14.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,8 @@
         "react-router-dom": "^6.22.0"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -25,10 +27,12 @@
         "eslint": "^8.55.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
+        "jsdom": "^30.0.1",
         "postcss": "^8.4.32",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.2.2",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0",
+        "vitest": "^3.2.7"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -42,6 +46,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -298,6 +355,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -344,6 +411,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -822,6 +1042,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1411,6 +1649,61 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1455,6 +1748,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1731,6 +2042,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1844,6 +2270,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1852,6 +2288,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -1929,6 +2375,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1999,6 +2455,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2053,6 +2519,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2068,6 +2551,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2179,6 +2672,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2199,6 +2706,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2216,6 +2752,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2230,6 +2783,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/didyoumean": {
@@ -2272,6 +2835,13 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2293,6 +2863,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2310,6 +2893,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -2588,6 +3178,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2596,6 +3196,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3016,6 +3626,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -3157,6 +3780,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3201,6 +3831,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3329,6 +4010,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3339,6 +4027,26 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3347,6 +4055,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3563,6 +4278,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3608,6 +4336,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3823,6 +4568,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -3888,6 +4661,13 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3951,6 +4731,16 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -4082,6 +4872,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -4127,6 +4930,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4146,6 +4956,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -4172,6 +4996,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -4221,6 +5065,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -4290,6 +5141,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -4338,6 +5203,56 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4349,6 +5264,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4409,6 +5350,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4519,6 +5470,163 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4533,6 +5641,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -4551,6 +5676,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "eslint": "^8.55.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "jsdom": "^30.0.1",
+    "jsdom": "^29.1.1",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,17 +6,21 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
+    "@stomp/stompjs": "^7.0.0",
+    "@tanstack/react-query": "^5.17.0",
+    "axios": "^1.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.0",
-    "@tanstack/react-query": "^5.17.0",
-    "@stomp/stompjs": "^7.0.0",
-    "axios": "^1.6.0"
+    "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
@@ -26,9 +30,11 @@
     "eslint": "^8.55.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "jsdom": "^30.0.1",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^3.2.7"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "check:colours": "node scripts/check-colours.mjs"
   },
   "dependencies": {
     "@stomp/stompjs": "^7.0.0",

--- a/frontend/scripts/check-colours.mjs
+++ b/frontend/scripts/check-colours.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Fails if any Tailwind palette colour is used directly in `src/`.
+ *
+ * Tailwind fails silently: `bg-surfce` emits no CSS and raises no error, so the element renders with no
+ * background at all — which on a dark canvas reads as a deliberate transparent panel rather than a
+ * mistake. There is no compiler for class names. This is the substitute.
+ *
+ * It catches the opposite mistake too: a literal `bg-white` reintroduced by a copy-paste would render
+ * correctly in light and be invisible against dark text. Colours belong in `src/index.css`, once per
+ * theme, and are reached through the semantic tokens declared in `tailwind.config.js`.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC = join(fileURLToPath(new URL('.', import.meta.url)), '..', 'src');
+
+const PALETTE = [
+  'slate', 'gray', 'zinc', 'neutral', 'stone', 'red', 'orange', 'amber', 'yellow', 'lime', 'green',
+  'emerald', 'teal', 'cyan', 'sky', 'blue', 'indigo', 'violet', 'purple', 'fuchsia', 'pink', 'rose',
+].join('|');
+
+/**
+ * Utility prefixes that take a colour, including the side-suffixed border forms.
+ *
+ * `border-t-blue-600` is in here deliberately: `LoadingSpinner` used exactly that shape, and a pattern
+ * anchored on `border-blue-600` walks straight past it.
+ */
+const PREFIX = '(?:bg|text|border|ring|ring-offset|divide|placeholder|from|via|to|decoration|outline|accent|caret|shadow|fill|stroke)(?:-[trblxyse])?';
+
+const NUMBERED = new RegExp(`\\b${PREFIX}-(?:${PALETTE})-\\d{2,3}\\b`, 'g');
+const NAMED = new RegExp(`\\b${PREFIX}-(?:white|black)\\b`, 'g');
+
+/** Every `.ts`/`.tsx` file under `src/`, depth-first. */
+const sourceFiles = (dir) =>
+  readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) return sourceFiles(path);
+    return /\.tsx?$/.test(path) ? [path] : [];
+  });
+
+const findings = sourceFiles(SRC).flatMap((path) =>
+  readFileSync(path, 'utf8')
+    .split('\n')
+    .flatMap((line, index) => {
+      const hits = [...line.matchAll(NUMBERED), ...line.matchAll(NAMED)].map((m) => m[0]);
+      return hits.length ? [`${relative(SRC, path)}:${index + 1}  ${[...new Set(hits)].join(', ')}`] : [];
+    }),
+);
+
+if (findings.length > 0) {
+  console.error('Palette colours used directly. Use a semantic token from tailwind.config.js instead:\n');
+  findings.forEach((f) => console.error(`  ${f}`));
+  console.error(`\n${findings.length} line(s).`);
+  process.exit(1);
+}
+
+console.log(`No palette colours in src/ — all ${sourceFiles(SRC).length} source files use tokens.`);

--- a/frontend/scripts/check-colours.mjs
+++ b/frontend/scripts/check-colours.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Fails if any Tailwind palette colour is used directly in `src/`.
+ * Fails if any Tailwind palette colour is used directly in the files Tailwind compiles.
  *
  * Tailwind fails silently: `bg-surfce` emits no CSS and raises no error, so the element renders with no
  * background at all — which on a dark canvas reads as a deliberate transparent panel rather than a
@@ -9,12 +9,22 @@
  * It catches the opposite mistake too: a literal `bg-white` reintroduced by a copy-paste would render
  * correctly in light and be invisible against dark text. Colours belong in `src/index.css`, once per
  * theme, and are reached through the semantic tokens declared in `tailwind.config.js`.
+ *
+ * Scope follows the `content` glob in `tailwind.config.js`, which is `index.html` as well as `src/`.
+ * A palette class in the HTML shell compiles exactly like one in a component, so checking only `src/`
+ * would leave a hole in the one guard that exists to have none.
+ *
+ * Known boundary: this matches named utilities, so arbitrary values (`bg-[#fff]`, `text-[rgb(0,0,0)]`)
+ * pass through. Nothing in the app uses that form, and a regex over arbitrary CSS would cost more in
+ * false positives than it buys.
  */
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const SRC = join(fileURLToPath(new URL('.', import.meta.url)), '..', 'src');
+const FRONTEND = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+const SRC = join(FRONTEND, 'src');
+const HTML_SHELL = join(FRONTEND, 'index.html');
 
 const PALETTE = [
   'slate', 'gray', 'zinc', 'neutral', 'stone', 'red', 'orange', 'amber', 'yellow', 'lime', 'green',
@@ -40,12 +50,17 @@ const sourceFiles = (dir) =>
     return /\.tsx?$/.test(path) ? [path] : [];
   });
 
-const findings = sourceFiles(SRC).flatMap((path) =>
+/** Everything Tailwind compiles class names out of: the HTML shell plus the component tree. */
+const compiledFiles = () => [HTML_SHELL, ...sourceFiles(SRC)];
+
+const findings = compiledFiles().flatMap((path) =>
   readFileSync(path, 'utf8')
     .split('\n')
     .flatMap((line, index) => {
       const hits = [...line.matchAll(NUMBERED), ...line.matchAll(NAMED)].map((m) => m[0]);
-      return hits.length ? [`${relative(SRC, path)}:${index + 1}  ${[...new Set(hits)].join(', ')}`] : [];
+      return hits.length
+        ? [`${relative(FRONTEND, path)}:${index + 1}  ${[...new Set(hits)].join(', ')}`]
+        : [];
     }),
 );
 
@@ -56,4 +71,4 @@ if (findings.length > 0) {
   process.exit(1);
 }
 
-console.log(`No palette colours in src/ — all ${sourceFiles(SRC).length} source files use tokens.`);
+console.log(`No palette colours — all ${compiledFiles().length} compiled files use tokens.`);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
+import { ThemeProvider } from './contexts/ThemeProvider';
 import AppRouter from './router';
 
 /**
@@ -20,17 +21,21 @@ const queryClient = new QueryClient({
 });
 
 /**
- * Application root: installs the query cache and the auth provider around the router.
+ * Application root: installs the theme, the query cache and the auth provider around the router.
  *
- * The order matters — auth reads through the query client, and everything the router renders needs
- * both.
+ * The order matters. Auth reads through the query client, and everything the router renders needs
+ * both. The theme sits outside them all because it depends on neither a session nor server state, and
+ * because the login and register pages render outside `Layout` but still inside `App` — which is what
+ * puts the theme toggle within reach before anyone has signed in.
  */
 const App: React.FC = () => (
-  <QueryClientProvider client={queryClient}>
-    <AuthProvider>
-      <AppRouter />
-    </AuthProvider>
-  </QueryClientProvider>
+  <ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <AppRouter />
+      </AuthProvider>
+    </QueryClientProvider>
+  </ThemeProvider>
 );
 
 export default App;

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -13,7 +13,7 @@ interface LayoutProps {
  * Applied by the router rather than by each page, so no authenticated page can be added without it.
  */
 const Layout: React.FC<LayoutProps> = ({ children }) => (
-  <div className="min-h-screen bg-gray-50 flex flex-col">
+  <div className="min-h-screen bg-canvas flex flex-col">
     <Navbar />
     <div className="flex flex-1">
       <Sidebar />

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -8,16 +8,29 @@ interface LayoutProps {
 }
 
 /**
- * The frame every signed-in page renders inside: fixed navbar, sidebar, and a scrolling content area.
+ * The frame every signed-in page renders inside: a sticky navbar, the sidebar rail, and the content
+ * area. Applied by the router rather than by each page, so no authenticated page can be added without
+ * it. How wide the page inside it may grow is decided by `PageContainer`, not here.
  *
- * Applied by the router rather than by each page, so no authenticated page can be added without it.
+ * `min-w-0` on the content column is load-bearing. A flex item's `min-width` defaults to `auto`, which
+ * resolves to its *min-content* width, so one child that cannot shrink — a long unbroken string, a wide
+ * table — overrules `flex-shrink` and drags the column past the viewport. `min-w-0` replaces that floor
+ * with zero and gives the shrinking back; the child then has to resolve the pressure itself, which is
+ * what the `truncate` and `break-words` rules further down the tree are for.
+ *
+ * It replaces an `overflow-auto` that was doing the same job by accident: a flex item whose overflow is
+ * not `visible` already has an automatic minimum size of zero. That was worth stating outright rather
+ * than leaving as a side effect — and it made `<main>` a scroll container, which would clip any sticky
+ * or overflowing child added inside it later. The cost is that a genuinely unshrinkable future child
+ * now overflows visibly instead of scrolling inside `<main>`; that is the better failure, and the fix
+ * then belongs on that child's own wrapper.
  */
 const Layout: React.FC<LayoutProps> = ({ children }) => (
   <div className="min-h-screen bg-canvas flex flex-col">
     <Navbar />
     <div className="flex flex-1">
       <Sidebar />
-      <main className="flex-1 p-6 overflow-auto">{children}</main>
+      <main className="flex-1 min-w-0 p-4 sm:p-6">{children}</main>
     </div>
   </div>
 );

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -9,15 +9,15 @@ const Navbar: React.FC = () => {
   const { user, logout } = useAuth();
 
   return (
-    <nav className="bg-white border-b border-gray-200 h-16 flex items-center px-6 justify-between sticky top-0 z-30">
+    <nav className="bg-surface border-b border-line h-16 flex items-center px-6 justify-between sticky top-0 z-30">
       <Link to="/dashboard" className="flex items-center gap-2">
         <span className="text-2xl">💪</span>
-        <span className="font-bold text-gray-900 text-lg">UpHealther</span>
+        <span className="font-bold text-fg text-lg">UpHealther</span>
       </Link>
       <div className="flex items-center gap-3">
         <NotificationBell />
         {user && (
-          <span className="text-sm text-gray-600 hidden sm:block">
+          <span className="text-sm text-fg-subtle hidden sm:block">
             Hi, <span className="font-medium">{user.name}</span>
           </span>
         )}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -3,8 +3,9 @@ import { Link } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
 import Button from '../ui/Button';
 import NotificationBell from '../notifications/NotificationBell';
+import ThemeToggle from '../theme/ThemeToggle';
 
-/** Top bar: brand link home, the notification bell, the signed-in user's name, and logout. */
+/** Top bar: brand link home, the theme toggle, the notification bell, the signed-in user's name, and logout. */
 const Navbar: React.FC = () => {
   const { user, logout } = useAuth();
 
@@ -15,6 +16,7 @@ const Navbar: React.FC = () => {
         <span className="font-bold text-fg text-lg">UpHealther</span>
       </Link>
       <div className="flex items-center gap-3">
+        <ThemeToggle />
         <NotificationBell />
         {user && (
           <span className="text-sm text-fg-subtle hidden sm:block">

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -10,20 +10,20 @@ const Navbar: React.FC = () => {
   const { user, logout } = useAuth();
 
   return (
-    <nav className="bg-surface border-b border-line h-16 flex items-center px-6 justify-between sticky top-0 z-30">
-      <Link to="/dashboard" className="flex items-center gap-2">
+    <nav className="bg-surface border-b border-line h-16 flex items-center gap-4 px-4 sm:px-6 justify-between sticky top-0 z-30">
+      <Link to="/dashboard" className="flex items-center gap-2 shrink-0">
         <span className="text-2xl">💪</span>
         <span className="font-bold text-fg text-lg">UpHealther</span>
       </Link>
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2 sm:gap-3 min-w-0">
         <ThemeToggle />
         <NotificationBell />
         {user && (
-          <span className="text-sm text-fg-subtle hidden sm:block">
+          <span className="text-sm text-fg-subtle hidden sm:block min-w-0 truncate">
             Hi, <span className="font-medium">{user.name}</span>
           </span>
         )}
-        <Button variant="ghost" size="sm" onClick={logout}>
+        <Button variant="ghost" size="sm" onClick={logout} className="shrink-0">
           Logout
         </Button>
       </div>

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -11,15 +11,15 @@ const Navbar: React.FC = () => {
 
   return (
     <nav className="bg-surface border-b border-line h-16 flex items-center gap-4 px-4 sm:px-6 justify-between sticky top-0 z-30">
-      <Link to="/dashboard" className="flex items-center gap-2 shrink-0">
-        <span className="text-2xl">💪</span>
-        <span className="font-bold text-fg text-lg">UpHealther</span>
+      <Link to="/dashboard" className="flex items-center gap-2 min-w-0">
+        <span className="text-2xl shrink-0" aria-hidden="true">💪</span>
+        <span className="font-bold text-fg text-lg truncate">UpHealther</span>
       </Link>
-      <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+      <div className="flex items-center gap-2 sm:gap-3 shrink-0">
         <ThemeToggle />
         <NotificationBell />
         {user && (
-          <span className="text-sm text-fg-subtle hidden sm:block min-w-0 truncate">
+          <span className="text-sm text-fg-subtle hidden sm:block max-w-[12rem] truncate">
             Hi, <span className="font-medium">{user.name}</span>
           </span>
         )}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -32,7 +32,7 @@ const navItems: NavItem[] = [
  * reachable from the dashboard.
  */
 const Sidebar: React.FC = () => (
-  <aside className="w-60 bg-gray-50 border-r border-gray-200 min-h-full flex-shrink-0 hidden md:block">
+  <aside className="w-60 bg-surface border-r border-line min-h-full flex-shrink-0 hidden md:block">
     <nav className="py-4">
       {navItems.map((item) => (
         <NavLink
@@ -41,8 +41,8 @@ const Sidebar: React.FC = () => (
           className={({ isActive }) =>
             `flex items-center gap-3 px-4 py-2.5 text-sm font-medium transition-colors ${
               isActive
-                ? 'bg-blue-50 text-blue-700 border-r-2 border-blue-600'
-                : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                ? 'bg-brand-soft text-brand-fg border-r-2 border-brand'
+                : 'text-fg-subtle hover:bg-muted hover:text-fg'
             }`
           }
         >

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -26,7 +26,7 @@ const NotificationBell: React.FC = () => {
   }, [open]);
 
   return (
-    <div className="relative" ref={containerRef}>
+    <div className="relative shrink-0" ref={containerRef}>
       <button
         onClick={() => setOpen((o) => !o)}
         className="relative w-9 h-9 flex items-center justify-center rounded-full hover:bg-muted transition-colors"

--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -29,12 +29,12 @@ const NotificationBell: React.FC = () => {
     <div className="relative" ref={containerRef}>
       <button
         onClick={() => setOpen((o) => !o)}
-        className="relative w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors"
+        className="relative w-9 h-9 flex items-center justify-center rounded-full hover:bg-muted transition-colors"
         aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
       >
         <span className="text-xl">🔔</span>
         {unreadCount > 0 && (
-          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center rounded-full bg-red-500 text-white text-[10px] font-bold">
+          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center rounded-full bg-danger text-fg-inverted text-[10px] font-bold">
             {unreadCount > 9 ? '9+' : unreadCount}
           </span>
         )}

--- a/frontend/src/components/notifications/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown.tsx
@@ -29,13 +29,13 @@ const NotificationDropdown: React.FC<Props> = ({ onClose }) => {
   };
 
   return (
-    <div className="absolute right-0 mt-2 w-80 max-w-[calc(100vw-2rem)] bg-white rounded-xl border border-gray-200 shadow-xl z-50 overflow-hidden">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
-        <span className="font-semibold text-gray-800 text-sm">
-          Notifications{unreadCount > 0 && <span className="text-blue-600"> ({unreadCount})</span>}
+    <div className="absolute right-0 mt-2 w-80 max-w-[calc(100vw-2rem)] bg-surface rounded-xl border border-line shadow-xl z-50 overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-line-subtle">
+        <span className="font-semibold text-fg-muted text-sm">
+          Notifications{unreadCount > 0 && <span className="text-brand-fg"> ({unreadCount})</span>}
         </span>
         {unreadCount > 0 && (
-          <button onClick={markAllRead} className="text-xs text-blue-600 hover:underline">
+          <button onClick={markAllRead} className="text-xs text-brand-fg hover:underline">
             Mark all read
           </button>
         )}
@@ -44,15 +44,15 @@ const NotificationDropdown: React.FC<Props> = ({ onClose }) => {
       {desktopPermission === 'default' && (
         <button
           onClick={requestDesktopPermission}
-          className="w-full text-left px-4 py-2 text-xs text-blue-700 bg-blue-50 hover:bg-blue-100 border-b border-gray-100"
+          className="w-full text-left px-4 py-2 text-xs text-brand-fg bg-brand-soft hover:bg-brand-soft-hover border-b border-line-subtle"
         >
           🔔 Enable desktop notifications
         </button>
       )}
 
-      <div className="max-h-96 overflow-y-auto divide-y divide-gray-100">
+      <div className="max-h-96 overflow-y-auto divide-y divide-line-subtle">
         {recent.length === 0 ? (
-          <p className="text-sm text-gray-500 text-center py-8">No notifications yet.</p>
+          <p className="text-sm text-fg-subtle text-center py-8">No notifications yet.</p>
         ) : (
           recent.map((n) => <NotificationItem key={n.id} notification={n} onSelect={select} />)
         )}
@@ -60,7 +60,7 @@ const NotificationDropdown: React.FC<Props> = ({ onClose }) => {
 
       <button
         onClick={() => { onClose(); navigate('/notifications'); }}
-        className="w-full text-center px-4 py-2.5 text-sm font-medium text-blue-600 hover:bg-gray-50 border-t border-gray-100"
+        className="w-full text-center px-4 py-2.5 text-sm font-medium text-brand-fg hover:bg-sunken border-t border-line-subtle"
       >
         View all notifications
       </button>

--- a/frontend/src/components/notifications/NotificationItem.tsx
+++ b/frontend/src/components/notifications/NotificationItem.tsx
@@ -23,16 +23,16 @@ const NotificationItem: React.FC<Props> = ({ notification, onSelect }) => {
   return (
     <button
       onClick={() => onSelect(notification)}
-      className={`w-full text-left flex gap-3 p-3 transition-colors hover:bg-gray-50 ${notification.read ? '' : 'bg-blue-50/50'}`}
+      className={`w-full text-left flex gap-3 p-3 transition-colors hover:bg-sunken ${notification.read ? '' : 'bg-brand-soft/50'}`}
     >
       <span className="text-lg leading-none mt-0.5">{meta.icon}</span>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <p className="text-sm font-medium text-gray-900 truncate">{notification.title}</p>
-          {!notification.read && <span className="w-2 h-2 rounded-full bg-blue-500 shrink-0" aria-label="unread" />}
+          <p className="text-sm font-medium text-fg truncate">{notification.title}</p>
+          {!notification.read && <span className="w-2 h-2 rounded-full bg-brand shrink-0" aria-label="unread" />}
         </div>
-        {notification.message && <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">{notification.message}</p>}
-        <p className="text-[11px] text-gray-400 mt-1">{relativeTime(notification.createdAt)}</p>
+        {notification.message && <p className="text-xs text-fg-subtle mt-0.5 line-clamp-2">{notification.message}</p>}
+        <p className="text-[11px] text-fg-faint mt-1">{relativeTime(notification.createdAt)}</p>
       </div>
     </button>
   );

--- a/frontend/src/components/notifications/ToastContainer.tsx
+++ b/frontend/src/components/notifications/ToastContainer.tsx
@@ -43,7 +43,7 @@ const ToastContainer: React.FC<Props> = ({ toasts, onDismiss }) => {
             key={t.id}
             role="status"
             aria-live="polite"
-            className={`${meta.bg} ${meta.ring} border rounded-xl shadow-lg p-3 flex items-start gap-2 animate-fade-in`}
+            className={`${meta.bg} ${meta.border} border rounded-xl shadow-lg p-3 flex items-start gap-2 animate-fade-in`}
           >
             <button
               type="button"
@@ -56,13 +56,13 @@ const ToastContainer: React.FC<Props> = ({ toasts, onDismiss }) => {
               <span className="text-lg leading-none mt-0.5">{meta.icon}</span>
               <span className="flex-1 min-w-0">
                 <span className={`block text-sm font-semibold ${meta.text} truncate`}>{t.title}</span>
-                {t.message && <span className="block text-xs text-gray-600 mt-0.5 line-clamp-2">{t.message}</span>}
+                {t.message && <span className="block text-xs text-fg-subtle mt-0.5 line-clamp-2">{t.message}</span>}
               </span>
             </button>
             <button
               type="button"
               onClick={() => onDismiss(t.id)}
-              className="text-gray-400 hover:text-gray-600 text-lg leading-none shrink-0"
+              className="text-fg-faint hover:text-fg-subtle text-lg leading-none shrink-0"
               aria-label="Dismiss notification"
             >
               &times;

--- a/frontend/src/components/notifications/ToastContainer.tsx
+++ b/frontend/src/components/notifications/ToastContainer.tsx
@@ -43,7 +43,7 @@ const ToastContainer: React.FC<Props> = ({ toasts, onDismiss }) => {
             key={t.id}
             role="status"
             aria-live="polite"
-            className={`${meta.bg} ${meta.ring} border rounded-xl shadow-lg p-3 flex items-start gap-2 animate-[fadeIn_0.2s_ease-out]`}
+            className={`${meta.bg} ${meta.ring} border rounded-xl shadow-lg p-3 flex items-start gap-2 animate-fade-in`}
           >
             <button
               type="button"

--- a/frontend/src/components/notifications/notificationMeta.test.ts
+++ b/frontend/src/components/notifications/notificationMeta.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { relativeTime } from './notificationMeta';
+
+/**
+ * `relativeTime` reads `Date.now()`, so the clock is frozen rather than the assertions loosened —
+ * otherwise a test straddling a minute boundary fails once in a while and teaches everyone to re-run.
+ */
+const NOW = new Date('2026-08-19T12:00:00.000Z');
+
+/** Offsets from {@link NOW}, expressed the way the function's thresholds are. */
+const secondsAgo = (seconds: number) => new Date(NOW.getTime() - seconds * 1000).toISOString();
+const minutesAgo = (minutes: number) => secondsAgo(minutes * 60);
+const hoursAgo = (hours: number) => minutesAgo(hours * 60);
+const daysAgo = (days: number) => hoursAgo(days * 24);
+
+describe('relativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('GivenATimestampUnderAMinuteOld_WhenFormatted_ThenItReadsJustNow', () => {
+    expect(relativeTime(secondsAgo(30))).toBe('just now');
+  });
+
+  it('GivenATimestampOfExactlyOneMinute_WhenFormatted_ThenItReadsInMinutes', () => {
+    expect(relativeTime(minutesAgo(1))).toBe('1m ago');
+  });
+
+  it('GivenATimestampOfHours_WhenFormatted_ThenItReadsInHours', () => {
+    expect(relativeTime(hoursAgo(3))).toBe('3h ago');
+  });
+
+  it('GivenATimestampOfDays_WhenFormatted_ThenItReadsInDays', () => {
+    expect(relativeTime(daysAgo(2))).toBe('2d ago');
+  });
+
+  it('GivenATimestampOverAWeekOld_WhenFormatted_ThenItFallsBackToALocaleDate', () => {
+    const iso = daysAgo(30);
+
+    expect(relativeTime(iso)).toBe(new Date(iso).toLocaleDateString());
+  });
+
+  it('GivenATimestampInTheFuture_WhenFormatted_ThenItReadsJustNow', () => {
+    expect(relativeTime(new Date(NOW.getTime() + 60_000).toISOString())).toBe('just now');
+  });
+});

--- a/frontend/src/components/notifications/notificationMeta.ts
+++ b/frontend/src/components/notifications/notificationMeta.ts
@@ -1,11 +1,18 @@
 import type { NotificationCategory } from '../../types';
 
-/** Icon + Tailwind classes per notification category, shared by the toast, dropdown and list. */
-export const categoryMeta: Record<NotificationCategory, { icon: string; bg: string; ring: string; text: string }> = {
-  INFO: { icon: 'ℹ️', bg: 'bg-blue-50', ring: 'border-blue-200', text: 'text-blue-700' },
-  SUCCESS: { icon: '✅', bg: 'bg-green-50', ring: 'border-green-200', text: 'text-green-700' },
-  WARNING: { icon: '⚠️', bg: 'bg-red-50', ring: 'border-red-200', text: 'text-red-700' },
-  REMINDER: { icon: '⏰', bg: 'bg-orange-50', ring: 'border-orange-200', text: 'text-orange-700' },
+/**
+ * Icon + token classes per notification category, shared by the toast, dropdown and list.
+ *
+ * Each category owns a hue that means only that category. WARNING is amber rather than red, so a
+ * warning cannot be mistaken for a failure; REMINDER is violet rather than orange, so it cannot be
+ * mistaken for a streak celebration; INFO is cyan rather than the brand blue the sidebar's active
+ * state already uses.
+ */
+export const categoryMeta: Record<NotificationCategory, { icon: string; bg: string; border: string; text: string }> = {
+  INFO: { icon: 'ℹ️', bg: 'bg-info-soft', border: 'border-info-line', text: 'text-info-fg' },
+  SUCCESS: { icon: '✅', bg: 'bg-success-soft', border: 'border-success-line', text: 'text-success-fg' },
+  WARNING: { icon: '⚠️', bg: 'bg-warning-soft', border: 'border-warning-line', text: 'text-warning-fg' },
+  REMINDER: { icon: '⏰', bg: 'bg-reminder-soft', border: 'border-reminder-line', text: 'text-reminder-fg' },
 };
 
 /**

--- a/frontend/src/components/theme/ThemeToggle.test.tsx
+++ b/frontend/src/components/theme/ThemeToggle.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../contexts/ThemeProvider';
+import ThemeToggle from './ThemeToggle';
+import { installMatchMedia } from '../../test/matchMediaStub';
+
+const renderToggle = () =>
+  render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>,
+  );
+
+const isDark = () => document.documentElement.classList.contains('dark');
+
+describe('ThemeToggle', () => {
+  it('GivenAnyTheme_WhenTheToggleRenders_ThenTheGroupIsNamedTheme', () => {
+    renderToggle();
+
+    expect(screen.getByRole('group', { name: 'Theme' })).toBeDefined();
+  });
+
+  it('GivenAnyTheme_WhenTheToggleRenders_ThenAllThreeChoicesArePresent', () => {
+    renderToggle();
+
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+  });
+
+  it('GivenTheSystemTheme_WhenTheToggleRenders_ThenTheSystemRadioIsChecked', () => {
+    renderToggle();
+
+    const system = screen.getByRole('radio', { name: /System/ }) as HTMLInputElement;
+    expect(system.checked).toBe(true);
+  });
+
+  it('GivenAStoredDarkTheme_WhenTheToggleRenders_ThenTheDarkRadioIsChecked', () => {
+    localStorage.setItem('theme', 'dark');
+
+    renderToggle();
+
+    expect((screen.getByRole('radio', { name: 'Dark' }) as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByRole('radio', { name: /System/ }) as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('GivenTheLightTheme_WhenTheDarkOptionIsSelected_ThenTheDocumentGainsTheDarkClass', () => {
+    localStorage.setItem('theme', 'light');
+    renderToggle();
+    expect(isDark()).toBe(false);
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Dark' }));
+
+    expect(isDark()).toBe(true);
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  // "System" alone tells a screen-reader user the rule but not the outcome — which is the one thing
+  // they cannot otherwise perceive, since the outcome is conveyed purely by colour.
+  it('GivenTheSystemThemeResolvingToDark_WhenTheToggleRenders_ThenTheSystemOptionNamesTheResolvedTheme', () => {
+    installMatchMedia(true);
+
+    renderToggle();
+
+    expect(screen.getByRole('radio', { name: 'System (currently dark)' })).toBeDefined();
+  });
+
+  it('GivenTheSystemThemeResolvingToLight_WhenTheToggleRenders_ThenTheSystemOptionNamesTheResolvedTheme', () => {
+    installMatchMedia(false);
+
+    renderToggle();
+
+    expect(screen.getByRole('radio', { name: 'System (currently light)' })).toBeDefined();
+  });
+
+  it('GivenAnExplicitTheme_WhenTheSystemOptionIsSelected_ThenTheDocumentFollowsTheOperatingSystem', () => {
+    localStorage.setItem('theme', 'light');
+    installMatchMedia(true);
+    renderToggle();
+    expect(isDark()).toBe(false);
+
+    fireEvent.click(screen.getByRole('radio', { name: /System/ }));
+
+    expect(isDark()).toBe(true);
+  });
+});

--- a/frontend/src/components/theme/ThemeToggle.tsx
+++ b/frontend/src/components/theme/ThemeToggle.tsx
@@ -64,7 +64,7 @@ const ThemeToggle: React.FC = () => {
     <fieldset className="flex items-center gap-0.5 rounded-full bg-muted p-0.5">
       <legend className="sr-only">Theme</legend>
       {options.map((option) => (
-        <label key={option.value} title={option.label} className="cursor-pointer">
+        <label key={option.value} title={option.label} className="group cursor-pointer">
           <input
             type="radio"
             name="theme"
@@ -73,7 +73,19 @@ const ThemeToggle: React.FC = () => {
             onChange={() => setTheme(option.value)}
             className="peer sr-only"
           />
-          <span className="flex w-8 h-8 items-center justify-center rounded-full text-fg-subtle transition-colors peer-hover:text-fg peer-checked:bg-brand peer-checked:text-fg-inverted peer-focus-visible:ring-2 peer-focus-visible:ring-focus peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-muted">
+          {/*
+            Hover is `group-*` while everything else is `peer-*`, and the difference is not arbitrary.
+            The peer here is the input, which is `sr-only` — a 1px clipped box behind the icon — so a
+            pointer never reaches it and `peer-hover` would be dead style. Checked and focus-visible are
+            states of the input itself, so those stay on the peer.
+
+            `peer-checked:group-hover:text-fg-inverted` looks redundant and is kept deliberately.
+            Tailwind happens to emit `peer-checked` after `group-hover`, so the selected pill would hold
+            its inverted text on hover anyway — but that is an ordering internal to Tailwind, not a
+            guarantee, and if it ever changed the only symptom would be dark-on-blue text nobody thought
+            to test. Stating the combination pins it.
+          */}
+          <span className="flex w-8 h-8 items-center justify-center rounded-full text-fg-subtle transition-colors group-hover:text-fg peer-checked:bg-brand peer-checked:text-fg-inverted peer-checked:group-hover:text-fg-inverted peer-focus-visible:ring-2 peer-focus-visible:ring-focus peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-muted">
             {option.icon}
             <span className="sr-only">
               {option.value === 'system' ? `${option.label} (currently ${resolvedTheme})` : option.label}

--- a/frontend/src/components/theme/ThemeToggle.tsx
+++ b/frontend/src/components/theme/ThemeToggle.tsx
@@ -61,7 +61,7 @@ const ThemeToggle: React.FC = () => {
   const { theme, resolvedTheme, setTheme } = useTheme();
 
   return (
-    <fieldset className="flex items-center gap-0.5 rounded-full bg-muted p-0.5">
+    <fieldset className="flex shrink-0 items-center gap-0.5 rounded-full bg-muted p-0.5">
       <legend className="sr-only">Theme</legend>
       {options.map((option) => (
         <label key={option.value} title={option.label} className="group cursor-pointer">

--- a/frontend/src/components/theme/ThemeToggle.tsx
+++ b/frontend/src/components/theme/ThemeToggle.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { useTheme } from '../../hooks/useTheme';
+import type { Theme } from '../../contexts/themeContextValue';
+
+/**
+ * Shared icon attributes.
+ *
+ * `stroke="currentColor"` is the point: an SVG icon inherits the token colour and therefore follows the
+ * theme it switches, where an emoji glyph carries its own fixed colours and cannot.
+ */
+const iconProps = {
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.8,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  className: 'w-4 h-4',
+  'aria-hidden': true,
+};
+
+const SunIcon: React.FC = () => (
+  <svg {...iconProps}>
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+  </svg>
+);
+
+const MonitorIcon: React.FC = () => (
+  <svg {...iconProps}>
+    <rect x="2" y="4" width="20" height="13" rx="2" />
+    <path d="M8 21h8M12 17v4" />
+  </svg>
+);
+
+const MoonIcon: React.FC = () => (
+  <svg {...iconProps}>
+    <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />
+  </svg>
+);
+
+/** The three states in increasing darkness, so the control reads as a scale rather than a menu. */
+const options: { value: Theme; label: string; icon: React.ReactNode }[] = [
+  { value: 'light', label: 'Light', icon: <SunIcon /> },
+  { value: 'system', label: 'System', icon: <MonitorIcon /> },
+  { value: 'dark', label: 'Dark', icon: <MoonIcon /> },
+];
+
+/**
+ * Three-state theme control: light, system, dark.
+ *
+ * Native radio inputs rather than buttons with ARIA. A radio group is what this is, and the real
+ * element brings arrow-key navigation, the group relationship and the "2 of 3, selected" announcement
+ * with it — none of which comes free from three buttons. The inputs are `sr-only`, which clips them
+ * visually while leaving them focusable and operable.
+ *
+ * The System option names what it currently resolves to, because "System" alone gives a screen-reader
+ * user the rule but not the outcome — and the outcome is otherwise conveyed by colour alone.
+ */
+const ThemeToggle: React.FC = () => {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+
+  return (
+    <fieldset className="flex items-center gap-0.5 rounded-full bg-muted p-0.5">
+      <legend className="sr-only">Theme</legend>
+      {options.map((option) => (
+        <label key={option.value} title={option.label} className="cursor-pointer">
+          <input
+            type="radio"
+            name="theme"
+            value={option.value}
+            checked={theme === option.value}
+            onChange={() => setTheme(option.value)}
+            className="peer sr-only"
+          />
+          <span className="flex w-8 h-8 items-center justify-center rounded-full text-fg-subtle transition-colors peer-hover:text-fg peer-checked:bg-brand peer-checked:text-fg-inverted peer-focus-visible:ring-2 peer-focus-visible:ring-focus peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-muted">
+            {option.icon}
+            <span className="sr-only">
+              {option.value === 'system' ? `${option.label} (currently ${resolvedTheme})` : option.label}
+            </span>
+          </span>
+        </label>
+      ))}
+    </fieldset>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -1,17 +1,20 @@
 import React from 'react';
 
+/** The fixed set of badge colours. Exported so the maps that choose one cannot drift from it. */
+export type BadgeVariant = 'green' | 'yellow' | 'blue' | 'red' | 'gray' | 'purple';
+
 /**
  * @param variant colour scheme; the palette is fixed so badges stay consistent across the app
  * @param children the label
  * @param className extra classes appended after the variant's, so they win on conflict
  */
 interface BadgeProps {
-  variant?: 'green' | 'yellow' | 'blue' | 'red' | 'gray' | 'purple';
+  variant?: BadgeVariant;
   children: React.ReactNode;
   className?: string;
 }
 
-const variantClasses: Record<NonNullable<BadgeProps['variant']>, string> = {
+const variantClasses: Record<BadgeVariant, string> = {
   green: 'bg-tint-green-soft text-tint-green-fg',
   yellow: 'bg-tint-yellow-soft text-tint-yellow-fg',
   blue: 'bg-tint-blue-soft text-tint-blue-fg',

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -11,13 +11,13 @@ interface BadgeProps {
   className?: string;
 }
 
-const variantClasses: Record<string, string> = {
-  green: 'bg-green-100 text-green-800',
-  yellow: 'bg-yellow-100 text-yellow-800',
-  blue: 'bg-blue-100 text-blue-800',
-  red: 'bg-red-100 text-red-800',
-  gray: 'bg-gray-100 text-gray-700',
-  purple: 'bg-purple-100 text-purple-800',
+const variantClasses: Record<NonNullable<BadgeProps['variant']>, string> = {
+  green: 'bg-tint-green-soft text-tint-green-fg',
+  yellow: 'bg-tint-yellow-soft text-tint-yellow-fg',
+  blue: 'bg-tint-blue-soft text-tint-blue-fg',
+  red: 'bg-tint-red-soft text-tint-red-fg',
+  gray: 'bg-muted text-fg-muted',
+  purple: 'bg-tint-purple-soft text-tint-purple-fg',
 };
 
 /** Small rounded label used for statuses, types and difficulties. */

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -17,10 +17,10 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const variantClasses: Record<string, string> = {
-  primary: 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500',
-  secondary: 'bg-gray-100 text-gray-800 hover:bg-gray-200 focus:ring-gray-400',
-  danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
-  ghost: 'bg-transparent text-gray-600 hover:bg-gray-100 focus:ring-gray-400',
+  primary: 'bg-brand text-fg-inverted hover:bg-brand-hover',
+  secondary: 'bg-muted text-fg-muted hover:bg-muted-strong',
+  danger: 'bg-danger text-fg-inverted hover:bg-danger-hover',
+  ghost: 'bg-transparent text-fg-subtle hover:bg-muted',
 };
 
 const sizeClasses: Record<string, string> = {

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -10,11 +10,11 @@ interface CardProps {
   className?: string;
 }
 
-/** White panel with an optional header. The standard container for a section of a page. */
+/** Themed panel with an optional header. The standard container for a section of a page. */
 const Card: React.FC<CardProps> = ({ children, header, className = '' }) => (
-  <div className={`bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden ${className}`}>
+  <div className={`bg-surface rounded-xl shadow-sm border border-line overflow-hidden ${className}`}>
     {header && (
-      <div className="px-6 py-4 border-b border-gray-200 font-semibold text-gray-800">
+      <div className="px-6 py-4 border-b border-line font-semibold text-fg-muted">
         {header}
       </div>
     )}

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -22,8 +22,8 @@ interface EmptyStateProps {
 const EmptyState: React.FC<EmptyStateProps> = ({ icon = '📭', title, description, action }) => (
   <div className="flex flex-col items-center justify-center py-16 text-center">
     <div className="text-5xl mb-4">{icon}</div>
-    <h3 className="text-lg font-semibold text-gray-800 mb-1">{title}</h3>
-    {description && <p className="text-sm text-gray-500 mb-4 max-w-sm">{description}</p>}
+    <h3 className="text-lg font-semibold text-fg-muted mb-1">{title}</h3>
+    {description && <p className="text-sm text-fg-subtle mb-4 max-w-sm">{description}</p>}
     {action && <div>{action}</div>}
   </div>
 );

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -24,18 +24,18 @@ const Input: React.FC<InputProps> = ({ label, error, id, className = '', ...rest
   return (
     <div className="flex flex-col gap-1">
       {label && (
-        <label htmlFor={inputId} className="text-sm font-medium text-gray-700">
+        <label htmlFor={inputId} className="text-sm font-medium text-fg-muted">
           {label}
         </label>
       )}
       <input
         id={inputId}
-        className={`rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-          error ? 'border-red-500 focus:ring-red-400' : 'border-gray-300'
+        className={`rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 ${
+          error ? 'border-danger focus:ring-danger' : 'border-line-strong'
         } ${className}`}
         {...rest}
       />
-      {error && <p className="text-xs text-red-500">{error}</p>}
+      {error && <p className="text-xs text-danger-fg">{error}</p>}
     </div>
   );
 };

--- a/frontend/src/components/ui/LoadingSpinner.tsx
+++ b/frontend/src/components/ui/LoadingSpinner.tsx
@@ -11,7 +11,7 @@ const sizeMap = { sm: 'h-4 w-4', md: 'h-8 w-8', lg: 'h-12 w-12' };
 const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ size = 'md' }) => (
   <div className="flex items-center justify-center">
     <div
-      className={`${sizeMap[size]} animate-spin rounded-full border-2 border-gray-300 border-t-blue-600`}
+      className={`${sizeMap[size]} animate-spin rounded-full border-2 border-line-strong border-t-brand`}
     />
   </div>
 );

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -22,7 +22,7 @@ const TwoModals: React.FC = () => (
   </>
 );
 
-/** Opens a modal from a button, so closing can be observed the way a page uses it. */
+/** Holds the open state itself, so closing can be observed the way a page drives it. */
 const Openable: React.FC = () => {
   const [open, setOpen] = useState(true);
   return (
@@ -40,10 +40,12 @@ describe('Modal', () => {
       expect(screen.getByRole('dialog', { name: 'New Health Area' })).toBeDefined();
     });
 
-    it('GivenAnOpenModal_WhenItRenders_ThenItIsMarkedAsModal', () => {
+    // Pins a deliberate omission, not an oversight: nothing here traps focus, so claiming the page
+    // behind is inert would strand a screen-reader user on controls it had removed from their buffer.
+    it('GivenAnOpenModal_WhenItRenders_ThenItDoesNotClaimTheRestOfThePageIsInert', () => {
       renderModal();
 
-      expect(screen.getByRole('dialog').getAttribute('aria-modal')).toBe('true');
+      expect(screen.getByRole('dialog').getAttribute('aria-modal')).toBeNull();
     });
 
     it('GivenAnOpenModal_WhenItRenders_ThenTheCloseControlIsLabelled', () => {
@@ -91,7 +93,22 @@ describe('Modal', () => {
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it('GivenAModalThatHasClosed_WhenEscapeIsPressed_ThenNothingListensForIt', () => {
+    // The listener is bound only while open. Asserting the dialog is still gone would pass either way;
+    // only the callback distinguishes a bound listener from an unbound one.
+    it('GivenAClosedModal_WhenEscapeIsPressed_ThenOnCloseIsNotCalled', () => {
+      const onClose = vi.fn();
+      render(
+        <Modal isOpen={false} onClose={onClose} title="New Health Area">
+          <p>body</p>
+        </Modal>,
+      );
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('GivenAnOpenModalThatHasSinceClosed_WhenEscapeIsPressedAgain_ThenItStaysClosed', () => {
       render(<Openable />);
       fireEvent.keyDown(document, { key: 'Escape' });
       expect(screen.queryByRole('dialog')).toBeNull();

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import Modal from './Modal';
+
+const renderModal = (onClose = vi.fn(), title = 'New Health Area') =>
+  render(
+    <Modal isOpen onClose={onClose} title={title}>
+      <p>body</p>
+    </Modal>,
+  );
+
+/** Two modals mounted at once, which is what `HealthAreasPage` does with its create/edit/delete trio. */
+const TwoModals: React.FC = () => (
+  <>
+    <Modal isOpen onClose={() => {}} title="New Health Area">
+      <p>create</p>
+    </Modal>
+    <Modal isOpen onClose={() => {}} title="Delete Health Area">
+      <p>confirm</p>
+    </Modal>
+  </>
+);
+
+/** Opens a modal from a button, so closing can be observed the way a page uses it. */
+const Openable: React.FC = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <Modal isOpen={open} onClose={() => setOpen(false)} title="New Health Area">
+      <p>body</p>
+    </Modal>
+  );
+};
+
+describe('Modal', () => {
+  describe('announcing itself', () => {
+    it('GivenAnOpenModal_WhenItRenders_ThenItIsADialogNamedByItsTitle', () => {
+      renderModal();
+
+      expect(screen.getByRole('dialog', { name: 'New Health Area' })).toBeDefined();
+    });
+
+    it('GivenAnOpenModal_WhenItRenders_ThenItIsMarkedAsModal', () => {
+      renderModal();
+
+      expect(screen.getByRole('dialog').getAttribute('aria-modal')).toBe('true');
+    });
+
+    it('GivenAnOpenModal_WhenItRenders_ThenTheCloseControlIsLabelled', () => {
+      renderModal();
+
+      expect(screen.getByRole('button', { name: 'Close modal' })).toBeDefined();
+    });
+
+    // A hard-coded id would make both dialogs point at the first title, so both would report the same
+    // name — the failure `useId` exists to prevent, and the one a single-modal test cannot see.
+    it('GivenTwoOpenModals_WhenTheyRender_ThenEachIsNamedByItsOwnTitle', () => {
+      render(<TwoModals />);
+
+      expect(screen.getByRole('dialog', { name: 'New Health Area' })).toBeDefined();
+      expect(screen.getByRole('dialog', { name: 'Delete Health Area' })).toBeDefined();
+    });
+  });
+
+  describe('closing', () => {
+    it('GivenAnOpenModal_WhenEscapeIsPressed_ThenItCloses', () => {
+      const onClose = vi.fn();
+      renderModal(onClose);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('GivenAnOpenModal_WhenTheCloseControlIsClicked_ThenItCloses', () => {
+      const onClose = vi.fn();
+      renderModal(onClose);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    // The backdrop is decorative and carries no role, so there is nothing accessible to query it by.
+    it('GivenAnOpenModal_WhenTheBackdropIsClicked_ThenItCloses', () => {
+      const onClose = vi.fn();
+      const { container } = renderModal(onClose);
+
+      fireEvent.click(container.firstElementChild!.firstElementChild!);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('GivenAModalThatHasClosed_WhenEscapeIsPressed_ThenNothingListensForIt', () => {
+      render(<Openable />);
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(screen.queryByRole('dialog')).toBeNull();
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+  });
+
+  it('GivenAClosedModal_WhenItRenders_ThenNeitherTheDialogNorItsBodyIsInTheDocument', () => {
+    render(
+      <Modal isOpen={false} onClose={() => {}} title="New Health Area">
+        <p>body</p>
+      </Modal>,
+    );
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(screen.queryByText('body')).toBeNull();
+  });
+});

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -33,13 +33,13 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
-      <div className="relative z-10 w-full max-w-lg rounded-xl bg-white shadow-xl mx-4">
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-800">{title}</h2>
+      <div className="absolute inset-0 bg-overlay/50" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-lg rounded-xl bg-surface border border-line-strong shadow-xl mx-4">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-line">
+          <h2 className="text-lg font-semibold text-fg-muted">{title}</h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 text-2xl leading-none"
+            className="text-fg-faint hover:text-fg-subtle text-2xl leading-none"
             aria-label="Close modal"
           >
             &times;

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useId } from 'react';
 
 /**
  * @param isOpen   whether the dialog is shown; when false the component renders nothing at all
  * @param onClose  called by the close button, the backdrop and the Escape key alike
- * @param title    heading text
+ * @param title    heading text, which also becomes the dialog's accessible name
  * @param children the dialog body, usually a form
  */
 interface ModalProps {
@@ -14,13 +14,31 @@ interface ModalProps {
 }
 
 /**
- * Centred dialog over a dimmed backdrop.
+ * Centred dialog over a dimmed backdrop, bounded by the viewport at any window size.
+ *
+ * The overlay's padding is what guarantees the gutter, and `max-h-full` resolves against that padded
+ * box — the overlay is `fixed inset-0`, so its height is definite and the percentage resolves without
+ * needing `vh` or `dvh` and their unit caveats. Inside it, `flex flex-col` with a `shrink-0` header and
+ * a scrolling body is what keeps the title and close button in place while a long form scrolls under
+ * them. `min-h-0` on that body is redundant — a flex item that is itself a scroll container already has
+ * an automatic minimum size of zero — but it is the one declaration that states the intent, and without
+ * the rule it names the body would push the panel past its own `max-height` and the scroll would never
+ * engage.
  *
  * Closes on Escape as well as on the button and the backdrop; the key listener is bound only while
  * open, so a closed modal costs nothing and several on one page cannot fight over the key. Nothing is
  * rendered when closed, which means the body is unmounted and its form state resets between openings.
+ *
+ * Known gap, deliberately not closed here: `aria-modal` tells assistive technology that the rest of the
+ * page is inert, but nothing traps the keyboard, so Tab still walks out into the page behind. Focus is
+ * neither moved in on open nor restored on close. Closing it properly means a native `<dialog>` with
+ * `showModal()`; see `docs/requirements/requirements.md` §6.
  */
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
+  // Three modals can share one page, so the title's id has to be unique per instance — a hard-coded
+  // one would make every dialog resolve the same accessible name.
+  const titleId = useId();
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
@@ -32,20 +50,27 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
       <div className="absolute inset-0 bg-overlay/50" onClick={onClose} />
-      <div className="relative z-10 w-full max-w-lg rounded-xl bg-surface border border-line-strong shadow-xl mx-4">
-        <div className="flex items-center justify-between px-6 py-4 border-b border-line">
-          <h2 className="text-lg font-semibold text-fg-muted">{title}</h2>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative z-10 flex max-h-full w-full min-w-0 max-w-lg flex-col overflow-hidden rounded-xl bg-surface border border-line-strong shadow-xl"
+      >
+        <div className="flex shrink-0 items-center justify-between gap-4 px-6 py-4 border-b border-line">
+          <h2 id={titleId} className="min-w-0 truncate text-lg font-semibold text-fg-muted">
+            {title}
+          </h2>
           <button
             onClick={onClose}
-            className="text-fg-faint hover:text-fg-subtle text-2xl leading-none"
+            className="shrink-0 text-fg-faint hover:text-fg-subtle text-2xl leading-none"
             aria-label="Close modal"
           >
             &times;
           </button>
         </div>
-        <div className="px-6 py-4">{children}</div>
+        <div className="min-h-0 overflow-y-auto overscroll-contain px-6 py-4">{children}</div>
       </div>
     </div>
   );

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -29,10 +29,12 @@ interface ModalProps {
  * open, so a closed modal costs nothing and several on one page cannot fight over the key. Nothing is
  * rendered when closed, which means the body is unmounted and its form state resets between openings.
  *
- * Known gap, deliberately not closed here: `aria-modal` tells assistive technology that the rest of the
- * page is inert, but nothing traps the keyboard, so Tab still walks out into the page behind. Focus is
- * neither moved in on open nor restored on close. Closing it properly means a native `<dialog>` with
- * `showModal()`; see `docs/requirements/requirements.md` §6.
+ * Deliberately no `aria-modal`. It would tell assistive technology that everything outside the dialog
+ * is inert, and nothing here makes that true: no focus trap, so Tab walks straight out into the page
+ * behind, and focus is neither moved in on open nor restored on close. Claiming it would leave a
+ * screen-reader user tabbing to controls the dialog has removed from their buffer — worse than the
+ * plain `dialog` role, which at least announces this panel honestly. Closing the gap properly means a
+ * native `<dialog>` with `showModal()`; see `docs/requirements/requirements.md` §6.
  */
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
   // Three modals can share one page, so the title's id has to be unique per instance — a hard-coded
@@ -54,7 +56,6 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
       <div className="absolute inset-0 bg-overlay/50" onClick={onClose} />
       <div
         role="dialog"
-        aria-modal="true"
         aria-labelledby={titleId}
         className="relative z-10 flex max-h-full w-full min-w-0 max-w-lg flex-col overflow-hidden rounded-xl bg-surface border border-line-strong shadow-xl"
       >

--- a/frontend/src/components/ui/PageContainer.test.tsx
+++ b/frontend/src/components/ui/PageContainer.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PageContainer from './PageContainer';
+
+/**
+ * These pin which cap each variant selects, and nothing more.
+ *
+ * jsdom has no layout engine and `vitest.config.ts` sets `css: false`, so no test in this repo can
+ * observe a width, a wrap or an overflow — see ADR-004. Asserting the class name is the one mechanical
+ * link between the requirement and the code; the layout itself is checked by hand.
+ */
+const capOf = (container: HTMLElement) => container.firstElementChild?.className ?? '';
+
+describe('PageContainer', () => {
+  it('GivenNoWidth_WhenThePageContainerRenders_ThenItCapsAtTheDefaultWidth', () => {
+    const { container } = render(<PageContainer>page</PageContainer>);
+
+    expect(capOf(container)).toContain('max-w-7xl');
+  });
+
+  it('GivenTheNarrowWidth_WhenThePageContainerRenders_ThenItCapsAtTheReadingWidth', () => {
+    const { container } = render(<PageContainer width="narrow">page</PageContainer>);
+
+    expect(capOf(container)).toContain('max-w-3xl');
+  });
+
+  it('GivenExtraClasses_WhenThePageContainerRenders_ThenTheyAreKeptAlongsideTheCap', () => {
+    const { container } = render(<PageContainer className="space-y-6">page</PageContainer>);
+
+    expect(capOf(container)).toContain('space-y-6');
+    expect(capOf(container)).toContain('max-w-7xl');
+  });
+
+  it('GivenAnyWidth_WhenThePageContainerRenders_ThenItShowsItsChildren', () => {
+    render(<PageContainer>the page</PageContainer>);
+
+    expect(screen.getByText('the page')).toBeDefined();
+  });
+});

--- a/frontend/src/components/ui/PageContainer.tsx
+++ b/frontend/src/components/ui/PageContainer.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+/**
+ * @param children  the page's content
+ * @param width     how far the content may grow — `wide` for lists, grids and dashboards, `narrow` for
+ *                  reading and form pages, where a long line of text is harder to follow
+ * @param className extra classes for the container itself, usually vertical rhythm
+ */
+interface PageContainerProps {
+  children: React.ReactNode;
+  width?: 'wide' | 'narrow';
+  className?: string;
+}
+
+/**
+ * The one place a page's width is decided.
+ *
+ * Pages used to cap themselves, with four different values across nine pages and nothing behind the
+ * choice — which is how `/health-areas` came to sit 896px wide in the middle of a 1536px window. A page
+ * now fills whatever the shell gives it and stops only where a line of text stops being comfortable to
+ * read.
+ *
+ * So the cap is on the measure, not on the layout: `wide` is roughly a hundred characters at the body
+ * size, `narrow` roughly sixty. Given the 240px sidebar and the shell's padding, `wide` does not begin
+ * to bite until about a 1570px viewport — below that a page simply fills the space.
+ */
+const widthClasses: Record<NonNullable<PageContainerProps['width']>, string> = {
+  wide: 'max-w-7xl',
+  narrow: 'max-w-3xl',
+};
+
+const PageContainer: React.FC<PageContainerProps> = ({ children, width = 'wide', className = '' }) => (
+  <div className={`w-full mx-auto ${widthClasses[width]} ${className}`}>{children}</div>
+);
+
+export default PageContainer;

--- a/frontend/src/components/ui/PageContainer.tsx
+++ b/frontend/src/components/ui/PageContainer.tsx
@@ -12,6 +12,12 @@ interface PageContainerProps {
   className?: string;
 }
 
+/** The two caps, by name. Not exported: `react-refresh/only-export-components` plus CI's zero-warning lint. */
+const widthClasses: Record<NonNullable<PageContainerProps['width']>, string> = {
+  wide: 'max-w-7xl',
+  narrow: 'max-w-3xl',
+};
+
 /**
  * The one place a page's width is decided.
  *
@@ -20,15 +26,12 @@ interface PageContainerProps {
  * now fills whatever the shell gives it and stops only where a line of text stops being comfortable to
  * read.
  *
- * So the cap is on the measure, not on the layout: `wide` is roughly a hundred characters at the body
- * size, `narrow` roughly sixty. Given the 240px sidebar and the shell's padding, `wide` does not begin
- * to bite until about a 1570px viewport — below that a page simply fills the space.
+ * So the cap is on the measure, not on the layout. At the 16px body size a proportional character
+ * averages roughly 8px, which puts `wide` (1280px) near 160 characters and `narrow` (768px) near 95 —
+ * the latter about the upper bound of the usual 45–90 guidance, and why prose and form pages take it.
+ * Given the 240px sidebar and the shell's padding, `wide` does not begin to bite until about a 1570px
+ * viewport; below that a page simply fills the space.
  */
-const widthClasses: Record<NonNullable<PageContainerProps['width']>, string> = {
-  wide: 'max-w-7xl',
-  narrow: 'max-w-3xl',
-};
-
 const PageContainer: React.FC<PageContainerProps> = ({ children, width = 'wide', className = '' }) => (
   <div className={`w-full mx-auto ${widthClasses[width]} ${className}`}>{children}</div>
 );

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -11,14 +11,21 @@ interface PageHeaderProps {
   action?: React.ReactNode;
 }
 
-/** Standard page heading: title, optional subtitle, optional right-aligned action. */
+/**
+ * Standard page heading: title, optional subtitle, optional right-aligned action.
+ *
+ * Wraps rather than squeezes. Below the width at which the heading and the action fit on one line the
+ * action drops underneath, which keeps a long title readable instead of shrinking the button beside
+ * it. `min-w-0` is what lets the heading block wrap at all — without it the block's min-content width
+ * is its floor, and the row grows past its container instead.
+ */
 const PageHeader: React.FC<PageHeaderProps> = ({ title, subtitle, action }) => (
-  <div className="flex items-start justify-between mb-6">
-    <div>
+  <div className="flex flex-wrap items-start justify-between gap-4 mb-6">
+    <div className="min-w-0">
       <h1 className="text-2xl font-bold text-fg">{title}</h1>
       {subtitle && <p className="mt-1 text-sm text-fg-subtle">{subtitle}</p>}
     </div>
-    {action && <div>{action}</div>}
+    {action && <div className="shrink-0">{action}</div>}
   </div>
 );
 

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -15,8 +15,8 @@ interface PageHeaderProps {
 const PageHeader: React.FC<PageHeaderProps> = ({ title, subtitle, action }) => (
   <div className="flex items-start justify-between mb-6">
     <div>
-      <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
-      {subtitle && <p className="mt-1 text-sm text-gray-500">{subtitle}</p>}
+      <h1 className="text-2xl font-bold text-fg">{title}</h1>
+      {subtitle && <p className="mt-1 text-sm text-fg-subtle">{subtitle}</p>}
     </div>
     {action && <div>{action}</div>}
   </div>

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -25,14 +25,14 @@ const Select: React.FC<SelectProps> = ({ label, options, error, id, className = 
   return (
     <div className="flex flex-col gap-1">
       {label && (
-        <label htmlFor={selectId} className="text-sm font-medium text-gray-700">
+        <label htmlFor={selectId} className="text-sm font-medium text-fg-muted">
           {label}
         </label>
       )}
       <select
         id={selectId}
-        className={`rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white ${
-          error ? 'border-red-500 focus:ring-red-400' : 'border-gray-300'
+        className={`rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 bg-surface ${
+          error ? 'border-danger focus:ring-danger' : 'border-line-strong'
         } ${className}`}
         {...rest}
       >
@@ -42,7 +42,7 @@ const Select: React.FC<SelectProps> = ({ label, options, error, id, className = 
           </option>
         ))}
       </select>
-      {error && <p className="text-xs text-red-500">{error}</p>}
+      {error && <p className="text-xs text-danger-fg">{error}</p>}
     </div>
   );
 };

--- a/frontend/src/components/ui/areaIcon.test.ts
+++ b/frontend/src/components/ui/areaIcon.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { areaIconGlyph, DEFAULT_AREA_ICON } from './areaIcon';
+
+describe('areaIconGlyph', () => {
+  it('GivenAnEmoji_WhenTheGlyphIsResolved_ThenItIsReturnedUnchanged', () => {
+    expect(areaIconGlyph('😴')).toBe('😴');
+  });
+
+  it('GivenAnEmojiWithSurroundingSpace_WhenTheGlyphIsResolved_ThenItIsTrimmed', () => {
+    expect(areaIconGlyph('  💧 ')).toBe('💧');
+  });
+
+  // The six seeded areas shipped with these, which is the whole reason the fallback exists.
+  it('GivenAMaterialSymbolsKey_WhenTheGlyphIsResolved_ThenTheDefaultIsUsed', () => {
+    expect(areaIconGlyph('water_drop')).toBe(DEFAULT_AREA_ICON);
+    expect(areaIconGlyph('self_improvement')).toBe(DEFAULT_AREA_ICON);
+    expect(areaIconGlyph('eco')).toBe(DEFAULT_AREA_ICON);
+  });
+
+  it('GivenAnEmptyIcon_WhenTheGlyphIsResolved_ThenTheDefaultIsUsed', () => {
+    expect(areaIconGlyph('')).toBe(DEFAULT_AREA_ICON);
+  });
+
+  it('GivenWhitespaceOnly_WhenTheGlyphIsResolved_ThenTheDefaultIsUsed', () => {
+    expect(areaIconGlyph('   ')).toBe(DEFAULT_AREA_ICON);
+  });
+
+  it('GivenNoIconAtAll_WhenTheGlyphIsResolved_ThenTheDefaultIsUsed', () => {
+    expect(areaIconGlyph(undefined)).toBe(DEFAULT_AREA_ICON);
+    expect(areaIconGlyph(null)).toBe(DEFAULT_AREA_ICON);
+  });
+});

--- a/frontend/src/components/ui/areaIcon.test.ts
+++ b/frontend/src/components/ui/areaIcon.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { areaIconGlyph, DEFAULT_AREA_ICON } from './areaIcon';
+import { areaIconGlyph, DEFAULT_AREA_ICON, isIconGlyph } from './areaIcon';
 
 describe('areaIconGlyph', () => {
   it('GivenAnEmoji_WhenTheGlyphIsResolved_ThenItIsReturnedUnchanged', () => {
@@ -8,6 +8,16 @@ describe('areaIconGlyph', () => {
 
   it('GivenAnEmojiWithSurroundingSpace_WhenTheGlyphIsResolved_ThenItIsTrimmed', () => {
     expect(areaIconGlyph('  💧 ')).toBe('💧');
+  });
+
+  // The first code point of a keycap is an ASCII digit, so a first-character test would reject it.
+  it('GivenAKeycapEmoji_WhenTheGlyphIsResolved_ThenItIsReturnedUnchanged', () => {
+    expect(areaIconGlyph('1️⃣')).toBe('1️⃣');
+  });
+
+  it('GivenAnEmojiWithASkinToneOrVariationSelector_WhenTheGlyphIsResolved_ThenItSurvivesIntact', () => {
+    expect(areaIconGlyph('👍🏽')).toBe('👍🏽');
+    expect(areaIconGlyph('❤️')).toBe('❤️');
   });
 
   // The six seeded areas shipped with these, which is the whole reason the fallback exists.
@@ -28,5 +38,28 @@ describe('areaIconGlyph', () => {
   it('GivenNoIconAtAll_WhenTheGlyphIsResolved_ThenTheDefaultIsUsed', () => {
     expect(areaIconGlyph(undefined)).toBe(DEFAULT_AREA_ICON);
     expect(areaIconGlyph(null)).toBe(DEFAULT_AREA_ICON);
+  });
+
+  // Stated so the boundary is a decision on the record rather than an accident of the pattern.
+  it('GivenPunctuationOrASymbol_WhenTheGlyphIsResolved_ThenItIsReturnedRatherThanRejected', () => {
+    expect(areaIconGlyph('!')).toBe('!');
+    expect(areaIconGlyph('™')).toBe('™');
+  });
+});
+
+describe('isIconGlyph', () => {
+  it('GivenAnIconKey_WhenAskedWhetherItIsAGlyph_ThenItIsNot', () => {
+    expect(isIconGlyph('fitness_center')).toBe(false);
+    expect(isIconGlyph('eco')).toBe(false);
+  });
+
+  it('GivenAnEmoji_WhenAskedWhetherItIsAGlyph_ThenItIs', () => {
+    expect(isIconGlyph('🌙')).toBe(true);
+  });
+
+  it('GivenNothingStored_WhenAskedWhetherItIsAGlyph_ThenItIsNot', () => {
+    expect(isIconGlyph('')).toBe(false);
+    expect(isIconGlyph(null)).toBe(false);
+    expect(isIconGlyph(undefined)).toBe(false);
   });
 });

--- a/frontend/src/components/ui/areaIcon.ts
+++ b/frontend/src/components/ui/areaIcon.ts
@@ -1,0 +1,23 @@
+/** Drawn for a health area with no icon, or one this application cannot render as a glyph. */
+export const DEFAULT_AREA_ICON = '🎯';
+
+/**
+ * An icon *key* starts with an ASCII word character; a glyph does not.
+ *
+ * The seeded areas were written against Material Symbols ligature names — `water_drop`,
+ * `fitness_center`, `self_improvement` — but no icon font is loaded anywhere, so the page drew those
+ * names as their own literal text. The form has always asked for an emoji. This is where the two
+ * readings are reconciled, on the render side, without trusting what is stored.
+ */
+const LOOKS_LIKE_AN_ICON_KEY = /^[\w-]/;
+
+/**
+ * The glyph to draw for a health area, given whatever the API returned.
+ *
+ * @param icon the stored icon, which is free-form text and validated nowhere
+ * @returns    the stored value when it looks like a glyph, otherwise {@link DEFAULT_AREA_ICON}
+ */
+export const areaIconGlyph = (icon: string | null | undefined): string => {
+  const trimmed = icon?.trim() ?? '';
+  return trimmed === '' || LOOKS_LIKE_AN_ICON_KEY.test(trimmed) ? DEFAULT_AREA_ICON : trimmed;
+};

--- a/frontend/src/components/ui/areaIcon.ts
+++ b/frontend/src/components/ui/areaIcon.ts
@@ -2,22 +2,36 @@
 export const DEFAULT_AREA_ICON = '🎯';
 
 /**
- * An icon *key* starts with an ASCII word character; a glyph does not.
+ * An icon *key* is an ASCII identifier and nothing else: `water_drop`, `fitness_center`, `eco`.
  *
- * The seeded areas were written against Material Symbols ligature names — `water_drop`,
- * `fitness_center`, `self_improvement` — but no icon font is loaded anywhere, so the page drew those
- * names as their own literal text. The form has always asked for an emoji. This is where the two
- * readings are reconciled, on the render side, without trusting what is stored.
+ * Anchored at both ends deliberately. A test on the first character alone would call `1️⃣` a key — its
+ * first code point is an ASCII digit — and silently swap out a glyph the user chose.
+ *
+ * Note what this does *not* claim: it rejects what is recognisably a key, not everything that is not
+ * an emoji. `!` and `™` are returned as they were stored. Deciding emoji-ness properly needs grapheme
+ * segmentation, which costs a `lib` change and mangles skin tones and variation selectors where it is
+ * unavailable — and buys nothing here, because the icon is drawn in a fixed clipping box that no value
+ * can widen. See ADR-005.
  */
-const LOOKS_LIKE_AN_ICON_KEY = /^[\w-]/;
+const ICON_KEY = /^[a-z][a-z0-9_-]*$/i;
+
+/**
+ * Whether a stored icon can be drawn as it stands.
+ *
+ * @param icon the stored icon, which is free-form text and validated nowhere
+ */
+export const isIconGlyph = (icon: string | null | undefined): boolean => {
+  const trimmed = icon?.trim() ?? '';
+  return trimmed !== '' && !ICON_KEY.test(trimmed);
+};
 
 /**
  * The glyph to draw for a health area, given whatever the API returned.
  *
- * @param icon the stored icon, which is free-form text and validated nowhere
- * @returns    the stored value when it looks like a glyph, otherwise {@link DEFAULT_AREA_ICON}
+ * @param icon the stored icon
+ * @returns    the stored value, trimmed, when it can be drawn; otherwise {@link DEFAULT_AREA_ICON}
  */
 export const areaIconGlyph = (icon: string | null | undefined): string => {
   const trimmed = icon?.trim() ?? '';
-  return trimmed === '' || LOOKS_LIKE_AN_ICON_KEY.test(trimmed) ? DEFAULT_AREA_ICON : trimmed;
+  return isIconGlyph(trimmed) ? trimmed : DEFAULT_AREA_ICON;
 };

--- a/frontend/src/components/upgrade/UpgradeCard.tsx
+++ b/frontend/src/components/upgrade/UpgradeCard.tsx
@@ -5,6 +5,7 @@ import UpgradeStatusBadge from './UpgradeStatusBadge';
 import UpgradeTypeBadge from './UpgradeTypeBadge';
 import Badge from '../ui/Badge';
 import Button from '../ui/Button';
+import { difficultyVariant, UNKNOWN_DIFFICULTY_VARIANT } from './upgradeMeta';
 
 /**
  * @param upgrade        the upgrade to show
@@ -18,13 +19,6 @@ interface Props {
   showActions?: boolean;
 }
 
-/** Difficulty to badge colour: green through red, so HARD reads as the demanding one. */
-const difficultyVariant: Record<string, 'green' | 'yellow' | 'red'> = {
-  EASY: 'green',
-  MEDIUM: 'yellow',
-  HARD: 'red',
-};
-
 /**
  * Summary card for one upgrade, with the transitions that are legal from its current status.
  *
@@ -36,27 +30,27 @@ const UpgradeCard: React.FC<Props> = ({ upgrade, onStatusChange, showActions = t
   const navigate = useNavigate();
 
   return (
-    <div className="bg-white rounded-xl border border-gray-200 p-4 shadow-sm hover:shadow-md transition-shadow">
+    <div className="bg-surface rounded-xl border border-line p-4 shadow-sm hover:shadow-md transition-shadow">
       <div className="flex items-start justify-between gap-2">
         <div className="flex-1 min-w-0">
           <h3
-            className="font-semibold text-gray-900 truncate cursor-pointer hover:text-blue-600"
+            className="font-semibold text-fg truncate cursor-pointer hover:text-brand-fg"
             onClick={() => navigate(`/upgrades/${upgrade.id}`)}
           >
             {upgrade.title}
           </h3>
           {upgrade.description && (
-            <p className="text-sm text-gray-500 mt-1 line-clamp-2">{upgrade.description}</p>
+            <p className="text-sm text-fg-subtle mt-1 line-clamp-2">{upgrade.description}</p>
           )}
         </div>
       </div>
       <div className="flex flex-wrap gap-2 mt-3">
         <UpgradeStatusBadge status={upgrade.status} />
         <UpgradeTypeBadge type={upgrade.type} />
-        <Badge variant={difficultyVariant[upgrade.difficulty] ?? 'gray'}>{upgrade.difficulty}</Badge>
+        <Badge variant={difficultyVariant[upgrade.difficulty] ?? UNKNOWN_DIFFICULTY_VARIANT}>{upgrade.difficulty}</Badge>
       </div>
       {showActions && onStatusChange && (
-        <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t border-gray-100">
+        <div className="flex flex-wrap gap-2 mt-3 pt-3 border-t border-line-subtle">
           {upgrade.status === 'IDEA' && (
             <Button size="sm" variant="secondary" onClick={() => onStatusChange(upgrade.id, 'PLANNED')}>
               Plan

--- a/frontend/src/components/upgrade/upgradeMeta.ts
+++ b/frontend/src/components/upgrade/upgradeMeta.ts
@@ -1,0 +1,17 @@
+import type { BadgeVariant } from '../ui/Badge';
+
+/**
+ * Difficulty to badge colour: green through red, so HARD reads as the demanding one.
+ *
+ * Shared rather than duplicated: the upgrade card and the upgrade details page both render this badge,
+ * and they disagreed — the card used this map and the details page an inline ternary whose final branch
+ * fell through to red for any unknown value.
+ */
+export const difficultyVariant: Record<string, BadgeVariant> = {
+  EASY: 'green',
+  MEDIUM: 'yellow',
+  HARD: 'red',
+};
+
+/** The variant for an unrecognised difficulty. Grey says "no opinion" rather than mislabelling it HARD. */
+export const UNKNOWN_DIFFICULTY_VARIANT: BadgeVariant = 'gray';

--- a/frontend/src/components/upgrade/upgradeMeta.ts
+++ b/frontend/src/components/upgrade/upgradeMeta.ts
@@ -1,4 +1,5 @@
 import type { BadgeVariant } from '../ui/Badge';
+import type { Difficulty } from '../../types';
 
 /**
  * Difficulty to badge colour: green through red, so HARD reads as the demanding one.
@@ -6,12 +7,20 @@ import type { BadgeVariant } from '../ui/Badge';
  * Shared rather than duplicated: the upgrade card and the upgrade details page both render this badge,
  * and they disagreed — the card used this map and the details page an inline ternary whose final branch
  * fell through to red for any unknown value.
+ *
+ * Keyed on `Difficulty` rather than `string` so adding a difficulty to the union fails the build here
+ * instead of rendering a colourless badge.
  */
-export const difficultyVariant: Record<string, BadgeVariant> = {
+export const difficultyVariant: Record<Difficulty, BadgeVariant> = {
   EASY: 'green',
   MEDIUM: 'yellow',
   HARD: 'red',
 };
 
-/** The variant for an unrecognised difficulty. Grey says "no opinion" rather than mislabelling it HARD. */
+/**
+ * The variant for an unrecognised difficulty. Grey says "no opinion" rather than mislabelling it HARD.
+ *
+ * Callers still need this despite the map above being total: `difficulty` arrives as unvalidated JSON
+ * from the API, so its static type is a claim about the backend rather than a fact about the value.
+ */
 export const UNKNOWN_DIFFICULTY_VARIANT: BadgeVariant = 'gray';

--- a/frontend/src/contexts/ThemeProvider.test.tsx
+++ b/frontend/src/contexts/ThemeProvider.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { ThemeProvider } from './ThemeProvider';
+import { useTheme } from '../hooks/useTheme';
+import { installMatchMedia, uninstallMatchMedia } from '../test/matchMediaStub';
+
+/** Renders the context's current values, so a test can assert on what a consumer would actually see. */
+const ThemeReadout: React.FC = () => {
+  const { theme, resolvedTheme } = useTheme();
+  return (
+    <>
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="resolved">{resolvedTheme}</span>
+    </>
+  );
+};
+
+/** A button that switches the theme, so the setter is exercised the way the toggle uses it. */
+const SetThemeButton: React.FC<{ to: 'light' | 'dark' | 'system' }> = ({ to }) => {
+  const { setTheme } = useTheme();
+  return (
+    <button type="button" onClick={() => setTheme(to)}>
+      set {to}
+    </button>
+  );
+};
+
+const renderProvider = (children: React.ReactNode = <ThemeReadout />) =>
+  render(<ThemeProvider>{children}</ThemeProvider>);
+
+const isDark = () => document.documentElement.classList.contains('dark');
+
+describe('ThemeProvider', () => {
+  describe('resolving the initial theme', () => {
+    it('GivenNoStoredTheme_WhenTheProviderMounts_ThenTheThemeIsSystem', () => {
+      renderProvider();
+
+      expect(screen.getByTestId('theme').textContent).toBe('system');
+    });
+
+    it('GivenAnUnrecognisedStoredValue_WhenTheProviderMounts_ThenTheThemeIsSystem', () => {
+      localStorage.setItem('theme', 'auto');
+
+      renderProvider();
+
+      expect(screen.getByTestId('theme').textContent).toBe('system');
+    });
+
+    it('GivenAStoredDarkTheme_WhenTheProviderMounts_ThenTheDarkClassIsOnTheDocumentElement', () => {
+      localStorage.setItem('theme', 'dark');
+
+      renderProvider();
+
+      expect(isDark()).toBe(true);
+    });
+
+    it('GivenAStoredLightTheme_WhenTheSystemPrefersDark_ThenTheDarkClassIsAbsent', () => {
+      localStorage.setItem('theme', 'light');
+      installMatchMedia(true);
+
+      renderProvider();
+
+      expect(isDark()).toBe(false);
+    });
+
+    it('GivenTheSystemTheme_WhenTheSystemPrefersDark_ThenTheResolvedThemeIsDark', () => {
+      installMatchMedia(true);
+
+      renderProvider();
+
+      expect(screen.getByTestId('resolved').textContent).toBe('dark');
+      expect(isDark()).toBe(true);
+    });
+  });
+
+  describe('following the system preference', () => {
+    it('GivenTheSystemTheme_WhenTheSystemPreferenceChangesToDark_ThenTheDarkClassIsAdded', () => {
+      const media = installMatchMedia(false);
+      renderProvider();
+      expect(isDark()).toBe(false);
+
+      act(() => media.setMatches(true));
+
+      expect(isDark()).toBe(true);
+    });
+
+    it('GivenTheSystemTheme_WhenTheSystemPreferenceChangesBackToLight_ThenTheDarkClassIsRemoved', () => {
+      const media = installMatchMedia(true);
+      renderProvider();
+      expect(isDark()).toBe(true);
+
+      act(() => media.setMatches(false));
+
+      expect(isDark()).toBe(false);
+    });
+
+    it('GivenAnExplicitLightTheme_WhenTheSystemPreferenceChangesToDark_ThenTheDarkClassIsStillAbsent', () => {
+      localStorage.setItem('theme', 'light');
+      const media = installMatchMedia(false);
+      renderProvider();
+
+      act(() => media.setMatches(true));
+
+      expect(isDark()).toBe(false);
+    });
+  });
+
+  describe('changing and persisting the theme', () => {
+    it('GivenAnyTheme_WhenSetThemeIsCalled_ThenTheChoiceIsWrittenToLocalStorage', () => {
+      renderProvider(<SetThemeButton to="dark" />);
+
+      act(() => screen.getByRole('button').click());
+
+      expect(localStorage.getItem('theme')).toBe('dark');
+      expect(isDark()).toBe(true);
+    });
+
+    it('GivenAnExplicitTheme_WhenSetThemeIsCalledWithSystem_ThenTheDocumentFollowsTheSystemPreferenceAgain', () => {
+      localStorage.setItem('theme', 'light');
+      installMatchMedia(true);
+      renderProvider(<SetThemeButton to="system" />);
+      expect(isDark()).toBe(false);
+
+      act(() => screen.getByRole('button').click());
+
+      expect(isDark()).toBe(true);
+    });
+  });
+
+  describe('surviving a hostile environment', () => {
+    it('GivenLocalStorageThrowsOnRead_WhenTheProviderMounts_ThenItFallsBackToSystemWithoutThrowing', () => {
+      const getItem = Storage.prototype.getItem;
+      Storage.prototype.getItem = () => {
+        throw new Error('SecurityError: storage is disabled');
+      };
+
+      try {
+        renderProvider();
+        expect(screen.getByTestId('theme').textContent).toBe('system');
+      } finally {
+        Storage.prototype.getItem = getItem;
+      }
+    });
+
+    it('GivenLocalStorageThrowsOnWrite_WhenSetThemeIsCalled_ThenTheThemeStillChanges', () => {
+      const setItem = Storage.prototype.setItem;
+      Storage.prototype.setItem = () => {
+        throw new Error('QuotaExceededError');
+      };
+
+      try {
+        renderProvider(<SetThemeButton to="dark" />);
+        act(() => screen.getByRole('button').click());
+        expect(isDark()).toBe(true);
+      } finally {
+        Storage.prototype.setItem = setItem;
+      }
+    });
+
+    it('GivenNoMatchMediaSupport_WhenTheProviderMounts_ThenItResolvesToLight', () => {
+      uninstallMatchMedia();
+
+      renderProvider();
+
+      expect(screen.getByTestId('resolved').textContent).toBe('light');
+      expect(isDark()).toBe(false);
+    });
+  });
+
+  describe('subscription lifecycle', () => {
+    it('GivenTheProviderIsUnmounted_WhenTheSystemPreferenceChanges_ThenNoListenerRemains', () => {
+      const media = installMatchMedia(false);
+      const { unmount } = renderProvider();
+
+      unmount();
+
+      expect(media.listenerCount()).toBe(0);
+    });
+
+    it('GivenStrictMode_WhenTheProviderMounts_ThenExactlyOneMediaQueryListenerIsRegistered', () => {
+      const media = installMatchMedia(false);
+
+      render(
+        <React.StrictMode>
+          <ThemeProvider>
+            <ThemeReadout />
+          </ThemeProvider>
+        </React.StrictMode>,
+      );
+
+      expect(media.listenerCount()).toBe(1);
+    });
+
+    it('GivenStrictMode_WhenTheProviderMounts_ThenTheDarkClassIsAppliedExactlyOnce', () => {
+      localStorage.setItem('theme', 'dark');
+
+      render(
+        <React.StrictMode>
+          <ThemeProvider>
+            <ThemeReadout />
+          </ThemeProvider>
+        </React.StrictMode>,
+      );
+
+      expect(document.documentElement.className.match(/dark/g)).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/src/contexts/ThemeProvider.tsx
+++ b/frontend/src/contexts/ThemeProvider.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { ThemeContext } from './themeContextValue';
+import type { Theme } from './themeContextValue';
+
+/** Shared with the boot script in `index.html`; changing one without the other reintroduces the flash. */
+const STORAGE_KEY = 'theme';
+const DARK_QUERY = '(prefers-color-scheme: dark)';
+
+/**
+ * Reads the saved choice, treating anything unrecognised as `system`.
+ *
+ * Guarded because reading `localStorage` can throw outright rather than return null — Firefox with
+ * storage disabled raises a SecurityError on property access, as does a third-party context with site
+ * data blocked. There is no error boundary above this provider, so an unguarded read would blank the
+ * whole application rather than degrade.
+ */
+const readStoredTheme = (): Theme => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored === 'light' || stored === 'dark' ? stored : 'system';
+  } catch {
+    // Storage unavailable: fall back to following the operating system.
+    return 'system';
+  }
+};
+
+/** The dark-preference query, or null where `matchMedia` is missing (some embedded webviews). */
+const darkMediaQuery = (): MediaQueryList | null =>
+  typeof window.matchMedia === 'function' ? window.matchMedia(DARK_QUERY) : null;
+
+/**
+ * Owns the theme: the user's choice, the operating system's preference, and the `dark` class on
+ * `<html>` that the whole stylesheet keys off.
+ *
+ * Mounted outermost, above the query client, because the theme is neither server state nor tied to a
+ * session — the login page needs it as much as the dashboard does.
+ *
+ * The class is also set before React runs, by the boot script in `index.html`. That script is what
+ * prevents the flash; this provider is what keeps the class true afterwards. The two agree by
+ * construction: same key, same values, same resolution rule.
+ */
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setThemeState] = useState<Theme>(readStoredTheme);
+  const [systemPrefersDark, setSystemPrefersDark] = useState(() => darkMediaQuery()?.matches ?? false);
+
+  // `system` means "follow it", not "follow it once at boot", so the query is subscribed to rather than
+  // sampled. Under StrictMode this effect runs, tears down and runs again on mount; the removal in the
+  // cleanup is the only thing stopping that from leaving two listeners behind, which would flip the
+  // resolved theme twice per change.
+  useEffect(() => {
+    const query = darkMediaQuery();
+    if (!query) return;
+
+    // Re-read here: the preference can change between the first render and this effect, and the initial
+    // state would then be stale with no event coming to correct it.
+    setSystemPrefersDark(query.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => setSystemPrefersDark(event.matches);
+    query.addEventListener('change', handleChange);
+    return () => query.removeEventListener('change', handleChange);
+  }, []);
+
+  const resolvedTheme = theme === 'system' ? (systemPrefersDark ? 'dark' : 'light') : theme;
+
+  // The two-argument `toggle` sets the class to a value rather than flipping it, so a double invocation
+  // under StrictMode lands in the same place as a single one.
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', resolvedTheme === 'dark');
+  }, [resolvedTheme]);
+
+  /** Records the choice. The state change is deliberately not conditional on the write succeeding. */
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // Storage full or blocked. The theme still changes for this session; it just will not survive a
+      // reload, which is a better outcome than refusing to switch at all.
+    }
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>{children}</ThemeContext.Provider>
+  );
+};

--- a/frontend/src/contexts/bootScript.test.tsx
+++ b/frontend/src/contexts/bootScript.test.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from './ThemeProvider';
+import { useTheme } from '../hooks/useTheme';
+import { installMatchMedia } from '../test/matchMediaStub';
+// Vite's `?raw` rather than `node:fs`: it resolves the file the same way the build does, and it keeps
+// the app's `tsconfig.json` free of Node types — see ADR-004.
+import indexHtml from '../../index.html?raw';
+
+/**
+ * The contract between the pre-paint boot script in `index.html` and `ThemeProvider`.
+ *
+ * The theme resolution rule is implemented twice — once in inline ES5 that runs during head parse, and
+ * once in the provider that takes over on mount — because nothing else can put the class on `<html>`
+ * before the first paint. The duplication is deliberate; the two silently drifting apart is not.
+ *
+ * If they disagree, the page paints one theme and then flips to the other. That is precisely the defect
+ * the boot script exists to prevent, it is invisible to every other test in this suite, and it is
+ * invisible to a reviewer reading either file on its own. So the agreement is asserted here rather than
+ * asserted in a comment.
+ *
+ * The script is read from `index.html` and executed verbatim rather than reimplemented, because a copy
+ * of it in this file would be one more thing that can drift.
+ */
+const BOOT_SCRIPT = (() => {
+  // The classic inline script, as opposed to the module script that loads the bundle.
+  const inline = [...indexHtml.matchAll(/<script(?![^>]*\b(?:src|type)=)[^>]*>([\s\S]*?)<\/script>/g)];
+
+  if (inline.length !== 1) {
+    throw new Error(
+      `Expected exactly one classic inline script in index.html, found ${inline.length}. ` +
+        'If the boot script moved or was split, this contract test needs to follow it.',
+    );
+  }
+
+  return inline[0][1];
+})();
+
+/**
+ * Runs the shipped boot script against the current window.
+ *
+ * `new Function` rather than a jsdom `<script>` insertion: it keeps execution synchronous and in this
+ * realm, so the stubbed `matchMedia` and `localStorage` are the ones the script sees.
+ *
+ * The usual objection to `new Function` does not apply. Nothing is interpolated into the body — it is
+ * the literal contents of a version-controlled file in this repository, read whole, and executing it
+ * unaltered is the entire point: a reimplementation here could drift from the shipped script exactly
+ * the way the shipped script can drift from the provider, which is the drift this file exists to catch.
+ */
+const runBootScript = () => {
+  new Function(BOOT_SCRIPT)();
+};
+
+const isDark = () => document.documentElement.classList.contains('dark');
+
+const clearTheClass = () => {
+  document.documentElement.className = '';
+};
+
+/** A button that switches the theme, so the provider persists through its real code path. */
+const SetThemeButton: React.FC<{ to: 'light' | 'dark' | 'system' }> = ({ to }) => {
+  const { setTheme } = useTheme();
+  return (
+    <button type="button" onClick={() => setTheme(to)}>
+      set {to}
+    </button>
+  );
+};
+
+/**
+ * Every combination of stored choice and operating-system preference that reaches the resolution rule,
+ * including the two malformed cases — because "anything unrecognised means system" is part of the rule
+ * and is written out separately in each implementation.
+ */
+const scenarios: { stored: string | null; systemDark: boolean; expectedDark: boolean }[] = [
+  { stored: null, systemDark: false, expectedDark: false },
+  { stored: null, systemDark: true, expectedDark: true },
+  { stored: 'light', systemDark: false, expectedDark: false },
+  { stored: 'light', systemDark: true, expectedDark: false },
+  { stored: 'dark', systemDark: false, expectedDark: true },
+  { stored: 'dark', systemDark: true, expectedDark: true },
+  { stored: 'system', systemDark: false, expectedDark: false },
+  { stored: 'system', systemDark: true, expectedDark: true },
+  { stored: 'auto', systemDark: true, expectedDark: true },
+  { stored: '', systemDark: false, expectedDark: false },
+];
+
+const seed = (stored: string | null, systemDark: boolean) => {
+  localStorage.clear();
+  if (stored !== null) localStorage.setItem('theme', stored);
+  installMatchMedia(systemDark);
+  clearTheClass();
+};
+
+describe('the boot script and ThemeProvider agree', () => {
+  it('GivenAnyStoredChoiceAndSystemPreference_WhenTheBootScriptRuns_ThenItResolvesTheThemeTheProviderWould', () => {
+    for (const { stored, systemDark, expectedDark } of scenarios) {
+      const describeCase = `stored=${JSON.stringify(stored)} systemDark=${systemDark}`;
+
+      seed(stored, systemDark);
+      runBootScript();
+      const bootResult = isDark();
+
+      seed(stored, systemDark);
+      render(<ThemeProvider>{null}</ThemeProvider>);
+      const providerResult = isDark();
+      cleanup();
+
+      expect(`${describeCase} -> boot:${bootResult}`).toBe(`${describeCase} -> boot:${expectedDark}`);
+      expect(`${describeCase} -> provider:${providerResult}`).toBe(
+        `${describeCase} -> provider:${expectedDark}`,
+      );
+    }
+  });
+
+  /**
+   * Binds the two to the same storage key without naming it twice.
+   *
+   * The provider writes through its own setter and the script reads on the next load, so renaming
+   * `STORAGE_KEY` in one place fails here instead of quietly reintroducing the flash.
+   */
+  it('GivenTheProviderPersistedAChoice_WhenTheBootScriptRunsOnTheNextLoad_ThenItReadsThatChoice', () => {
+    installMatchMedia(false);
+    render(
+      <ThemeProvider>
+        <SetThemeButton to="dark" />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'set dark' }));
+    expect(isDark()).toBe(true);
+
+    cleanup();
+    clearTheClass();
+    runBootScript();
+
+    expect(isDark()).toBe(true);
+  });
+
+  it('GivenTheProviderPersistedLightAgainstADarkSystem_WhenTheBootScriptRuns_ThenTheChoiceStillWins', () => {
+    installMatchMedia(true);
+    render(
+      <ThemeProvider>
+        <SetThemeButton to="light" />
+      </ThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'set light' }));
+
+    cleanup();
+    clearTheClass();
+    runBootScript();
+
+    expect(isDark()).toBe(false);
+  });
+
+  /**
+   * The script has to survive storage being unreadable, because it runs before React and there is no
+   * error boundary that early — an exception here leaves the page with no application at all.
+   */
+  it('GivenLocalStorageThrowsOnRead_WhenTheBootScriptRuns_ThenItBootsLightWithoutThrowing', () => {
+    installMatchMedia(false);
+    clearTheClass();
+    const getItem = Storage.prototype.getItem;
+    Storage.prototype.getItem = () => {
+      throw new Error('SecurityError: storage is blocked');
+    };
+
+    try {
+      expect(() => runBootScript()).not.toThrow();
+      expect(isDark()).toBe(false);
+    } finally {
+      Storage.prototype.getItem = getItem;
+    }
+  });
+});

--- a/frontend/src/contexts/themeContextValue.ts
+++ b/frontend/src/contexts/themeContextValue.ts
@@ -1,0 +1,29 @@
+import { createContext } from 'react';
+
+/**
+ * The three states the user can choose between.
+ *
+ * `system` is not a snapshot of the operating system's preference taken at boot — it is a standing
+ * instruction to follow it, including while the tab is open.
+ */
+export type Theme = 'light' | 'dark' | 'system';
+
+/**
+ * What the theme context exposes: the user's choice, what that choice currently resolves to, and the
+ * setter that persists it.
+ *
+ * `theme` and `resolvedTheme` are both needed and are not interchangeable. Anything rendering the
+ * *choice* must read `theme`, or selecting "System" would light up "Dark"; anything rendering the
+ * *effect* must read `resolvedTheme`.
+ */
+export interface ThemeContextType {
+  theme: Theme;
+  resolvedTheme: 'light' | 'dark';
+  setTheme: (theme: Theme) => void;
+}
+
+/**
+ * The context object itself, kept in its own module so the file holding the provider component exports
+ * only components — which is what lets React Fast Refresh work on it.
+ */
+export const ThemeContext = createContext<ThemeContextType | null>(null);

--- a/frontend/src/hooks/useTheme.test.tsx
+++ b/frontend/src/hooks/useTheme.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { useTheme } from './useTheme';
+
+const Consumer: React.FC = () => {
+  useTheme();
+  return null;
+};
+
+describe('useTheme', () => {
+  it('GivenNoProvider_WhenUseThemeIsCalled_ThenItThrowsAGuidingError', () => {
+    // React logs the error boundary trace to the console before rethrowing; silenced so a deliberate
+    // failure does not look like a broken test run.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      expect(() => render(<Consumer />)).toThrowError('useTheme must be used within ThemeProvider');
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+import { ThemeContext } from '../contexts/themeContextValue';
+
+/**
+ * Reads the theme context: the chosen theme, what it resolves to now, and the setter.
+ *
+ * @throws Error when called outside `ThemeProvider` — a null context would otherwise surface much later
+ * as an unexplained "cannot read property of null" inside a component.
+ */
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,191 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/**
+ * The theme's single source of truth.
+ *
+ * Values are space-separated RGB channels rather than hex so Tailwind can compose an alpha onto them —
+ * see the `<alpha-value>` pattern in `tailwind.config.js`.
+ *
+ * Every foreground/background pair used in the app was checked against WCAG AA: 4.5:1 for text, 3:1 for
+ * control boundaries and graphical state. The worst text pair is 4.63:1 and the worst non-text pair is
+ * 3.29:1. `line` and `line-subtle` are deliberate exceptions — a card's outline and a list's divider
+ * identify no component or state, and forcing 3:1 there would put a mid-grey box round every panel.
+ *
+ * `.dark` is put on `<html>` by the boot script in `index.html` before first paint, and kept in step
+ * afterwards by `ThemeProvider`.
+ */
+@layer base {
+  :root {
+    color-scheme: light;
+
+    --color-canvas: 249 250 251;
+    --color-surface: 255 255 255;
+    --color-sunken: 249 250 251;
+    --color-muted: 243 244 246;
+    --color-muted-strong: 229 231 235;
+
+    --color-line-subtle: 239 241 244;
+    --color-line: 229 231 235;
+    --color-line-strong: 124 133 147;
+
+    --color-fg: 17 24 39;
+    --color-fg-muted: 55 65 81;
+    --color-fg-subtle: 91 100 114;
+    --color-fg-faint: 107 114 128;
+    --color-fg-inverted: 255 255 255;
+
+    --color-overlay: 17 24 39;
+    --color-focus: 29 78 216;
+
+    --color-brand: 37 99 235;
+    --color-brand-hover: 29 78 216;
+    --color-brand-soft: 239 246 255;
+    --color-brand-soft-hover: 219 234 254;
+    --color-brand-line: 147 197 253;
+    --color-brand-fg: 29 78 216;
+
+    --color-success: 21 128 61;
+    --color-success-soft: 240 253 244;
+    --color-success-line: 134 239 172;
+    --color-success-fg: 21 128 61;
+
+    --color-warning-soft: 255 251 235;
+    --color-warning-line: 252 211 77;
+    --color-warning-fg: 146 64 14;
+
+    --color-danger: 220 38 38;
+    --color-danger-hover: 185 28 28;
+    --color-danger-soft: 254 242 242;
+    --color-danger-line: 252 165 165;
+    --color-danger-fg: 185 28 28;
+
+    --color-info-soft: 236 254 255;
+    --color-info-line: 103 232 249;
+    --color-info-fg: 21 94 117;
+
+    --color-reminder-soft: 245 243 255;
+    --color-reminder-line: 196 181 253;
+    --color-reminder-fg: 109 40 217;
+
+    --color-streak-soft: 255 247 237;
+    --color-streak-line: 253 186 116;
+    --color-streak-fg: 194 65 12;
+
+    --color-accent-soft: 224 231 255;
+    --color-accent-fg: 79 70 229;
+
+    --color-tint-green-soft: 220 252 231;
+    --color-tint-green-fg: 22 101 52;
+    --color-tint-yellow-soft: 254 249 195;
+    --color-tint-yellow-fg: 133 77 14;
+    --color-tint-blue-soft: 219 234 254;
+    --color-tint-blue-fg: 30 64 175;
+    --color-tint-red-soft: 254 226 226;
+    --color-tint-red-fg: 153 27 27;
+    --color-tint-purple-soft: 243 232 255;
+    --color-tint-purple-fg: 107 33 168;
+  }
+
+  .dark {
+    /*
+     * Tells the browser to render its own chrome dark: the native `<select>` popup that `Select.tsx`
+     * relies on, number-input spinners, scrollbars and the default caret. Nothing in CSS can reach
+     * those, so without this they stay light on a dark page.
+     */
+    color-scheme: dark;
+
+    --color-canvas: 13 16 21;
+    --color-surface: 23 27 34;
+    --color-sunken: 33 38 48;
+    --color-muted: 43 49 59;
+    --color-muted-strong: 58 65 77;
+
+    --color-line-subtle: 37 43 52;
+    --color-line: 51 58 69;
+    --color-line-strong: 107 118 134;
+
+    --color-fg: 242 244 247;
+    --color-fg-muted: 199 205 216;
+    --color-fg-subtle: 154 164 178;
+    --color-fg-faint: 138 148 163;
+    --color-fg-inverted: 255 255 255;
+
+    --color-overlay: 0 0 0;
+    --color-focus: 147 197 253;
+
+    --color-brand: 37 99 235;
+    --color-brand-hover: 29 78 216;
+    --color-brand-soft: 23 38 63;
+    --color-brand-soft-hover: 30 49 84;
+    --color-brand-line: 44 76 130;
+    --color-brand-fg: 147 197 253;
+
+    --color-success: 34 197 94;
+    --color-success-soft: 16 46 30;
+    --color-success-line: 33 107 65;
+    --color-success-fg: 110 231 160;
+
+    --color-warning-soft: 51 38 10;
+    --color-warning-line: 124 90 22;
+    --color-warning-fg: 252 211 77;
+
+    --color-danger: 220 38 38;
+    --color-danger-hover: 185 28 28;
+    --color-danger-soft: 58 24 28;
+    --color-danger-line: 127 42 42;
+    --color-danger-fg: 252 165 165;
+
+    --color-info-soft: 15 44 52;
+    --color-info-line: 23 98 122;
+    --color-info-fg: 103 232 249;
+
+    --color-reminder-soft: 36 30 64;
+    --color-reminder-line: 76 61 147;
+    --color-reminder-fg: 196 181 253;
+
+    --color-streak-soft: 51 33 14;
+    --color-streak-line: 138 78 27;
+    --color-streak-fg: 253 186 116;
+
+    --color-accent-soft: 35 40 88;
+    --color-accent-fg: 165 180 252;
+
+    --color-tint-green-soft: 20 48 31;
+    --color-tint-green-fg: 134 239 172;
+    --color-tint-yellow-soft: 51 42 11;
+    --color-tint-yellow-fg: 253 224 71;
+    --color-tint-blue-soft: 23 38 63;
+    --color-tint-blue-fg: 147 197 253;
+    --color-tint-red-soft: 58 24 28;
+    --color-tint-red-fg: 252 165 165;
+    --color-tint-purple-soft: 42 30 66;
+    --color-tint-purple-fg: 216 180 254;
+  }
+
+  /*
+   * On `html` rather than `body`: this is what the browser paints for overscroll, and for the frame
+   * between the boot script running and React mounting, so nothing flashes white.
+   */
+  html {
+    background-color: rgb(var(--color-canvas));
+  }
+
+  body {
+    color: rgb(var(--color-fg));
+  }
+
+  /* Preflight hard-codes gray-400 here, which is 2.54:1 on white — below AA for text. */
+  ::placeholder {
+    color: rgb(var(--color-fg-faint));
+    opacity: 1;
+  }
+
+  /* The toasts animate in; someone who has asked for less motion should still see them appear. */
+  @media (prefers-reduced-motion: reduce) {
+    .animate-fade-in {
+      animation: none;
+    }
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -182,10 +182,18 @@
     opacity: 1;
   }
 
-  /* The toasts animate in; someone who has asked for less motion should still see them appear. */
-  @media (prefers-reduced-motion: reduce) {
-    .animate-fade-in {
-      animation: none;
-    }
+}
+
+/*
+ * The toasts animate in; someone who has asked for less motion should still see them appear.
+ *
+ * Deliberately outside `@layer base`. Tailwind emits base before utilities and both selectors are
+ * specificity (0,1,0), so the same rule inside the base layer loses to the `animate-fade-in` utility on
+ * source order and silently does nothing. Unlayered CSS outranks every Tailwind layer, so this wins
+ * where it belongs and needs no `!important`.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in {
+    animation: none;
   }
 }

--- a/frontend/src/pages/ActiveUpgradesPage.tsx
+++ b/frontend/src/pages/ActiveUpgradesPage.tsx
@@ -8,6 +8,7 @@ import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import UpgradeCard from '../components/upgrade/UpgradeCard';
 import type { UpgradeStatus } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /**
  * The upgrades currently running, with the transitions available from `ACTIVE`.
@@ -29,7 +30,7 @@ const ActiveUpgradesPage: React.FC = () => {
   if (error) return <p className="text-danger-fg text-center py-10">Failed to load upgrades.</p>;
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <PageContainer>
       <PageHeader
         title="Active Upgrades"
         subtitle="Upgrades you are currently working on"
@@ -48,7 +49,7 @@ const ActiveUpgradesPage: React.FC = () => {
           ))}
         </div>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/ActiveUpgradesPage.tsx
+++ b/frontend/src/pages/ActiveUpgradesPage.tsx
@@ -39,7 +39,7 @@ const ActiveUpgradesPage: React.FC = () => {
       {upgrades.length === 0 ? (
         <EmptyState icon="🔥" title="No active upgrades" description="Activate a planned upgrade to start tracking progress." action={<Button onClick={() => navigate('/upgrades/planned')}>View Planned</Button>} />
       ) : (
-        <div className="grid sm:grid-cols-2 gap-4">
+        <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
           {upgrades.map((u) => (
             <UpgradeCard
               key={u.id}

--- a/frontend/src/pages/ActiveUpgradesPage.tsx
+++ b/frontend/src/pages/ActiveUpgradesPage.tsx
@@ -26,7 +26,7 @@ const ActiveUpgradesPage: React.FC = () => {
   });
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-red-500 text-center py-10">Failed to load upgrades.</p>;
+  if (error) return <p className="text-danger-fg text-center py-10">Failed to load upgrades.</p>;
 
   return (
     <div className="max-w-4xl mx-auto">

--- a/frontend/src/pages/DailyCheckinPage.tsx
+++ b/frontend/src/pages/DailyCheckinPage.tsx
@@ -74,8 +74,8 @@ const DailyCheckinPage: React.FC = () => {
     return (
       <div className="max-w-xl mx-auto text-center py-20">
         <div className="text-6xl mb-4">🎉</div>
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">Check-in Complete!</h2>
-        <p className="text-gray-500 mb-6">Great job tracking your upgrades today.</p>
+        <h2 className="text-2xl font-bold text-fg mb-2">Check-in Complete!</h2>
+        <p className="text-fg-subtle mb-6">Great job tracking your upgrades today.</p>
         <Button onClick={() => navigate('/dashboard')}>Back to Dashboard</Button>
       </div>
     );
@@ -91,7 +91,7 @@ const DailyCheckinPage: React.FC = () => {
         <form onSubmit={handleSubmit} className="space-y-4">
           {upgrades.map((u: HealthUpgrade) => (
             <Card key={u.id} header={u.title}>
-              {u.description && <p className="text-sm text-gray-500 mb-3">{u.description}</p>}
+              {u.description && <p className="text-sm text-fg-subtle mb-3">{u.description}</p>}
 
               {trackingType(u) === 'BOOLEAN' && (
                 <label className="flex items-center gap-3 cursor-pointer">
@@ -109,12 +109,12 @@ const DailyCheckinPage: React.FC = () => {
                 <div className="flex items-center gap-2">
                   <input
                     type="number"
-                    className="rounded-lg border border-gray-300 px-3 py-2 text-sm w-28 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="rounded-lg border border-line-strong px-3 py-2 text-sm w-28 focus:outline-none focus:ring-2"
                     placeholder="0"
                     value={progressMap[u.id]?.numericValue ?? ''}
                     onChange={(e) => updateProgress(u.id, { numericValue: numOrUndef(e.target.value) })}
                   />
-                  <span className="text-sm text-gray-500">{u.trackingConfig?.targetUnit ?? ''}</span>
+                  <span className="text-sm text-fg-subtle">{u.trackingConfig?.targetUnit ?? ''}</span>
                 </div>
               )}
 
@@ -125,7 +125,7 @@ const DailyCheckinPage: React.FC = () => {
                       key={n}
                       type="button"
                       onClick={() => updateProgress(u.id, { rating: n })}
-                      className={`w-10 h-10 rounded-full text-sm font-semibold transition-colors ${progressMap[u.id]?.rating === n ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}
+                      className={`w-10 h-10 rounded-full text-sm font-semibold transition-colors ${progressMap[u.id]?.rating === n ? 'bg-brand text-fg-inverted' : 'bg-muted text-fg-muted hover:bg-muted-strong'}`}
                     >
                       {n}
                     </button>
@@ -135,7 +135,7 @@ const DailyCheckinPage: React.FC = () => {
 
               {trackingType(u) === 'TEXT' && (
                 <textarea
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="w-full rounded-lg border border-line-strong px-3 py-2 text-sm focus:outline-none focus:ring-2"
                   rows={2}
                   placeholder="Add your note..."
                   value={progressMap[u.id]?.note ?? ''}
@@ -146,7 +146,7 @@ const DailyCheckinPage: React.FC = () => {
               {trackingType(u) !== 'TEXT' && (
                 <input
                   type="text"
-                  className="mt-3 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-600 focus:outline-none focus:ring-1 focus:ring-gray-400"
+                  className="mt-3 w-full rounded-lg border border-line px-3 py-2 text-sm text-fg-subtle focus:outline-none focus:ring-1"
                   placeholder="Optional note..."
                   value={progressMap[u.id]?.note ?? ''}
                   onChange={(e) => updateProgress(u.id, { note: e.target.value })}

--- a/frontend/src/pages/DailyCheckinPage.tsx
+++ b/frontend/src/pages/DailyCheckinPage.tsx
@@ -9,6 +9,7 @@ import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import { useNavigate } from 'react-router-dom';
 import type { HealthUpgrade, CreateProgressRequest } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /** Draft entries being filled in, keyed by upgrade id, until the whole form is submitted. */
 type ProgressMap = Record<string, Partial<CreateProgressRequest>>;
@@ -82,7 +83,7 @@ const DailyCheckinPage: React.FC = () => {
   }
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <PageContainer width="narrow">
       <PageHeader title="Daily Check-in" subtitle={`Today: ${new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}`} />
 
       {upgrades.length === 0 ? (
@@ -160,7 +161,7 @@ const DailyCheckinPage: React.FC = () => {
           </Button>
         </form>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/DailyCheckinPage.tsx
+++ b/frontend/src/pages/DailyCheckinPage.tsx
@@ -73,12 +73,12 @@ const DailyCheckinPage: React.FC = () => {
 
   if (submitted) {
     return (
-      <div className="max-w-xl mx-auto text-center py-20">
+      <PageContainer width="narrow" className="text-center py-20">
         <div className="text-6xl mb-4">🎉</div>
         <h2 className="text-2xl font-bold text-fg mb-2">Check-in Complete!</h2>
         <p className="text-fg-subtle mb-6">Great job tracking your upgrades today.</p>
         <Button onClick={() => navigate('/dashboard')}>Back to Dashboard</Button>
-      </div>
+      </PageContainer>
     );
   }
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ import UpgradeCard from '../components/upgrade/UpgradeCard';
 import EmptyState from '../components/ui/EmptyState';
 import { performUpgradeAction } from '../api/upgrades';
 import type { UpgradeStatus } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /**
  * Landing page after sign-in: counts, the weekly rate, streaks, overdue warnings and today's upgrades.
@@ -41,16 +42,16 @@ const DashboardPage: React.FC = () => {
   const streakEntries = Object.entries(data?.streaks ?? {});
 
   return (
-    <div className="max-w-6xl mx-auto space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
+    <PageContainer className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="min-w-0">
           <h1 className="text-2xl font-bold text-fg">
             Good {new Date().getHours() < 12 ? 'morning' : new Date().getHours() < 18 ? 'afternoon' : 'evening'},{' '}
             {user?.name?.split(' ')[0]} 👋
           </h1>
           <p className="text-fg-subtle mt-1">{new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}</p>
         </div>
-        <Button onClick={() => navigate('/upgrades/backlog')}>+ Add Upgrade</Button>
+        <Button className="shrink-0" onClick={() => navigate('/upgrades/backlog')}>+ Add Upgrade</Button>
       </div>
 
       {(data?.overdueUpgrades?.length ?? 0) > 0 && (
@@ -63,7 +64,7 @@ const DashboardPage: React.FC = () => {
         </div>
       )}
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <Card className="text-center">
           <div className="text-3xl font-bold text-brand-fg">{data?.activeUpgrades.length ?? 0}</div>
           <div className="text-sm text-fg-subtle mt-1">Active</div>
@@ -146,7 +147,7 @@ const DashboardPage: React.FC = () => {
           </div>
         </Card>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -45,7 +45,7 @@ const DashboardPage: React.FC = () => {
     <PageContainer className="space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="min-w-0">
-          <h1 className="text-2xl font-bold text-fg">
+          <h1 className="text-2xl font-bold text-fg break-words">
             Good {new Date().getHours() < 12 ? 'morning' : new Date().getHours() < 18 ? 'afternoon' : 'evening'},{' '}
             {user?.name?.split(' ')[0]} 👋
           </h1>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -34,7 +34,7 @@ const DashboardPage: React.FC = () => {
   };
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-red-500 text-center py-10">Failed to load dashboard.</p>;
+  if (error) return <p className="text-danger-fg text-center py-10">Failed to load dashboard.</p>;
 
   // Rounded, not scaled: the API sends a percentage already (see DashboardDto.weeklyCompletionRate).
   const completionPct = Math.round(data?.weeklyCompletionRate ?? 0);
@@ -44,53 +44,53 @@ const DashboardPage: React.FC = () => {
     <div className="max-w-6xl mx-auto space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">
+          <h1 className="text-2xl font-bold text-fg">
             Good {new Date().getHours() < 12 ? 'morning' : new Date().getHours() < 18 ? 'afternoon' : 'evening'},{' '}
             {user?.name?.split(' ')[0]} 👋
           </h1>
-          <p className="text-gray-500 mt-1">{new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}</p>
+          <p className="text-fg-subtle mt-1">{new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}</p>
         </div>
         <Button onClick={() => navigate('/upgrades/backlog')}>+ Add Upgrade</Button>
       </div>
 
       {(data?.overdueUpgrades?.length ?? 0) > 0 && (
-        <div className="bg-red-50 border border-red-200 rounded-xl p-4 flex items-center gap-3">
+        <div className="bg-danger-soft border border-danger-line rounded-xl p-4 flex items-center gap-3">
           <span className="text-2xl">⚠️</span>
           <div>
-            <p className="font-medium text-red-800">{data!.overdueUpgrades.length} overdue upgrade{data!.overdueUpgrades.length > 1 ? 's' : ''}</p>
-            <p className="text-sm text-red-600">Some upgrades are past their target date.</p>
+            <p className="font-medium text-danger-fg">{data!.overdueUpgrades.length} overdue upgrade{data!.overdueUpgrades.length > 1 ? 's' : ''}</p>
+            <p className="text-sm text-danger-fg">Some upgrades are past their target date.</p>
           </div>
         </div>
       )}
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <Card className="text-center">
-          <div className="text-3xl font-bold text-blue-600">{data?.activeUpgrades.length ?? 0}</div>
-          <div className="text-sm text-gray-500 mt-1">Active</div>
+          <div className="text-3xl font-bold text-brand-fg">{data?.activeUpgrades.length ?? 0}</div>
+          <div className="text-sm text-fg-subtle mt-1">Active</div>
         </Card>
         <Card className="text-center">
-          <div className="text-3xl font-bold text-indigo-600">{data?.plannedUpgrades.length ?? 0}</div>
-          <div className="text-sm text-gray-500 mt-1">Planned</div>
+          <div className="text-3xl font-bold text-accent-fg">{data?.plannedUpgrades.length ?? 0}</div>
+          <div className="text-sm text-fg-subtle mt-1">Planned</div>
         </Card>
         <Card className="text-center">
-          <div className="text-3xl font-bold text-green-600">{completionPct}%</div>
-          <div className="text-sm text-gray-500 mt-1">Weekly Rate</div>
+          <div className="text-3xl font-bold text-success-fg">{completionPct}%</div>
+          <div className="text-sm text-fg-subtle mt-1">Weekly Rate</div>
         </Card>
         <Card className="text-center">
-          <div className="text-3xl font-bold text-orange-500">{streakEntries.length}</div>
-          <div className="text-sm text-gray-500 mt-1">Streaks</div>
+          <div className="text-3xl font-bold text-streak-fg">{streakEntries.length}</div>
+          <div className="text-sm text-fg-subtle mt-1">Streaks</div>
         </Card>
       </div>
 
       <Card header="Weekly Completion Rate">
         <div className="flex items-center gap-4">
-          <div className="flex-1 bg-gray-200 rounded-full h-4 overflow-hidden">
+          <div className="flex-1 bg-muted-strong rounded-full h-4 overflow-hidden">
             <div
-              className="h-full bg-green-500 rounded-full transition-all duration-500"
+              className="h-full bg-success rounded-full transition-all duration-500"
               style={{ width: `${completionPct}%` }}
             />
           </div>
-          <span className="text-sm font-semibold text-gray-700 w-12 text-right">{completionPct}%</span>
+          <span className="text-sm font-semibold text-fg-muted w-12 text-right">{completionPct}%</span>
         </div>
       </Card>
 
@@ -125,9 +125,9 @@ const DashboardPage: React.FC = () => {
         <Card header="Current Streaks 🔥">
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
             {streakEntries.map(([id, count]) => (
-              <div key={id} className="bg-orange-50 rounded-lg p-3 text-center">
-                <div className="text-2xl font-bold text-orange-600">{count}</div>
-                <div className="text-xs text-gray-500 mt-1">days</div>
+              <div key={id} className="bg-streak-soft rounded-lg p-3 text-center">
+                <div className="text-2xl font-bold text-streak-fg">{count}</div>
+                <div className="text-xs text-fg-subtle mt-1">days</div>
               </div>
             ))}
           </div>
@@ -138,9 +138,9 @@ const DashboardPage: React.FC = () => {
         <Card header="Recently Completed 🎉">
           <div className="space-y-2">
             {data!.recentlyCompleted.map((u) => (
-              <div key={u.id} className="flex items-center gap-3 p-2 rounded-lg bg-gray-50">
-                <span className="text-green-500 text-lg">✓</span>
-                <span className="text-sm font-medium text-gray-800">{u.title}</span>
+              <div key={u.id} className="flex items-center gap-3 p-2 rounded-lg bg-sunken">
+                <span className="text-success-fg text-lg">✓</span>
+                <span className="text-sm font-medium text-fg-muted">{u.title}</span>
               </div>
             ))}
           </div>

--- a/frontend/src/pages/HealthAreasPage.tsx
+++ b/frontend/src/pages/HealthAreasPage.tsx
@@ -10,7 +10,7 @@ import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import type { CreateHealthAreaRequest, HealthArea } from '../types';
 import PageContainer from '../components/ui/PageContainer';
-import { areaIconGlyph, DEFAULT_AREA_ICON } from '../components/ui/areaIcon';
+import { areaIconGlyph, DEFAULT_AREA_ICON, isIconGlyph } from '../components/ui/areaIcon';
 
 /**
  * Manages health areas — the folders upgrades are filed under.
@@ -60,10 +60,21 @@ const HealthAreasPage: React.FC = () => {
     await updateMutation.mutateAsync({ id: editArea.id, req: form });
   };
 
-  /** Opens the edit modal pre-filled from an area; nullable fields become empty strings for the inputs. */
+  /**
+   * Opens the edit modal pre-filled from an area; nullable fields become empty strings for the inputs.
+   *
+   * A stored icon the card cannot draw arrives as empty rather than as itself. Showing `water_drop` in a
+   * field labelled "Icon (emoji)" next to a card showing the default would invite the user to press Save
+   * and write the unusable value straight back.
+   */
   const openEdit = (area: HealthArea) => {
     setEditArea(area);
-    setForm({ name: area.name, description: area.description ?? '', icon: area.icon ?? '', color: area.color ?? '' });
+    setForm({
+      name: area.name,
+      description: area.description ?? '',
+      icon: isIconGlyph(area.icon) ? (area.icon ?? '').trim() : '',
+      color: area.color ?? '',
+    });
   };
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
@@ -88,7 +99,7 @@ const HealthAreasPage: React.FC = () => {
         <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
           {areas.map((area) => (
             <Card key={area.id}>
-              <div className="flex min-w-0 items-start gap-2">
+              <div className="flex items-start gap-2">
                 <span
                   className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden text-2xl leading-none"
                   aria-hidden="true"

--- a/frontend/src/pages/HealthAreasPage.tsx
+++ b/frontend/src/pages/HealthAreasPage.tsx
@@ -65,7 +65,7 @@ const HealthAreasPage: React.FC = () => {
   };
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-red-500 text-center py-10">Failed to load health areas.</p>;
+  if (error) return <p className="text-danger-fg text-center py-10">Failed to load health areas.</p>;
 
   return (
     <div className="max-w-4xl mx-auto">
@@ -90,14 +90,14 @@ const HealthAreasPage: React.FC = () => {
                 <div className="flex items-center gap-2">
                   <span className="text-2xl">{area.icon ?? '🎯'}</span>
                   <div>
-                    <h3 className="font-semibold text-gray-900">{area.name}</h3>
+                    <h3 className="font-semibold text-fg">{area.name}</h3>
                     {area.upgradeCount !== undefined && (
-                      <p className="text-xs text-gray-500">{area.upgradeCount} upgrade{area.upgradeCount !== 1 ? 's' : ''}</p>
+                      <p className="text-xs text-fg-subtle">{area.upgradeCount} upgrade{area.upgradeCount !== 1 ? 's' : ''}</p>
                     )}
                   </div>
                 </div>
               </div>
-              {area.description && <p className="text-sm text-gray-500 mt-2">{area.description}</p>}
+              {area.description && <p className="text-sm text-fg-subtle mt-2">{area.description}</p>}
               <div className="flex gap-2 mt-4">
                 <Button size="sm" variant="secondary" onClick={() => openEdit(area)}>Edit</Button>
                 <Button size="sm" variant="danger" onClick={() => setDeleteId(area.id)}>Delete</Button>
@@ -134,7 +134,7 @@ const HealthAreasPage: React.FC = () => {
       </Modal>
 
       <Modal isOpen={!!deleteId} onClose={() => setDeleteId(null)} title="Delete Health Area">
-        <p className="text-gray-600 mb-4">Are you sure you want to delete this health area? This action cannot be undone.</p>
+        <p className="text-fg-subtle mb-4">Are you sure you want to delete this health area? This action cannot be undone.</p>
         <div className="flex gap-2 justify-end">
           <Button variant="secondary" onClick={() => setDeleteId(null)}>Cancel</Button>
           <Button variant="danger" loading={deleteMutation.isPending} onClick={() => deleteId && deleteMutation.mutate(deleteId)}>

--- a/frontend/src/pages/HealthAreasPage.tsx
+++ b/frontend/src/pages/HealthAreasPage.tsx
@@ -9,6 +9,8 @@ import Input from '../components/ui/Input';
 import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import type { CreateHealthAreaRequest, HealthArea } from '../types';
+import PageContainer from '../components/ui/PageContainer';
+import { areaIconGlyph, DEFAULT_AREA_ICON } from '../components/ui/areaIcon';
 
 /**
  * Manages health areas — the folders upgrades are filed under.
@@ -68,7 +70,7 @@ const HealthAreasPage: React.FC = () => {
   if (error) return <p className="text-danger-fg text-center py-10">Failed to load health areas.</p>;
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <PageContainer>
       <PageHeader
         title="Health Areas"
         subtitle="Organize your upgrades by health focus area"
@@ -77,28 +79,31 @@ const HealthAreasPage: React.FC = () => {
 
       {areas.length === 0 ? (
         <EmptyState
-          icon="🎯"
+          icon={DEFAULT_AREA_ICON}
           title="No health areas yet"
           description="Create areas like Sleep, Nutrition, Fitness to organize your upgrades."
           action={<Button onClick={() => setIsCreateOpen(true)}>Create Your First Area</Button>}
         />
       ) : (
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
           {areas.map((area) => (
             <Card key={area.id}>
-              <div className="flex items-start justify-between">
-                <div className="flex items-center gap-2">
-                  <span className="text-2xl">{area.icon ?? '🎯'}</span>
-                  <div>
-                    <h3 className="font-semibold text-fg">{area.name}</h3>
-                    {area.upgradeCount !== undefined && (
-                      <p className="text-xs text-fg-subtle">{area.upgradeCount} upgrade{area.upgradeCount !== 1 ? 's' : ''}</p>
-                    )}
-                  </div>
+              <div className="flex min-w-0 items-start gap-2">
+                <span
+                  className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden text-2xl leading-none"
+                  aria-hidden="true"
+                >
+                  {areaIconGlyph(area.icon)}
+                </span>
+                <div className="min-w-0">
+                  <h3 className="font-semibold text-fg break-words">{area.name}</h3>
+                  {area.upgradeCount !== undefined && (
+                    <p className="text-xs text-fg-subtle">{area.upgradeCount} upgrade{area.upgradeCount !== 1 ? 's' : ''}</p>
+                  )}
                 </div>
               </div>
-              {area.description && <p className="text-sm text-fg-subtle mt-2">{area.description}</p>}
-              <div className="flex gap-2 mt-4">
+              {area.description && <p className="text-sm text-fg-subtle mt-2 break-words">{area.description}</p>}
+              <div className="flex flex-wrap gap-2 mt-4">
                 <Button size="sm" variant="secondary" onClick={() => openEdit(area)}>Edit</Button>
                 <Button size="sm" variant="danger" onClick={() => setDeleteId(area.id)}>Delete</Button>
               </div>
@@ -142,7 +147,7 @@ const HealthAreasPage: React.FC = () => {
           </Button>
         </div>
       </Modal>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -41,12 +41,12 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-xl p-8 w-full max-w-md">
+    <div className="min-h-screen bg-gradient-to-br from-brand-soft to-accent-soft flex items-center justify-center p-4">
+      <div className="bg-surface rounded-2xl shadow-xl p-8 w-full max-w-md">
         <div className="text-center mb-8">
           <div className="text-5xl mb-3">💪</div>
-          <h1 className="text-2xl font-bold text-gray-900">UpHealther</h1>
-          <p className="text-gray-500 mt-1">Sign in to your account</p>
+          <h1 className="text-2xl font-bold text-fg">UpHealther</h1>
+          <p className="text-fg-subtle mt-1">Sign in to your account</p>
         </div>
         <form onSubmit={handleSubmit} className="space-y-4">
           <Input
@@ -65,14 +65,14 @@ const LoginPage: React.FC = () => {
             placeholder="••••••••"
             autoComplete="current-password"
           />
-          {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+          {error && <p className="text-sm text-danger-fg text-center">{error}</p>}
           <Button type="submit" loading={loading} className="w-full">
             Sign In
           </Button>
         </form>
-        <p className="text-center text-sm text-gray-500 mt-6">
+        <p className="text-center text-sm text-fg-subtle mt-6">
           Don't have an account?{' '}
-          <Link to="/register" className="text-blue-600 hover:underline font-medium">
+          <Link to="/register" className="text-brand-fg hover:underline font-medium">
             Register
           </Link>
         </p>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
+import ThemeToggle from '../components/theme/ThemeToggle';
 
 /**
  * Sign-in page, one of the two routes reachable without a session.
@@ -41,7 +42,11 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-brand-soft to-accent-soft flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-brand-soft to-accent-soft flex items-center justify-center p-4 relative">
+      {/* These pages render outside Layout, so the navbar toggle cannot reach them. */}
+      <div className="absolute top-4 right-4">
+        <ThemeToggle />
+      </div>
       <div className="bg-surface rounded-2xl shadow-xl p-8 w-full max-w-md">
         <div className="text-center mb-8">
           <div className="text-5xl mb-3">💪</div>

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -6,6 +6,7 @@ import Button from '../components/ui/Button';
 import EmptyState from '../components/ui/EmptyState';
 import NotificationItem from '../components/notifications/NotificationItem';
 import type { AppNotification } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /**
  * The full notification list, with an all/unread filter.
@@ -27,7 +28,7 @@ const NotificationsPage: React.FC = () => {
   };
 
   return (
-    <div className="max-w-3xl mx-auto">
+    <PageContainer>
       <PageHeader
         title="Notifications"
         subtitle={unreadCount > 0 ? `${unreadCount} unread` : 'You are all caught up'}
@@ -68,7 +69,7 @@ const NotificationsPage: React.FC = () => {
           ))}
         </div>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -47,7 +47,7 @@ const NotificationsPage: React.FC = () => {
             key={f}
             onClick={() => setFilter(f)}
             className={`px-3 py-1.5 rounded-lg text-sm font-medium capitalize transition-colors ${
-              filter === f ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+              filter === f ? 'bg-brand text-fg-inverted' : 'bg-muted text-fg-muted hover:bg-muted-strong'
             }`}
           >
             {f}{f === 'unread' && unreadCount > 0 ? ` (${unreadCount})` : ''}
@@ -62,7 +62,7 @@ const NotificationsPage: React.FC = () => {
           description="Updates about your upgrades, streaks, reminders and overdue items will show up here."
         />
       ) : (
-        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-100">
+        <div className="bg-surface rounded-xl border border-line shadow-sm overflow-hidden divide-y divide-line-subtle">
           {shown.map((n) => (
             <NotificationItem key={n.id} notification={n} onSelect={select} />
           ))}

--- a/frontend/src/pages/PlannedUpgradesPage.tsx
+++ b/frontend/src/pages/PlannedUpgradesPage.tsx
@@ -32,7 +32,7 @@ const PlannedUpgradesPage: React.FC = () => {
   });
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-red-500 text-center py-10">Failed to load upgrades.</p>;
+  if (error) return <p className="text-danger-fg text-center py-10">Failed to load upgrades.</p>;
 
   return (
     <div className="max-w-4xl mx-auto">
@@ -48,7 +48,7 @@ const PlannedUpgradesPage: React.FC = () => {
           {sorted.map((u) => (
             <div key={u.id}>
               {u.plannedStartDate && (
-                <p className="text-xs text-gray-400 mb-1 ml-1">
+                <p className="text-xs text-fg-faint mb-1 ml-1">
                   Starts: {new Date(u.plannedStartDate).toLocaleDateString()}
                 </p>
               )}

--- a/frontend/src/pages/PlannedUpgradesPage.tsx
+++ b/frontend/src/pages/PlannedUpgradesPage.tsx
@@ -8,6 +8,7 @@ import UpgradeCard from '../components/upgrade/UpgradeCard';
 import Button from '../components/ui/Button';
 import { useNavigate } from 'react-router-dom';
 import type { UpgradeStatus } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /**
  * Upgrades committed to a start date but not yet running, soonest first.
@@ -35,7 +36,7 @@ const PlannedUpgradesPage: React.FC = () => {
   if (error) return <p className="text-danger-fg text-center py-10">Failed to load upgrades.</p>;
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <PageContainer>
       <PageHeader
         title="Planned Upgrades"
         subtitle="Upgrades scheduled to start soon"
@@ -57,7 +58,7 @@ const PlannedUpgradesPage: React.FC = () => {
           ))}
         </div>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/PlannedUpgradesPage.tsx
+++ b/frontend/src/pages/PlannedUpgradesPage.tsx
@@ -45,7 +45,7 @@ const PlannedUpgradesPage: React.FC = () => {
       {sorted.length === 0 ? (
         <EmptyState icon="📅" title="No planned upgrades" description="Move ideas from backlog to plan, or create a new upgrade." action={<Button onClick={() => navigate('/upgrades/backlog')}>Go to Backlog</Button>} />
       ) : (
-        <div className="grid sm:grid-cols-2 gap-4">
+        <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
           {sorted.map((u) => (
             <div key={u.id}>
               {u.plannedStartDate && (

--- a/frontend/src/pages/ProgressHistoryPage.tsx
+++ b/frontend/src/pages/ProgressHistoryPage.tsx
@@ -26,7 +26,7 @@ const ProgressHistoryPage: React.FC = () => {
   const sorted = [...progress].sort((a: ProgressEntry, b: ProgressEntry) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   if (pLoading || uLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (pError || uError) return <p className="text-red-500 text-center py-10">Failed to load progress history.</p>;
+  if (pError || uError) return <p className="text-danger-fg text-center py-10">Failed to load progress history.</p>;
 
   return (
     <div className="max-w-3xl mx-auto">
@@ -39,23 +39,23 @@ const ProgressHistoryPage: React.FC = () => {
             {sorted.map((entry) => {
               const upgrade = upgradeMap[entry.upgradeId];
               return (
-                <div key={entry.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg text-sm">
+                <div key={entry.id} className="flex items-center justify-between p-3 bg-sunken rounded-lg text-sm">
                   <div className="flex-1 min-w-0">
-                    <p className="font-medium text-gray-900 truncate">{upgrade?.title ?? 'Unknown Upgrade'}</p>
-                    <p className="text-gray-400 text-xs">{new Date(entry.date).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}</p>
+                    <p className="font-medium text-fg truncate">{upgrade?.title ?? 'Unknown Upgrade'}</p>
+                    <p className="text-fg-faint text-xs">{new Date(entry.date).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}</p>
                   </div>
                   <div className="flex items-center gap-2 ml-4">
                     {entry.completed !== undefined && (
                       <Badge variant={entry.completed ? 'green' : 'red'}>{entry.completed ? '✓ Done' : '✗ Missed'}</Badge>
                     )}
                     {entry.numericValue !== undefined && (
-                      <span className="font-semibold text-gray-700">{entry.numericValue} {entry.unit}</span>
+                      <span className="font-semibold text-fg-muted">{entry.numericValue} {entry.unit}</span>
                     )}
                     {entry.rating !== undefined && (
-                      <span className="text-yellow-500">{'⭐'.repeat(entry.rating)}</span>
+                      <span>{'⭐'.repeat(entry.rating)}</span>
                     )}
                     {entry.note && (
-                      <span className="text-gray-400 italic truncate max-w-32">{entry.note}</span>
+                      <span className="text-fg-faint italic truncate max-w-32">{entry.note}</span>
                     )}
                   </div>
                 </div>

--- a/frontend/src/pages/ProgressHistoryPage.tsx
+++ b/frontend/src/pages/ProgressHistoryPage.tsx
@@ -8,6 +8,7 @@ import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import Badge from '../components/ui/Badge';
 import type { ProgressEntry, HealthUpgrade } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /**
  * The last seven days of progress across every upgrade, newest first.
@@ -29,7 +30,7 @@ const ProgressHistoryPage: React.FC = () => {
   if (pError || uError) return <p className="text-danger-fg text-center py-10">Failed to load progress history.</p>;
 
   return (
-    <div className="max-w-3xl mx-auto">
+    <PageContainer>
       <PageHeader title="Progress History" subtitle="Your progress entries from the last 7 days" />
       {sorted.length === 0 ? (
         <EmptyState icon="📈" title="No progress logged yet" description="Log progress on your active upgrades to see history here." />
@@ -64,7 +65,7 @@ const ProgressHistoryPage: React.FC = () => {
           </div>
         </Card>
       )}
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -45,12 +45,12 @@ const RegisterPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-xl p-8 w-full max-w-md">
+    <div className="min-h-screen bg-gradient-to-br from-brand-soft to-accent-soft flex items-center justify-center p-4">
+      <div className="bg-surface rounded-2xl shadow-xl p-8 w-full max-w-md">
         <div className="text-center mb-8">
           <div className="text-5xl mb-3">💪</div>
-          <h1 className="text-2xl font-bold text-gray-900">Create Account</h1>
-          <p className="text-gray-500 mt-1">Start your health journey today</p>
+          <h1 className="text-2xl font-bold text-fg">Create Account</h1>
+          <p className="text-fg-subtle mt-1">Start your health journey today</p>
         </div>
         <form onSubmit={handleSubmit} className="space-y-4">
           <Input
@@ -85,14 +85,14 @@ const RegisterPage: React.FC = () => {
             placeholder="••••••••"
             autoComplete="new-password"
           />
-          {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+          {error && <p className="text-sm text-danger-fg text-center">{error}</p>}
           <Button type="submit" loading={loading} className="w-full">
             Create Account
           </Button>
         </form>
-        <p className="text-center text-sm text-gray-500 mt-6">
+        <p className="text-center text-sm text-fg-subtle mt-6">
           Already have an account?{' '}
-          <Link to="/login" className="text-blue-600 hover:underline font-medium">
+          <Link to="/login" className="text-brand-fg hover:underline font-medium">
             Sign In
           </Link>
         </p>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
+import ThemeToggle from '../components/theme/ThemeToggle';
 
 /**
  * Account creation page, and the other route reachable without a session.
@@ -45,7 +46,11 @@ const RegisterPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-brand-soft to-accent-soft flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-brand-soft to-accent-soft flex items-center justify-center p-4 relative">
+      {/* These pages render outside Layout, so the navbar toggle cannot reach them. */}
+      <div className="absolute top-4 right-4">
+        <ThemeToggle />
+      </div>
       <div className="bg-surface rounded-2xl shadow-xl p-8 w-full max-w-md">
         <div className="text-center mb-8">
           <div className="text-5xl mb-3">💪</div>

--- a/frontend/src/pages/UpgradeBacklogPage.tsx
+++ b/frontend/src/pages/UpgradeBacklogPage.tsx
@@ -76,7 +76,7 @@ const UpgradeBacklogPage: React.FC = () => {
   const areaOptions = [{ value: '', label: 'No area' }, ...areas.map((a) => ({ value: a.id, label: a.name }))];
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-red-500 text-center py-10">Failed to load the backlog.</p>;
+  if (error) return <p className="text-danger-fg text-center py-10">Failed to load the backlog.</p>;
 
   return (
     <div className="max-w-4xl mx-auto">

--- a/frontend/src/pages/UpgradeBacklogPage.tsx
+++ b/frontend/src/pages/UpgradeBacklogPage.tsx
@@ -11,6 +11,7 @@ import LoadingSpinner from '../components/ui/LoadingSpinner';
 import EmptyState from '../components/ui/EmptyState';
 import UpgradeCard from '../components/upgrade/UpgradeCard';
 import type { CreateUpgradeRequest, UpgradeType, Difficulty, UpgradeStatus } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /**
  * The upgrade types offered when creating one: the eight kinds the product defines.
@@ -79,7 +80,7 @@ const UpgradeBacklogPage: React.FC = () => {
   if (error) return <p className="text-danger-fg text-center py-10">Failed to load the backlog.</p>;
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <PageContainer>
       <PageHeader
         title="Idea Backlog"
         subtitle="Health upgrade ideas waiting to be planned"
@@ -109,7 +110,7 @@ const UpgradeBacklogPage: React.FC = () => {
           </div>
         </form>
       </Modal>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/UpgradeBacklogPage.tsx
+++ b/frontend/src/pages/UpgradeBacklogPage.tsx
@@ -89,7 +89,7 @@ const UpgradeBacklogPage: React.FC = () => {
       {upgrades.length === 0 ? (
         <EmptyState icon="💡" title="No ideas yet" description="Capture your health upgrade ideas here before planning them." action={<Button onClick={() => setIsOpen(true)}>Add First Idea</Button>} />
       ) : (
-        <div className="grid sm:grid-cols-2 gap-4">
+        <div className="grid sm:grid-cols-2 xl:grid-cols-3 gap-4">
           {upgrades.map((u) => (
             <UpgradeCard key={u.id} upgrade={u} onStatusChange={handleStatusChange} />
           ))}

--- a/frontend/src/pages/UpgradeDetailsPage.tsx
+++ b/frontend/src/pages/UpgradeDetailsPage.tsx
@@ -17,6 +17,7 @@ import UpgradeTypeBadge from '../components/upgrade/UpgradeTypeBadge';
 import Badge from '../components/ui/Badge';
 import { difficultyVariant, UNKNOWN_DIFFICULTY_VARIANT } from '../components/upgrade/upgradeMeta';
 import type { CreateProgressRequest, CreateReflectionRequest, TrackingType, Frequency } from '../types';
+import PageContainer from '../components/ui/PageContainer';
 
 /** Today as `YYYY-MM-DD`, the date format the progress and reflection APIs expect. */
 const today = () => new Date().toISOString().split('T')[0];
@@ -122,7 +123,7 @@ const UpgradeDetailsPage: React.FC = () => {
   if (error || !upgrade) return <p className="text-danger-fg text-center py-10">Failed to load this upgrade.</p>;
 
   return (
-    <div className="max-w-3xl mx-auto space-y-6">
+    <PageContainer width="narrow" className="space-y-6">
       <button onClick={() => navigate(-1)} className="text-sm text-brand-fg hover:underline">← Back</button>
 
       <Card>
@@ -400,7 +401,7 @@ const UpgradeDetailsPage: React.FC = () => {
           </div>
         </form>
       </Modal>
-    </div>
+    </PageContainer>
   );
 };
 

--- a/frontend/src/pages/UpgradeDetailsPage.tsx
+++ b/frontend/src/pages/UpgradeDetailsPage.tsx
@@ -15,6 +15,7 @@ import Modal from '../components/ui/Modal';
 import UpgradeStatusBadge from '../components/upgrade/UpgradeStatusBadge';
 import UpgradeTypeBadge from '../components/upgrade/UpgradeTypeBadge';
 import Badge from '../components/ui/Badge';
+import { difficultyVariant, UNKNOWN_DIFFICULTY_VARIANT } from '../components/upgrade/upgradeMeta';
 import type { CreateProgressRequest, CreateReflectionRequest, TrackingType, Frequency } from '../types';
 
 /** Today as `YYYY-MM-DD`, the date format the progress and reflection APIs expect. */
@@ -118,33 +119,33 @@ const UpgradeDetailsPage: React.FC = () => {
   });
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error || !upgrade) return <p className="text-red-500 text-center py-10">Failed to load this upgrade.</p>;
+  if (error || !upgrade) return <p className="text-danger-fg text-center py-10">Failed to load this upgrade.</p>;
 
   return (
     <div className="max-w-3xl mx-auto space-y-6">
-      <button onClick={() => navigate(-1)} className="text-sm text-blue-600 hover:underline">← Back</button>
+      <button onClick={() => navigate(-1)} className="text-sm text-brand-fg hover:underline">← Back</button>
 
       <Card>
         <div className="flex flex-wrap gap-2 mb-3">
           <UpgradeStatusBadge status={upgrade.status} />
           <UpgradeTypeBadge type={upgrade.type} />
-          <Badge variant={upgrade.difficulty === 'EASY' ? 'green' : upgrade.difficulty === 'MEDIUM' ? 'yellow' : 'red'}>
+          <Badge variant={difficultyVariant[upgrade.difficulty] ?? UNKNOWN_DIFFICULTY_VARIANT}>
             {upgrade.difficulty}
           </Badge>
         </div>
-        <h1 className="text-2xl font-bold text-gray-900">{upgrade.title}</h1>
-        {upgrade.description && <p className="text-gray-600 mt-2">{upgrade.description}</p>}
+        <h1 className="text-2xl font-bold text-fg">{upgrade.title}</h1>
+        {upgrade.description && <p className="text-fg-subtle mt-2">{upgrade.description}</p>}
         {upgrade.motivation && (
-          <div className="mt-4 bg-blue-50 rounded-lg p-3">
-            <p className="text-sm text-blue-700"><strong>Motivation:</strong> {upgrade.motivation}</p>
+          <div className="mt-4 bg-brand-soft rounded-lg p-3">
+            <p className="text-sm text-brand-fg"><strong>Motivation:</strong> {upgrade.motivation}</p>
           </div>
         )}
         {upgrade.successCriteria && (
-          <div className="mt-2 bg-green-50 rounded-lg p-3">
-            <p className="text-sm text-green-700"><strong>Success Criteria:</strong> {upgrade.successCriteria}</p>
+          <div className="mt-2 bg-success-soft rounded-lg p-3">
+            <p className="text-sm text-success-fg"><strong>Success Criteria:</strong> {upgrade.successCriteria}</p>
           </div>
         )}
-        <div className="mt-4 grid grid-cols-2 gap-4 text-sm text-gray-500">
+        <div className="mt-4 grid grid-cols-2 gap-4 text-sm text-fg-subtle">
           {upgrade.plannedStartDate && <div><span className="font-medium">Planned Start:</span> {new Date(upgrade.plannedStartDate).toLocaleDateString()}</div>}
           {upgrade.actualStartDate && <div><span className="font-medium">Actual Start:</span> {new Date(upgrade.actualStartDate).toLocaleDateString()}</div>}
           {upgrade.targetEndDate && <div><span className="font-medium">Target End:</span> {new Date(upgrade.targetEndDate).toLocaleDateString()}</div>}
@@ -152,11 +153,11 @@ const UpgradeDetailsPage: React.FC = () => {
       </Card>
 
       {streak.current > 0 && (
-        <div className="bg-orange-50 border border-orange-200 rounded-xl p-4 flex items-center gap-3">
+        <div className="bg-streak-soft border border-streak-line rounded-xl p-4 flex items-center gap-3">
           <span className="text-3xl">🔥</span>
           <div>
-            <p className="font-semibold text-orange-700">{streak.current}-day streak!</p>
-            <p className="text-sm text-orange-500">Longest streak: {streak.longest} day{streak.longest === 1 ? '' : 's'}. Keep it up!</p>
+            <p className="font-semibold text-streak-fg">{streak.current}-day streak!</p>
+            <p className="text-sm text-streak-fg">Longest streak: {streak.longest} day{streak.longest === 1 ? '' : 's'}. Keep it up!</p>
           </div>
         </div>
       )}
@@ -180,32 +181,32 @@ const UpgradeDetailsPage: React.FC = () => {
       }>
         {upgrade.trackingConfig ? (
           <div className="grid grid-cols-2 gap-3 text-sm">
-            <div><span className="text-gray-500">Type:</span> <span className="font-medium">{upgrade.trackingConfig.trackingType}</span></div>
-            <div><span className="text-gray-500">Frequency:</span> <span className="font-medium">{upgrade.trackingConfig.frequency}</span></div>
+            <div><span className="text-fg-subtle">Type:</span> <span className="font-medium">{upgrade.trackingConfig.trackingType}</span></div>
+            <div><span className="text-fg-subtle">Frequency:</span> <span className="font-medium">{upgrade.trackingConfig.frequency}</span></div>
             {upgrade.trackingConfig.targetNumericValue != null && (
-              <div><span className="text-gray-500">Target:</span> <span className="font-medium">{upgrade.trackingConfig.targetNumericValue} {upgrade.trackingConfig.targetUnit}</span></div>
+              <div><span className="text-fg-subtle">Target:</span> <span className="font-medium">{upgrade.trackingConfig.targetNumericValue} {upgrade.trackingConfig.targetUnit}</span></div>
             )}
           </div>
         ) : (
-          <p className="text-gray-500 text-sm text-center py-4">No tracking configured yet. Configure how you'll track this upgrade.</p>
+          <p className="text-fg-subtle text-sm text-center py-4">No tracking configured yet. Configure how you'll track this upgrade.</p>
         )}
       </Card>
 
       <Card header={<span>Reminders ({reminders.length})</span>}>
         {reminders.length === 0 ? (
-          <p className="text-gray-500 text-sm mb-4">No reminders yet. Add one to get notified.</p>
+          <p className="text-fg-subtle text-sm mb-4">No reminders yet. Add one to get notified.</p>
         ) : (
           <div className="space-y-2 mb-4">
             {reminders.map((r) => (
-              <div key={r.id} className="flex items-center justify-between p-2 bg-gray-50 rounded-lg text-sm">
+              <div key={r.id} className="flex items-center justify-between p-2 bg-sunken rounded-lg text-sm">
                 <div className="flex items-center gap-2">
                   <span className="font-medium">⏰ {r.reminderTime.slice(0, 5)}</span>
-                  <span className="text-gray-500">{r.daysOfWeek.length ? r.daysOfWeek.join(', ') : 'Every day'}</span>
+                  <span className="text-fg-subtle">{r.daysOfWeek.length ? r.daysOfWeek.join(', ') : 'Every day'}</span>
                   {!r.enabled && <Badge variant="gray">disabled</Badge>}
                 </div>
                 <button
                   onClick={() => deleteReminderMut.mutate(r.id)}
-                  className="text-red-500 hover:text-red-700 text-xs font-medium"
+                  className="text-danger-fg hover:underline text-xs font-medium"
                 >
                   Remove
                 </button>
@@ -215,11 +216,11 @@ const UpgradeDetailsPage: React.FC = () => {
         )}
         <form
           onSubmit={(e) => { e.preventDefault(); createReminderMut.mutate(); }}
-          className="flex flex-wrap items-end gap-3 border-t border-gray-100 pt-3"
+          className="flex flex-wrap items-end gap-3 border-t border-line-subtle pt-3"
         >
           <Input label="Time" type="time" value={reminderTime} onChange={(e) => setReminderTime(e.target.value)} />
           <div>
-            <label className="text-sm font-medium text-gray-700 block mb-1">Days <span className="text-gray-400">(none = every day)</span></label>
+            <label className="text-sm font-medium text-fg-muted block mb-1">Days <span className="text-fg-faint">(none = every day)</span></label>
             <div className="flex gap-1">
               {DAYS.map((d) => (
                 <button
@@ -227,7 +228,7 @@ const UpgradeDetailsPage: React.FC = () => {
                   type="button"
                   title={d}
                   onClick={() => toggleDay(d)}
-                  className={`w-9 h-9 rounded-lg text-xs font-medium transition-colors ${reminderDays.includes(d) ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}
+                  className={`w-9 h-9 rounded-lg text-xs font-medium transition-colors ${reminderDays.includes(d) ? 'bg-brand text-fg-inverted' : 'bg-muted text-fg-subtle hover:bg-muted-strong'}`}
                 >
                   {d[0]}
                 </button>
@@ -245,17 +246,17 @@ const UpgradeDetailsPage: React.FC = () => {
         </div>
       }>
         {progress.length === 0 ? (
-          <p className="text-gray-500 text-sm text-center py-4">No progress logged yet.</p>
+          <p className="text-fg-subtle text-sm text-center py-4">No progress logged yet.</p>
         ) : (
           <div className="space-y-2 max-h-64 overflow-y-auto">
             {[...progress].reverse().map((p) => (
-              <div key={p.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg text-sm">
-                <span className="text-gray-500">{new Date(p.date).toLocaleDateString()}</span>
+              <div key={p.id} className="flex items-center justify-between p-3 bg-sunken rounded-lg text-sm">
+                <span className="text-fg-subtle">{new Date(p.date).toLocaleDateString()}</span>
                 <div className="flex items-center gap-3">
                   {p.completed !== undefined && <Badge variant={p.completed ? 'green' : 'red'}>{p.completed ? 'Done' : 'Missed'}</Badge>}
                   {p.numericValue !== undefined && <span className="font-medium">{p.numericValue} {p.unit}</span>}
                   {p.rating !== undefined && <span>⭐ {p.rating}/5</span>}
-                  {p.note && <span className="text-gray-500 italic truncate max-w-32">{p.note}</span>}
+                  {p.note && <span className="text-fg-subtle italic truncate max-w-32">{p.note}</span>}
                 </div>
               </div>
             ))}
@@ -270,12 +271,12 @@ const UpgradeDetailsPage: React.FC = () => {
         </div>
       }>
         {reflections.length === 0 ? (
-          <p className="text-gray-500 text-sm text-center py-4">No reflections yet.</p>
+          <p className="text-fg-subtle text-sm text-center py-4">No reflections yet.</p>
         ) : (
           <div className="space-y-3">
             {[...reflections].reverse().map((r) => (
-              <div key={r.id} className="p-3 bg-gray-50 rounded-lg text-sm space-y-1">
-                <p className="text-gray-400">{new Date(r.date).toLocaleDateString()}</p>
+              <div key={r.id} className="p-3 bg-sunken rounded-lg text-sm space-y-1">
+                <p className="text-fg-faint">{new Date(r.date).toLocaleDateString()}</p>
                 {r.whatWorked && <p><strong>✅ What worked:</strong> {r.whatWorked}</p>}
                 {r.whatDidNotWork && <p><strong>❌ What didn't:</strong> {r.whatDidNotWork}</p>}
                 {r.nextAdjustment && <p><strong>🔄 Next:</strong> {r.nextAdjustment}</p>}
@@ -295,7 +296,7 @@ const UpgradeDetailsPage: React.FC = () => {
           {(!upgrade.trackingConfig || upgrade.trackingConfig.trackingType === 'BOOLEAN') && (
             <label className="flex items-center gap-2 cursor-pointer">
               <input type="checkbox" checked={progressForm.completed ?? false} onChange={(e) => setProgressForm({ ...progressForm, completed: e.target.checked })} className="w-4 h-4 rounded" />
-              <span className="text-sm font-medium text-gray-700">Completed</span>
+              <span className="text-sm font-medium text-fg-muted">Completed</span>
             </label>
           )}
           {upgrade.trackingConfig?.trackingType === 'NUMERIC' && (
@@ -303,10 +304,10 @@ const UpgradeDetailsPage: React.FC = () => {
           )}
           {upgrade.trackingConfig?.trackingType === 'RATING' && (
             <div>
-              <label className="text-sm font-medium text-gray-700">Rating (1-5)</label>
+              <label className="text-sm font-medium text-fg-muted">Rating (1-5)</label>
               <div className="flex gap-2 mt-2">
                 {[1, 2, 3, 4, 5].map((n) => (
-                  <button key={n} type="button" onClick={() => setProgressForm({ ...progressForm, rating: n })} className={`w-10 h-10 rounded-full text-sm font-semibold transition-colors ${progressForm.rating === n ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}`}>{n}</button>
+                  <button key={n} type="button" onClick={() => setProgressForm({ ...progressForm, rating: n })} className={`w-10 h-10 rounded-full text-sm font-semibold transition-colors ${progressForm.rating === n ? 'bg-brand text-fg-inverted' : 'bg-muted text-fg-muted hover:bg-muted-strong'}`}>{n}</button>
                 ))}
               </div>
             </div>
@@ -323,16 +324,16 @@ const UpgradeDetailsPage: React.FC = () => {
         <form onSubmit={(e) => { e.preventDefault(); reflectionMutation.mutate(reflectionForm); }} className="space-y-4">
           <Input label="Date" type="date" value={reflectionForm.date} onChange={(e) => setReflectionForm({ ...reflectionForm, date: e.target.value })} />
           <div>
-            <label className="text-sm font-medium text-gray-700">What worked?</label>
-            <textarea className="w-full mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" rows={2} value={reflectionForm.whatWorked ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, whatWorked: e.target.value })} />
+            <label className="text-sm font-medium text-fg-muted">What worked?</label>
+            <textarea className="w-full mt-1 rounded-lg border border-line-strong px-3 py-2 text-sm focus:outline-none focus:ring-2" rows={2} value={reflectionForm.whatWorked ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, whatWorked: e.target.value })} />
           </div>
           <div>
-            <label className="text-sm font-medium text-gray-700">What didn't work?</label>
-            <textarea className="w-full mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" rows={2} value={reflectionForm.whatDidNotWork ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, whatDidNotWork: e.target.value })} />
+            <label className="text-sm font-medium text-fg-muted">What didn't work?</label>
+            <textarea className="w-full mt-1 rounded-lg border border-line-strong px-3 py-2 text-sm focus:outline-none focus:ring-2" rows={2} value={reflectionForm.whatDidNotWork ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, whatDidNotWork: e.target.value })} />
           </div>
           <div>
-            <label className="text-sm font-medium text-gray-700">Next adjustment?</label>
-            <textarea className="w-full mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" rows={2} value={reflectionForm.nextAdjustment ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, nextAdjustment: e.target.value })} />
+            <label className="text-sm font-medium text-fg-muted">Next adjustment?</label>
+            <textarea className="w-full mt-1 rounded-lg border border-line-strong px-3 py-2 text-sm focus:outline-none focus:ring-2" rows={2} value={reflectionForm.nextAdjustment ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, nextAdjustment: e.target.value })} />
           </div>
           <div className="grid grid-cols-2 gap-4">
             <Input label="Difficulty (1-5)" type="number" min={1} max={5} value={reflectionForm.difficultyRating ?? ''} onChange={(e) => setReflectionForm({ ...reflectionForm, difficultyRating: intOrUndef(e.target.value) })} />
@@ -391,7 +392,7 @@ const UpgradeDetailsPage: React.FC = () => {
               onChange={(e) => setTrackingForm({ ...trackingForm, requiredDaily: e.target.checked })}
               className="w-4 h-4 rounded"
             />
-            <span className="text-sm font-medium text-gray-700">Required daily</span>
+            <span className="text-sm font-medium text-fg-muted">Required daily</span>
           </label>
           <div className="flex gap-2 justify-end">
             <Button variant="secondary" type="button" onClick={() => setTrackingOpen(false)}>Cancel</Button>

--- a/frontend/src/pages/UpgradeDetailsPage.tsx
+++ b/frontend/src/pages/UpgradeDetailsPage.tsx
@@ -134,16 +134,16 @@ const UpgradeDetailsPage: React.FC = () => {
             {upgrade.difficulty}
           </Badge>
         </div>
-        <h1 className="text-2xl font-bold text-fg">{upgrade.title}</h1>
-        {upgrade.description && <p className="text-fg-subtle mt-2">{upgrade.description}</p>}
+        <h1 className="text-2xl font-bold text-fg break-words">{upgrade.title}</h1>
+        {upgrade.description && <p className="text-fg-subtle mt-2 break-words">{upgrade.description}</p>}
         {upgrade.motivation && (
           <div className="mt-4 bg-brand-soft rounded-lg p-3">
-            <p className="text-sm text-brand-fg"><strong>Motivation:</strong> {upgrade.motivation}</p>
+            <p className="text-sm text-brand-fg break-words"><strong>Motivation:</strong> {upgrade.motivation}</p>
           </div>
         )}
         {upgrade.successCriteria && (
           <div className="mt-2 bg-success-soft rounded-lg p-3">
-            <p className="text-sm text-success-fg"><strong>Success Criteria:</strong> {upgrade.successCriteria}</p>
+            <p className="text-sm text-success-fg break-words"><strong>Success Criteria:</strong> {upgrade.successCriteria}</p>
           </div>
         )}
         <div className="mt-4 grid grid-cols-2 gap-4 text-sm text-fg-subtle">

--- a/frontend/src/router/ProtectedRoute.tsx
+++ b/frontend/src/router/ProtectedRoute.tsx
@@ -16,7 +16,7 @@ interface Props {
  */
 const ProtectedRoute: React.FC<Props> = ({ children }) => {
   const { isAuthenticated, isLoading } = useAuth();
-  if (isLoading) return <div className="min-h-screen flex items-center justify-center"><LoadingSpinner size="lg" /></div>;
+  if (isLoading) return <div className="min-h-screen bg-canvas flex items-center justify-center"><LoadingSpinner size="lg" /></div>;
   if (!isAuthenticated) return <Navigate to="/login" replace />;
   return <>{children}</>;
 };

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,24 @@
+import { afterEach, beforeEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { installMatchMedia } from './test/matchMediaStub';
+
+/**
+ * Per-test isolation.
+ *
+ * `localStorage` and the `dark` class on `<html>` both outlive a test — they live on the jsdom window,
+ * not on the rendered tree — so a test that sets either would otherwise decide the outcome of the next
+ * one. Resetting here rather than in each file is what keeps the suite order-independent.
+ *
+ * `matchMedia` is stubbed for every test, not only the ones that care, so no test silently depends on
+ * whatever jsdom reports by default.
+ */
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.className = '';
+  installMatchMedia(false);
+});
+
+// Testing Library only auto-cleans when Vitest's globals are on. They are off here — see ADR-004.
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/src/test/matchMediaStub.ts
+++ b/frontend/src/test/matchMediaStub.ts
@@ -1,0 +1,60 @@
+/**
+ * A `window.matchMedia` that tests can drive.
+ *
+ * jsdom implements `matchMedia`, but nothing can change what it reports — so the branch that matters
+ * most, the operating system's colour scheme flipping while the tab is open, would be unreachable.
+ * This stub exposes `setMatches`, which updates `matches` and notifies every registered listener, and
+ * `listenerCount`, which is how a test asserts that a subscription was cleaned up rather than leaked.
+ */
+export interface MatchMediaStub {
+  /** Changes what the query reports and fires `change` at every registered listener. */
+  setMatches: (matches: boolean) => void;
+  /** How many listeners are currently registered. Zero after a correct unmount. */
+  listenerCount: () => number;
+}
+
+/**
+ * Replaces `window.matchMedia` with a controllable stub.
+ *
+ * Installed for every test by `setupTests.ts` reporting `false`, so a test that does not care about the
+ * system preference still gets a deterministic one. Call it again with `true` to start dark.
+ */
+export const installMatchMedia = (initialMatches = false): MatchMediaStub => {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  let matches = initialMatches;
+
+  const query = {
+    get matches() {
+      return matches;
+    },
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: (_type: string, listener: EventListener) =>
+      listeners.add(listener as (event: MediaQueryListEvent) => void),
+    removeEventListener: (_type: string, listener: EventListener) =>
+      listeners.delete(listener as (event: MediaQueryListEvent) => void),
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    dispatchEvent: () => true,
+  } as unknown as MediaQueryList;
+
+  window.matchMedia = () => query;
+
+  return {
+    setMatches: (next: boolean) => {
+      matches = next;
+      listeners.forEach((listener) => listener({ matches: next } as MediaQueryListEvent));
+    },
+    listenerCount: () => listeners.size,
+  };
+};
+
+/**
+ * Removes `window.matchMedia` entirely, standing in for the embedded webviews that lack it.
+ *
+ * `Reflect.deleteProperty` rather than `delete window.matchMedia`, which TypeScript rejects on a
+ * non-optional property.
+ */
+export const uninstallMatchMedia = (): void => {
+  Reflect.deleteProperty(window, 'matchMedia');
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,8 +1,99 @@
-/** @type {import('tailwindcss').Config} */
+/**
+ * Every colour in the app is a semantic token, not a palette shade.
+ *
+ * Tokens are declared as `rgb(var(--color-x) / <alpha-value>)` rather than as a hex string because two
+ * call sites need Tailwind's opacity modifier on a colour that must theme: the modal scrim
+ * (`bg-overlay/50`) and the unread notification row (`bg-brand-soft/50`). A hex-valued custom property
+ * cannot take that modifier; space-separated channels can, and Tailwind composes the alpha itself.
+ *
+ * The values live in `src/index.css`, once per theme.
+ *
+ * `darkMode: 'class'` rather than `'selector'`: the declared dependency range is `^3.4.0` and
+ * `'selector'` only landed in 3.4.1, so a fresh install resolving 3.4.0 exactly would break. It also
+ * compiles to a `.dark` descendant selector rather than `:where(.dark, .dark *)`, which has zero
+ * specificity — the higher specificity is what makes a one-off `dark:` override stick.
+ *
+ * @type {import('tailwindcss').Config}
+ */
+
+/** @param {string} name the token's name, without the `--color-` prefix */
+const token = (name) => `rgb(var(--color-${name}) / <alpha-value>)`;
+
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  darkMode: 'class',
   theme: {
     extend: {
+      colors: {
+        canvas: token('canvas'),
+        surface: token('surface'),
+        // Named `sunken` and never `inset`: Tailwind merges a colour named `inset` into its existing
+        // `ring-inset` utility, which would silently recolour any inset ring.
+        sunken: token('sunken'),
+        muted: { DEFAULT: token('muted'), strong: token('muted-strong') },
+        line: { DEFAULT: token('line'), subtle: token('line-subtle'), strong: token('line-strong') },
+        fg: {
+          DEFAULT: token('fg'),
+          muted: token('fg-muted'),
+          subtle: token('fg-subtle'),
+          faint: token('fg-faint'),
+          inverted: token('fg-inverted'),
+        },
+        overlay: token('overlay'),
+        focus: token('focus'),
+
+        brand: {
+          DEFAULT: token('brand'),
+          hover: token('brand-hover'),
+          soft: token('brand-soft'),
+          'soft-hover': token('brand-soft-hover'),
+          line: token('brand-line'),
+          fg: token('brand-fg'),
+        },
+        success: {
+          DEFAULT: token('success'),
+          soft: token('success-soft'),
+          line: token('success-line'),
+          fg: token('success-fg'),
+        },
+        warning: { soft: token('warning-soft'), line: token('warning-line'), fg: token('warning-fg') },
+        danger: {
+          DEFAULT: token('danger'),
+          hover: token('danger-hover'),
+          soft: token('danger-soft'),
+          line: token('danger-line'),
+          fg: token('danger-fg'),
+        },
+        info: { soft: token('info-soft'), line: token('info-line'), fg: token('info-fg') },
+        reminder: { soft: token('reminder-soft'), line: token('reminder-line'), fg: token('reminder-fg') },
+        streak: { soft: token('streak-soft'), line: token('streak-line'), fg: token('streak-fg') },
+        accent: { soft: token('accent-soft'), fg: token('accent-fg') },
+
+        // Decorative category tints, for `Badge` only. Deliberately independent of the semantic families
+        // above: `tint-red` on a MEDICAL_PREVENTIVE badge is a category colour, not a danger signal, and
+        // must not move when the danger hue does. Grey has no hue meaning, so it reuses `muted`.
+        tint: {
+          green: { soft: token('tint-green-soft'), fg: token('tint-green-fg') },
+          yellow: { soft: token('tint-yellow-soft'), fg: token('tint-yellow-fg') },
+          blue: { soft: token('tint-blue-soft'), fg: token('tint-blue-fg') },
+          red: { soft: token('tint-red-soft'), fg: token('tint-red-fg') },
+          purple: { soft: token('tint-purple-soft'), fg: token('tint-purple-fg') },
+        },
+      },
+
+      // Preflight paints every element's default border colour, and out of the box that is gray-200 —
+      // a light rule that would survive into the dark theme on any element carrying `border` with no
+      // colour class of its own.
+      borderColor: { DEFAULT: token('line') },
+
+      // One focus colour for the whole app, so `focus:ring-2` needs no colour class at the call site.
+      // Without the opacity override Tailwind applies `ringOpacity.DEFAULT` of 0.5 to the base ring.
+      ringColor: { DEFAULT: 'rgb(var(--color-focus))' },
+      ringOpacity: { DEFAULT: '1' },
+      // Tailwind's default offset colour is `#fff`. Left alone, every control using `ring-offset-2`
+      // draws a white halo against a near-black page.
+      ringOffsetColor: { DEFAULT: 'rgb(var(--color-surface))' },
+
       // Declared here rather than as an arbitrary `animate-[fadeIn_...]` value at the call site: the
       // arbitrary form emits the `animation` property but no `@keyframes`, so it names a keyframe that
       // does not exist and the element never animates.

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,19 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      // Declared here rather than as an arbitrary `animate-[fadeIn_...]` value at the call site: the
+      // arbitrary form emits the `animation` property but no `@keyframes`, so it names a keyframe that
+      // does not exist and the element never animates.
+      keyframes: {
+        'fade-in': {
+          from: { opacity: '0', transform: 'translateY(-4px)' },
+          to: { opacity: '1', transform: 'none' },
+        },
+      },
+      animation: { 'fade-in': 'fade-in 0.2s ease-out' },
+    },
+  },
   plugins: [],
 }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
+
+/**
+ * Test configuration, layered over the real build configuration rather than restating it.
+ *
+ * Vitest reads this file *instead of* `vite.config.ts` when both exist, so the plugin list is merged in
+ * explicitly — without the merge the tests would run without the React plugin and every `.tsx` file
+ * would fail to transform.
+ *
+ * Kept out of `vite.config.ts` so the production build configuration does not type-depend on a
+ * development-only package. See `docs/ADRs/ADR-004-frontend-test-harness.md`.
+ */
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: 'jsdom',
+      setupFiles: ['./src/setupTests.ts'],
+      include: ['src/**/*.test.{ts,tsx}'],
+      // `describe`/`it`/`expect` are imported explicitly instead, which is what keeps `tsconfig.json`'s
+      // `types` array — and therefore the production type check — untouched.
+      globals: false,
+      restoreMocks: true,
+      css: false,
+    },
+  }),
+);


### PR DESCRIPTION
Promotes `dev` to `main`: 36 commits, 69 files, +4429 / −361, across four merged pull requests.

## What is in it

**#27 — Architecture diagrams.** Seven views of the system in `docs/architecture/arch-diagrams/`,
three of them generated from source by `generate.py`, with a CI job that fails when they drift from the
code they describe.

**#38 — Dark mode.** Every colour in the SPA became a semantic token declared in `tailwind.config.js`
and valued once per theme in `index.css`; a three-state toggle (light / dark / follow the OS); a
classic inline boot script that applies the stored choice before first paint, so the page never flashes
the wrong theme. `npm run check:colours` fails CI on any direct palette use, because Tailwind emits
nothing and reports nothing for a class it does not recognise. Also the frontend's first test harness —
Vitest, jsdom and Testing Library — recorded in
[ADR-004](docs/ADRs/ADR-004-frontend-test-harness.md).

**#39 — Responsive layout.** One `PageContainer` decides page width instead of nine ad-hoc caps; the
shell is shrinkable by construction (`min-w-0`, stated rather than inherited by accident from an
`overflow-auto` that looked inert); a dialog is bounded by its overlay and scrolls its own body; and a
health area's icon can no longer widen its card, with `V5` correcting the seeded values from Material
Symbols keys to emoji. Recorded in
[ADR-005](docs/ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md).

**#40 — README reconciliation.** Two edits made directly on `main` through the web editor are now on
`dev` too, by merge rather than cherry-pick, so `main` is an ancestor of `dev` and the divergence stops
recurring.

## Trade-offs accepted

- **A future unshrinkable child now overflows visibly** instead of scrolling silently inside `<main>`.
  A visible bug beats a hidden one; the fix belongs on that child's own wrapper.
- **Eight of nine page widths changed**, most of them widening. ADR-005 says which and why.
- **`aria-modal` is deliberately withheld** from the dialog until a focus trap exists — claiming it
  without one strands screen-reader users on focusable but unannounced controls.
- **Container queries were turned down** despite being the correct answer to the sidebar's breakpoint
  offset; ADR-005 names the threshold that would earn the dependency.
- **Still no accessibility or visual-regression gate.** jsdom has no layout engine, so widths, wrapping
  and overflow are verified by hand. Carried as an open question in `requirements.md` §6, per ADR-004.

## Verified

CI green on `dev` at `ac46d3c` — backend build and tests (144), frontend build and lint, and the
diagram drift check. Frontend suite is 61 tests, up from zero at the last release. The layout work was
additionally checked in a real browser at 320, 360, 486, 684, 1040 and 1540px, in both themes, with the
dialog open at 320×568 and at a 381px-tall viewport.

Requirements grew by FR-34…41 and NFR-16…20; each names the class or test that enforces it, or says
plainly that nothing does.
