### PR TITLE
release: observability — a log worth reading, an audit trail, metrics and probes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,13 @@ DB_PASSWORD=healthupgrades
 # served through the Vite dev proxy or the nginx proxy (i.e. when it calls the API on another origin).
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 
+# Observability
+# `json-logs` switches logback-spring.xml from Boot's readable console pattern to JSON. docker-compose
+# sets it; leave it empty locally so the console stays readable.
+SPRING_PROFILES_ACTIVE=
+# Log level for this application's own packages. INFO in a deployment; DEBUG to read along.
+LOG_LEVEL_APP=INFO
+
 # Frontend
 # Optional. Leave empty to use the same-origin /api proxy (Vite in dev, nginx in prod) — recommended.
 # Set this only if the API is hosted on a different origin than the frontend.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,35 @@ docker-compose up --build
 
 - Frontend: http://localhost:3000
 - Backend: http://localhost:8080
-- API docs: http://localhost:8080/actuator/health
+- Health: http://localhost:8080/actuator/health
+
+`docker-compose` waits for the backend to report **ready** before starting the frontend, so the first
+page load is never proxied to an API that is still migrating its schema.
+
+### Observability
+
+Logs go to stdout and nowhere else — `docker logs healthupgrades-backend` is the whole of it. Under
+compose they are **one JSON object per line**; a local `mvn spring-boot:run` gets Spring Boot's readable
+console pattern instead. `SPRING_PROFILES_ACTIVE=json-logs` is what switches between them, and
+`LOG_LEVEL_APP=DEBUG` turns this application's own packages up for a run.
+
+Every line carries a **trace id**, which is also returned as the `X-Trace-Id` response header and on the
+body of any error. It is the one thing worth quoting in a bug report:
+
+```bash
+docker logs healthupgrades-backend | grep <the id from the error>
+```
+
+Two streams are worth knowing about:
+
+| What | Where |
+|---|---|
+| Who did what, and whether it was allowed | the `AUDIT` logger — `action`, `outcome`, `actorId`, `resourceId` |
+| Latency, error rate, saturation, pool depth, audit and job counters | http://localhost:8080/actuator/prometheus |
+
+`/actuator` serves **only** `health`, `info` and `prometheus`; anything else answers 404 by design.
+Liveness and readiness are separate: http://localhost:8080/actuator/health/liveness and
+`/actuator/health/readiness`.
 
 ### Demo Account
 
@@ -308,7 +336,14 @@ cd frontend && npm run test:coverage
 | `POSTGRES_USER` | `healthupgrades` | PostgreSQL username |
 | `POSTGRES_PASSWORD` | `healthupgrades` | PostgreSQL password |
 | `DB_URL` | `jdbc:postgresql://localhost:5432/healthupgrades` | Full JDBC URL |
+| `DB_USERNAME` | `healthupgrades` | Database user the backend connects as |
+| `DB_PASSWORD` | `healthupgrades` | Password for that user |
 | `JWT_SECRET` | (default dev key) | JWT signing secret (change in production!) |
+| `SPRING_PROFILES_ACTIVE` | (empty; `json-logs` under compose) | `json-logs` switches log output to one JSON object per line |
+| `LOG_LEVEL_APP` | `INFO` | Level for this application's own packages. `DEBUG` to read along |
+| `UPGRADE_OVERDUE_CRON` | `0 0 8 * * *` | When the overdue sweep runs (server timezone) |
+| `NOTIFY_CHECKIN_CRON` | `0 0 18 * * *` | When the daily check-in nudge runs |
+| `NOTIFY_REMINDERS_CRON` | `0 * * * * *` | How often reminders are dispatched |
 | `CORS_ALLOWED_ORIGINS` | `http://localhost:3000` | Comma-separated origins allowed to call the API cross-origin (only needed when not using the dev/nginx `/api` proxy) |
 | `VITE_API_URL` | (empty) | Backend API URL for frontend. Leave empty to use the same-origin `/api` proxy (Vite in dev, nginx in prod) — recommended. Set only if the API is on another origin. |
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -84,6 +84,18 @@ side. Both are deliberate, not drift.
   `defaults.xml` is what puts the trace id on a plain-text line. See
   `../docs/ADRs/ADR-010-structured-logging-and-a-level-policy.md`.
 
+- **A state change is recorded through `AuditTrail`, not through a `log.info`.** Every state-changing
+  use case wraps its body in `auditTrail.recording(action, userId, resourceId, ...)`, which records the
+  attempt whether it succeeded or was refused — a refusal is the entry somebody actually goes looking
+  for, and BR-15 means an attempt on another user's record leaves no other trace. Adding an operation
+  means adding a constant to `AuditAction` (in `common`, deliberately: one vocabulary, readable in one
+  place) and wrapping the body; it does **not** mean a new log statement.
+
+  `AuditEvent` holds two enums and two identifiers and nothing else, so there is nowhere to put a title
+  or an email even by accident. Keep it that way — `AuditEventTest` fails the build on a field that
+  could hold free text. The same bound applies to metric tags: an action and an outcome are closed sets,
+  a user id is not. See `../docs/ADRs/ADR-011-audit-as-a-log-stream.md`.
+
 - **Optimistic locking** via `@Version` on entities (e.g. `HealthUpgrade.version`) → concurrent edits
   return 409.
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -72,6 +72,18 @@ side. Both are deliberate, not drift.
   back only where it leaves the process, through `CorrelationId.of(tracer)`, which handles the three
   shapes of "no id". See `../docs/ADRs/ADR-007-request-correlation-through-micrometer-tracing.md`.
 
+- **A log level is a claim about who has to act.** `ERROR` is a fault somebody must act on now, `WARN`
+  is degraded but still serving, `INFO` is a state transition, `DEBUG` is for a developer reading
+  along. `com.healthupgrades` runs at `INFO`, so a `DEBUG` line is invisible in any deployment until
+  someone sets `LOG_LEVEL_APP` — write one only where that is the right answer.
+
+  **Nothing personal goes in a log line**: ids and enum values, never a title, an email, a reflection
+  body, a progress note or an IP address. That is NFR-6, and it applies to the message *and* to
+  anything handed to a `{}` placeholder. The output format is chosen by the `json-logs` profile in
+  `src/main/resources/logback-spring.xml`; do not write a `<pattern>` there, because Boot's imported
+  `defaults.xml` is what puts the trace id on a plain-text line. See
+  `../docs/ADRs/ADR-010-structured-logging-and-a-level-policy.md`.
+
 - **Optimistic locking** via `@Version` on entities (e.g. `HealthUpgrade.version`) → concurrent edits
   return 409.
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,4 +8,12 @@ FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 EXPOSE 8080
+
+# Declared on the image rather than only in docker-compose, so anything that runs this container knows
+# how to ask whether it is working. Readiness, not the aggregate health endpoint: this answers "can it
+# serve traffic", which is the question a scheduler is actually asking. start-period covers JVM start
+# and Flyway migration, during which an unhealthy answer is correct and must not count against it.
+# wget is busybox's, already in the alpine image - no package to install.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3     CMD wget -qO- http://localhost:8080/actuator/health/readiness || exit 1
+
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -29,6 +29,12 @@
           a major release and spring-boot-testcontainers 3.2.5 is built against 1.x. See ADR-008.
         -->
         <testcontainers.version>1.21.4</testcontainers.version>
+        <!--
+          Not managed by spring-boot-dependencies, so the version is ours to keep correct. 7.4 is the
+          last release built against logback 1.3/1.4; 8.x compiles against logback 1.5, which Boot 3.2.5
+          does not ship (it resolves logback 1.4.14). Re-check this pin on any Boot upgrade. See ADR-010.
+        -->
+        <logstash.encoder.version>7.4</logstash.encoder.version>
     </properties>
 
     <dependencies>
@@ -109,6 +115,17 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+
+        <!--
+          The JSON encoder logback-spring.xml selects under the json-logs profile. A container's log is
+          read by a machine before a person, and the trace id, the level and the audit fields are only
+          queryable if they are fields rather than substrings of a message. See ADR-010.
+        -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>${logstash.encoder.version}</version>
         </dependency>
 
         <!-- Test -->

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -128,6 +128,17 @@
             <version>${logstash.encoder.version}</version>
         </dependency>
 
+        <!--
+          Turns what actuator already collects - request latency, error rate, JVM and connection-pool
+          saturation - into something a scraper can read, alongside this application's own counters.
+          A pull endpoint, so it needs no collector to exist before it is useful. Version managed by
+          spring-boot-dependencies. See ADR-012.
+        -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/healthupgrades/auth/application/AuthService.java
+++ b/backend/src/main/java/com/healthupgrades/auth/application/AuthService.java
@@ -1,12 +1,18 @@
 package com.healthupgrades.auth.application;
 
+import com.healthupgrades.common.domain.audit.AuditAction;
+import com.healthupgrades.common.domain.audit.AuditEvent;
+import com.healthupgrades.common.domain.audit.AuditOutcome;
 import com.healthupgrades.common.domain.exception.BusinessRuleException;
+import com.healthupgrades.common.domain.port.out.AuditTrail;
 import com.healthupgrades.common.security.JwtTokenProvider;
 import com.healthupgrades.user.application.port.in.UserCommand;
 import com.healthupgrades.user.application.port.in.UserQuery;
 import com.healthupgrades.user.domain.model.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AccountStatusException;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -27,6 +33,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder; // BCrypt encoder
     private final JwtTokenProvider tokenProvider; // issues JWTs
     private final AuthenticationManager authenticationManager; // verifies credentials on login
+    private final AuditTrail auditTrail; // records who signed in, and who was turned away
 
     /**
      * Registers a new user and issues a token for them.
@@ -41,16 +48,25 @@ public class AuthService {
      */
     @Transactional
     public AuthResult register(String name, String email, String password) {
-        if (userQuery.existsByEmail(email)) {
-            throw new BusinessRuleException("Email already registered: " + email);
+        // Recorded by hand rather than through AuditTrail.recording, because until the save returns
+        // there is no user id to name as the actor, and the email that would identify the attempt is
+        // exactly what NFR-6 says must not be written down.
+        try {
+            if (userQuery.existsByEmail(email)) {
+                throw new BusinessRuleException("Email already registered: " + email);
+            }
+            User user = User.builder()
+                    .name(name)
+                    .email(email)
+                    .passwordHash(passwordEncoder.encode(password)) // never store the raw password
+                    .build();
+            user = userCommand.save(user);
+            auditTrail.record(AuditEvent.allowed(AuditAction.AUTH_REGISTER, user.getId(), user.getId()));
+            return new AuthResult(tokenProvider.generateToken(user.getEmail()), user);
+        } catch (RuntimeException thrown) {
+            auditTrail.record(AuditEvent.from(AuditAction.AUTH_REGISTER, null, null, thrown));
+            throw thrown;
         }
-        User user = User.builder()
-                .name(name)
-                .email(email)
-                .passwordHash(passwordEncoder.encode(password)) // never store the raw password
-                .build();
-        user = userCommand.save(user);
-        return new AuthResult(tokenProvider.generateToken(user.getEmail()), user);
     }
 
     /**
@@ -64,10 +80,25 @@ public class AuthService {
      *         only reachable if the account is deleted mid-request
      */
     public AuthResult login(String email, String password) {
-        authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password)); // throws on bad creds
-        User user = userQuery.findByEmail(email)
-                .orElseThrow(() -> new BusinessRuleException("User not found"));
-        return new AuthResult(tokenProvider.generateToken(user.getEmail()), user);
+        try {
+            authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password)); // throws on bad creds
+            User user = userQuery.findByEmail(email)
+                    .orElseThrow(() -> new BusinessRuleException("User not found"));
+            auditTrail.record(AuditEvent.allowed(AuditAction.AUTH_LOGIN, user.getId(), user.getId()));
+            return new AuthResult(tokenProvider.generateToken(user.getEmail()), user);
+        } catch (BadCredentialsException | AccountStatusException refused) {
+            // A refused login is recorded with no subject at all. The submitted email is personal data
+            // (NFR-6) and there is no user id to name, because naming one would mean confirming that
+            // the account exists. What survives is the count and the trace id — a rate signal, not an
+            // attribution, which is the honest limit of auditing an anonymous endpoint.
+            auditTrail.record(new AuditEvent(AuditAction.AUTH_LOGIN, null, null, AuditOutcome.REFUSED));
+            throw refused;
+        } catch (RuntimeException thrown) {
+            // Everything else is a fault, not a rejection - the same distinction GlobalExceptionHandler
+            // draws when it refuses to report a database outage to the user as a wrong password.
+            auditTrail.record(AuditEvent.from(AuditAction.AUTH_LOGIN, null, null, thrown));
+            throw thrown;
+        }
     }
 
     /**

--- a/backend/src/main/java/com/healthupgrades/auth/application/AuthService.java
+++ b/backend/src/main/java/com/healthupgrades/auth/application/AuthService.java
@@ -61,8 +61,12 @@ public class AuthService {
                     .passwordHash(passwordEncoder.encode(password)) // never store the raw password
                     .build();
             user = userCommand.save(user);
+            // Recorded after the token exists, not before. Issuing it can fail - a secret too short to
+            // sign with - and recording ALLOWED first would then put one attempt in the trail twice,
+            // once as allowed and once as failed, with the counter double-counting to match.
+            AuthResult result = new AuthResult(tokenProvider.generateToken(user.getEmail()), user);
             auditTrail.record(AuditEvent.allowed(AuditAction.AUTH_REGISTER, user.getId(), user.getId()));
-            return new AuthResult(tokenProvider.generateToken(user.getEmail()), user);
+            return result;
         } catch (RuntimeException thrown) {
             auditTrail.record(AuditEvent.from(AuditAction.AUTH_REGISTER, null, null, thrown));
             throw thrown;
@@ -84,8 +88,11 @@ public class AuthService {
             authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password)); // throws on bad creds
             User user = userQuery.findByEmail(email)
                     .orElseThrow(() -> new BusinessRuleException("User not found"));
+            // As in register: after the token, so a signing failure cannot produce two entries for one
+            // sign-in attempt.
+            AuthResult result = new AuthResult(tokenProvider.generateToken(user.getEmail()), user);
             auditTrail.record(AuditEvent.allowed(AuditAction.AUTH_LOGIN, user.getId(), user.getId()));
-            return new AuthResult(tokenProvider.generateToken(user.getEmail()), user);
+            return result;
         } catch (BadCredentialsException | AccountStatusException refused) {
             // A refused login is recorded with no subject at all. The submitted email is personal data
             // (NFR-6) and there is no user id to name, because naming one would mean confirming that

--- a/backend/src/main/java/com/healthupgrades/common/adapter/out/audit/LoggingAuditTrail.java
+++ b/backend/src/main/java/com/healthupgrades/common/adapter/out/audit/LoggingAuditTrail.java
@@ -1,12 +1,15 @@
 package com.healthupgrades.common.adapter.out.audit;
 
 import com.healthupgrades.common.domain.audit.AuditEvent;
+import com.healthupgrades.common.domain.audit.AuditOutcome;
 import com.healthupgrades.common.domain.port.out.AuditTrail;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.UUID;
 
@@ -47,30 +50,73 @@ public class LoggingAuditTrail implements AuditTrail {
     /**
      * {@inheritDoc}
      *
-     * <p>INFO, because an audit entry is a state transition rather than a fault — a refusal is the
-     * system working. The level policy is in
-     * {@code docs/ADRs/ADR-010-structured-logging-and-a-level-policy.md}.
+     * <p><b>An {@code ALLOWED} entry waits for the commit.</b> Every caller wraps the body of an
+     * {@code @Transactional} service method, so the work returns while its transaction is still open —
+     * the commit happens afterwards, in the proxy. No repository adapter flushes, so a {@code @Version}
+     * clash or a unique constraint losing a race is decided <em>at commit</em>, after the service method
+     * has returned. Writing the entry at that point would have the trail and the counter both claim an
+     * edit succeeded while the caller was answered 409 and nothing was persisted. Deferring it through
+     * the same {@code afterCommit} route {@code NotificationService} already uses is what makes
+     * "allowed" mean what {@code ADR-011} says it means.
      *
-     * <p>The counter is derived here rather than incremented separately at the call site so the two can
-     * never disagree about what happened. Its tags are the action key and the outcome, both closed
-     * enums: the actor and the resource are deliberately not tags, because a user id as a label is an
-     * unbounded cardinality and a metrics backend is the wrong place to look one up anyway.
+     * <p>Refusals and faults are written immediately and deliberately: they already describe an attempt
+     * that did not land, they are the security-relevant half, and a process that dies before commit
+     * should not take them with it.
      */
     @Override
     public void record(AuditEvent event) {
-        log.info("{} {} {} {} {}",
-                keyValue("action", event.action().key()),
-                keyValue("outcome", event.outcome()),
-                keyValue("resource", event.action().resource()),
-                keyValue("actorId", idOrNone(event.actorUserId())),
-                keyValue("resourceId", idOrNone(event.resourceId())));
+        if (event.outcome() == AuditOutcome.ALLOWED && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCompletion(int status) {
+                    // afterCompletion rather than afterCommit, so a rollback is recorded rather than
+                    // leaving the attempt with no entry at all.
+                    write(status == STATUS_COMMITTED ? event : event.refused());
+                }
+            });
+            return;
+        }
+        write(event);
+    }
 
-        Counter.builder(COUNTER)
-                .description("Audited attempts, by what was attempted and how it ended")
-                .tag("action", event.action().key())
-                .tag("outcome", event.outcome().name())
-                .register(meterRegistry)
-                .increment();
+    /**
+     * Writes one entry, and never lets a failure to do so fail the work being audited.
+     *
+     * <p>The port says implementations must not throw, and this is where that is honoured. It matters
+     * most on the refusal path: {@code AuditTrail.recording} calls this from inside its catch block, so
+     * an exception escaping here would <em>replace</em> the business exception — turning a
+     * {@code BusinessRuleException} that should be a 422 into an unhandled 500 with the real cause lost.
+     *
+     * <p>The two halves are guarded separately so a meter failure still leaves the audit line, which is
+     * the half that matters. If the logging subsystem itself is what failed there is nowhere left to
+     * report it, and the second write will throw for the same reason the first did.
+     */
+    private void write(AuditEvent event) {
+        try {
+            log.info("{} {} {} {} {}",
+                    keyValue("action", event.action().key()),
+                    keyValue("outcome", event.outcome()),
+                    keyValue("resource", event.action().resource()),
+                    keyValue("actorId", idOrNone(event.actorUserId())),
+                    keyValue("resourceId", idOrNone(event.resourceId())));
+        } catch (RuntimeException unwritable) {
+            return; // Nothing can be reported about a broken logger, by a logger.
+        }
+
+        try {
+            // Derived from the same call as the line above, so the count and the trail cannot disagree.
+            // Tagged by action and outcome only: both are closed enums, whereas an actor or a resource
+            // id is an unbounded label, and a metrics backend is the wrong place to look one up anyway.
+            Counter.builder(COUNTER)
+                    .description("Audited attempts, by what was attempted and how it ended")
+                    .tag("action", event.action().key())
+                    .tag("outcome", event.outcome().name())
+                    .register(meterRegistry)
+                    .increment();
+        } catch (RuntimeException uncountable) {
+            log.error("{} was recorded but could not be counted",
+                    keyValue("action", event.action().key()), uncountable);
+        }
     }
 
     /**

--- a/backend/src/main/java/com/healthupgrades/common/adapter/out/audit/LoggingAuditTrail.java
+++ b/backend/src/main/java/com/healthupgrades/common/adapter/out/audit/LoggingAuditTrail.java
@@ -1,0 +1,85 @@
+package com.healthupgrades.common.adapter.out.audit;
+
+import com.healthupgrades.common.domain.audit.AuditEvent;
+import com.healthupgrades.common.domain.port.out.AuditTrail;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
+
+/**
+ * Adapter writing the audit trail to its own log stream, and counting the same events as it goes.
+ *
+ * <p><b>Why a log stream and not a table.</b> An audit entry has to survive the transaction it observes:
+ * a refused transition rolls back, and a row written inside that transaction would roll back with it —
+ * exactly the entry somebody was looking for. It also arrives already correlated, because the trace id
+ * is on the line, so an entry leads back to the request that produced it without a foreign key.
+ * {@code docs/ADRs/ADR-011-audit-as-a-log-stream.md} records the decision and what would reverse it.
+ *
+ * <p>The logger is named {@code AUDIT} rather than after this class so the stream can be routed or
+ * filtered on its own, by a level or by an appender, without knowing where in the package tree it is
+ * written from.
+ *
+ * <p>Fields are emitted through {@code StructuredArguments}, which renders {@code key=value} into the
+ * message for a person reading the console and a first-class JSON field for anything querying it — one
+ * statement that is legible in both of the formats {@code logback-spring.xml} selects between.
+ */
+@Component
+public class LoggingAuditTrail implements AuditTrail {
+
+    /** Not this class's name: the stream is the thing being addressed, not the writer. */
+    private static final Logger log = LoggerFactory.getLogger("AUDIT");
+
+    private static final String COUNTER = "audit.events";
+    private static final String UNKNOWN = "none";
+
+    private final MeterRegistry meterRegistry;
+
+    public LoggingAuditTrail(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>INFO, because an audit entry is a state transition rather than a fault — a refusal is the
+     * system working. The level policy is in
+     * {@code docs/ADRs/ADR-010-structured-logging-and-a-level-policy.md}.
+     *
+     * <p>The counter is derived here rather than incremented separately at the call site so the two can
+     * never disagree about what happened. Its tags are the action key and the outcome, both closed
+     * enums: the actor and the resource are deliberately not tags, because a user id as a label is an
+     * unbounded cardinality and a metrics backend is the wrong place to look one up anyway.
+     */
+    @Override
+    public void record(AuditEvent event) {
+        log.info("{} {} {} {} {}",
+                keyValue("action", event.action().key()),
+                keyValue("outcome", event.outcome()),
+                keyValue("resource", event.action().resource()),
+                keyValue("actorId", idOrNone(event.actorUserId())),
+                keyValue("resourceId", idOrNone(event.resourceId())));
+
+        Counter.builder(COUNTER)
+                .description("Audited attempts, by what was attempted and how it ended")
+                .tag("action", event.action().key())
+                .tag("outcome", event.outcome().name())
+                .register(meterRegistry)
+                .increment();
+    }
+
+    /**
+     * Renders an absent identifier as a value rather than as {@code null}.
+     *
+     * <p>"There is no actor" is a fact worth recording — a refused login has one deliberately, since
+     * the submitted email is personal data — and a stable field set is what makes the stream queryable.
+     */
+    private static String idOrNone(UUID id) {
+        return id == null ? UNKNOWN : id.toString();
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/common/domain/audit/AuditAction.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/audit/AuditAction.java
@@ -1,0 +1,76 @@
+package com.healthupgrades.common.domain.audit;
+
+/**
+ * The closed vocabulary of things this application audits.
+ *
+ * <p>An enum rather than a string for three reasons: it is a metric label and therefore has to be
+ * bounded; a typo cannot reach production; and reading this file is how somebody finds out what the
+ * audit trail does and does not cover, which a scattering of string literals would never tell them.
+ *
+ * <p>It lives in {@code common} because the audit trail is one trail, not nine. That does mean a
+ * context adding an operation edits a file outside itself — the same trade-off the shared kernel makes
+ * everywhere else, and the reason it is worth paying here is that the alternative is a per-context
+ * vocabulary nobody can enumerate.
+ *
+ * <p><b>What is deliberately absent:</b> notifications. They are raised by schedulers and event
+ * listeners rather than by a person — {@code dispatchReminders} alone runs every minute — so auditing
+ * them would record the system talking to itself, at volume, under the heading of who did what.
+ * Marking one read is a display flag, not a change to the user's record.
+ * See {@code docs/ADRs/ADR-011-audit-as-a-log-stream.md}.
+ */
+public enum AuditAction {
+
+    /** A visitor registered and became a user. */
+    AUTH_REGISTER("auth.register", AuditedResource.USER),
+
+    /** Somebody presented credentials. Refused as often as allowed, and both are worth knowing. */
+    AUTH_LOGIN("auth.login", AuditedResource.USER),
+
+    UPGRADE_CREATE("upgrade.create", AuditedResource.HEALTH_UPGRADE),
+    UPGRADE_UPDATE("upgrade.update", AuditedResource.HEALTH_UPGRADE),
+    UPGRADE_DELETE("upgrade.delete", AuditedResource.HEALTH_UPGRADE),
+    UPGRADE_PLAN("upgrade.plan", AuditedResource.HEALTH_UPGRADE),
+    UPGRADE_ACTIVATE("upgrade.activate", AuditedResource.HEALTH_UPGRADE),
+    UPGRADE_PAUSE("upgrade.pause", AuditedResource.HEALTH_UPGRADE),
+    UPGRADE_COMPLETE("upgrade.complete", AuditedResource.HEALTH_UPGRADE),
+    UPGRADE_ABANDON("upgrade.abandon", AuditedResource.HEALTH_UPGRADE),
+    UPGRADE_RESCHEDULE("upgrade.reschedule", AuditedResource.HEALTH_UPGRADE),
+
+    AREA_CREATE("area.create", AuditedResource.HEALTH_AREA),
+    AREA_UPDATE("area.update", AuditedResource.HEALTH_AREA),
+    AREA_DELETE("area.delete", AuditedResource.HEALTH_AREA),
+
+    /** Changing how an upgrade is measured changes what its past progress means. */
+    TRACKING_CONFIGURE("tracking.configure", AuditedResource.TRACKING_CONFIG),
+    PROGRESS_RECORD("progress.record", AuditedResource.PROGRESS_ENTRY),
+
+    /** Reflections are append-only (BR-13), so there is nothing else to audit about one. */
+    REFLECTION_CREATE("reflection.create", AuditedResource.REFLECTION),
+
+    REMINDER_CREATE("reminder.create", AuditedResource.REMINDER),
+    REMINDER_UPDATE("reminder.update", AuditedResource.REMINDER),
+    REMINDER_DELETE("reminder.delete", AuditedResource.REMINDER);
+
+    private final String key;
+    private final AuditedResource resource;
+
+    AuditAction(String key, AuditedResource resource) {
+        this.key = key;
+        this.resource = resource;
+    }
+
+    /**
+     * The dotted name written to the log and used as a metric tag.
+     *
+     * <p>Stable on purpose: it is what a saved log query or a dashboard matches on, so it is a contract
+     * and not a display string. Renaming a constant is free; changing a key is a breaking change.
+     */
+    public String key() {
+        return key;
+    }
+
+    /** The kind of record this action acts on. */
+    public AuditedResource resource() {
+        return resource;
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/common/domain/audit/AuditEvent.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/audit/AuditEvent.java
@@ -42,4 +42,17 @@ public record AuditEvent(AuditAction action, UUID actorUserId, UUID resourceId, 
     public static AuditEvent from(AuditAction action, UUID actorUserId, UUID resourceId, RuntimeException thrown) {
         return new AuditEvent(action, actorUserId, resourceId, AuditOutcome.of(thrown));
     }
+
+    /**
+     * The same attempt, recorded as refused.
+     *
+     * <p>For the case where the work returned but its transaction did not commit — an optimistic-lock
+     * clash or a unique constraint losing a race, both decided by the database after the service method
+     * has already returned. The reason is not knowable at that point, so it is recorded as a refusal
+     * rather than a fault: the likely causes are the database declining the write, and calling every one
+     * of them {@link AuditOutcome#FAILED} would drown the signal that outcome exists to raise.
+     */
+    public AuditEvent refused() {
+        return new AuditEvent(action, actorUserId, resourceId, AuditOutcome.REFUSED);
+    }
 }

--- a/backend/src/main/java/com/healthupgrades/common/domain/audit/AuditEvent.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/audit/AuditEvent.java
@@ -1,0 +1,45 @@
+package com.healthupgrades.common.domain.audit;
+
+import java.util.UUID;
+
+/**
+ * One entry in the audit trail: who attempted what, against which record, and how it ended.
+ *
+ * <p><b>There is deliberately nowhere to put free text.</b> Every field is an enum or an identifier,
+ * so NFR-6 — the application does not log personal data — is enforced by the type rather than by
+ * whoever reviews the next call site. An upgrade's title, a reflection's body and an email address
+ * cannot be audited because they cannot be represented. When an audit entry is not enough to
+ * understand what happened, the trace id on the line leads to the request that produced it.
+ *
+ * <p>The occurrence time is not a field either: the log line is timestamped by the logging framework,
+ * and a second timestamp chosen by a caller would only ever be a way for the two to disagree.
+ *
+ * @param action     what was attempted
+ * @param actorUserId the user who attempted it, or {@code null} where the actor is genuinely unknown —
+ *                    a refused login is the case that matters, since the submitted email is personal
+ *                    data and is therefore never recorded
+ * @param resourceId  the record acted on, or {@code null} where there is not one: registration has no
+ *                    user yet, and a login acts on no record at all
+ * @param outcome     how the attempt ended
+ */
+public record AuditEvent(AuditAction action, UUID actorUserId, UUID resourceId, AuditOutcome outcome) {
+
+    /**
+     * @throws IllegalArgumentException if the action or outcome is missing, which would produce an
+     *         entry that cannot be read or counted
+     */
+    public AuditEvent {
+        if (action == null) throw new IllegalArgumentException("An audit event must name its action");
+        if (outcome == null) throw new IllegalArgumentException("An audit event must state its outcome");
+    }
+
+    /** The attempt succeeded. */
+    public static AuditEvent allowed(AuditAction action, UUID actorUserId, UUID resourceId) {
+        return new AuditEvent(action, actorUserId, resourceId, AuditOutcome.ALLOWED);
+    }
+
+    /** The attempt ended in the exception given, classified by {@link AuditOutcome#of}. */
+    public static AuditEvent from(AuditAction action, UUID actorUserId, UUID resourceId, RuntimeException thrown) {
+        return new AuditEvent(action, actorUserId, resourceId, AuditOutcome.of(thrown));
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/common/domain/audit/AuditOutcome.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/audit/AuditOutcome.java
@@ -1,0 +1,46 @@
+package com.healthupgrades.common.domain.audit;
+
+import com.healthupgrades.common.domain.exception.BusinessRuleException;
+import com.healthupgrades.common.domain.exception.DuplicateProgressException;
+import com.healthupgrades.common.domain.exception.OptimisticLockException;
+import com.healthupgrades.common.domain.exception.ResourceNotFoundException;
+
+/**
+ * How an audited attempt ended.
+ *
+ * <p>The distinction between {@link #REFUSED} and {@link #FAILED} is the whole point of having three
+ * values rather than two: a refusal is the system working — somebody asked for something the rules do
+ * not allow — while a failure is the system broken. Collapsing them would make the one alerting signal
+ * worth having indistinguishable from ordinary traffic.
+ */
+public enum AuditOutcome {
+
+    /** The attempt was allowed and completed. */
+    ALLOWED,
+
+    /** The system decided no: a rule, an ownership check or a conflict refused it. Nobody is paged. */
+    REFUSED,
+
+    /** The attempt did not complete because something broke. Someone has to look. */
+    FAILED;
+
+    /**
+     * Classifies the exception an audited operation threw.
+     *
+     * <p>The four exceptions in {@code common.domain.exception} are the vocabulary this application
+     * uses for "no", so they are refusals and everything else is a fault. Listing them explicitly
+     * rather than testing a package name keeps the classification greppable, and a fifth exception
+     * added later and forgotten here is recorded {@link #FAILED} — visibly wrong in a dashboard rather
+     * than silently miscounted.
+     *
+     * @param thrown what the operation threw
+     * @return {@link #REFUSED} for a decision, {@link #FAILED} for a fault
+     */
+    public static AuditOutcome of(RuntimeException thrown) {
+        boolean refusal = thrown instanceof BusinessRuleException
+                || thrown instanceof ResourceNotFoundException
+                || thrown instanceof DuplicateProgressException
+                || thrown instanceof OptimisticLockException;
+        return refusal ? REFUSED : FAILED;
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/common/domain/audit/AuditOutcome.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/audit/AuditOutcome.java
@@ -33,6 +33,13 @@ public enum AuditOutcome {
      * added later and forgotten here is recorded {@link #FAILED} — visibly wrong in a dashboard rather
      * than silently miscounted.
      *
+     * <p>Note what does <em>not</em> arrive here: a {@code @Version} clash decided at commit. No
+     * repository adapter flushes, so that exception is thrown by the transaction proxy after the
+     * service method has returned — outside any call this classifier sees. The audit adapter handles it
+     * on the rollback path instead, which is why {@code OptimisticLockException} being listed below is
+     * about keeping this function total over the domain's vocabulary for "no", not about a path that
+     * reaches it today.
+     *
      * @param thrown what the operation threw
      * @return {@link #REFUSED} for a decision, {@link #FAILED} for a fault
      */

--- a/backend/src/main/java/com/healthupgrades/common/domain/audit/AuditedResource.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/audit/AuditedResource.java
@@ -1,0 +1,32 @@
+package com.healthupgrades.common.domain.audit;
+
+/**
+ * The kinds of record an audited action can act on.
+ *
+ * <p>Each {@link AuditAction} names its own, so a call site cannot pair an action with the wrong kind
+ * of resource. It is a closed set for the same reason the actions are: it is a metric label, and a
+ * label whose values are not bounded is a cardinality problem waiting to happen.
+ */
+public enum AuditedResource {
+
+    /** A user account. */
+    USER,
+
+    /** A health upgrade — the aggregate this application exists to move through a lifecycle. */
+    HEALTH_UPGRADE,
+
+    /** A health area an upgrade can be filed under. */
+    HEALTH_AREA,
+
+    /** How an upgrade is measured. */
+    TRACKING_CONFIG,
+
+    /** One day's progress against one upgrade. */
+    PROGRESS_ENTRY,
+
+    /** A written reflection about an upgrade. */
+    REFLECTION,
+
+    /** A reminder attached to an upgrade. */
+    REMINDER
+}

--- a/backend/src/main/java/com/healthupgrades/common/domain/port/out/AuditTrail.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/port/out/AuditTrail.java
@@ -4,6 +4,7 @@ import com.healthupgrades.common.domain.audit.AuditAction;
 import com.healthupgrades.common.domain.audit.AuditEvent;
 
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -52,5 +53,28 @@ public interface AuditTrail {
             operation.run();
             return null;
         });
+    }
+
+    /**
+     * Runs an operation that brings a record into existence, and names that record in the entry.
+     *
+     * <p>A creation cannot use {@link #recording(AuditAction, UUID, UUID, Supplier)}: the resource id is
+     * an argument there, and a new upgrade has no id until the save returns — so the entry would say
+     * somebody created something without saying what. That is the one question a creation entry exists
+     * to answer.
+     *
+     * @param createdId reads the new record's id off the result, once there is one
+     */
+    default <T> T recordingCreation(AuditAction action, UUID actorUserId, Supplier<T> operation,
+                                    Function<T, UUID> createdId) {
+        try {
+            T result = operation.get();
+            record(AuditEvent.allowed(action, actorUserId, createdId.apply(result)));
+            return result;
+        } catch (RuntimeException thrown) {
+            // Nothing was created, so there is genuinely no resource to name.
+            record(AuditEvent.from(action, actorUserId, null, thrown));
+            throw thrown;
+        }
     }
 }

--- a/backend/src/main/java/com/healthupgrades/common/domain/port/out/AuditTrail.java
+++ b/backend/src/main/java/com/healthupgrades/common/domain/port/out/AuditTrail.java
@@ -1,0 +1,56 @@
+package com.healthupgrades.common.domain.port.out;
+
+import com.healthupgrades.common.domain.audit.AuditAction;
+import com.healthupgrades.common.domain.audit.AuditEvent;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+/**
+ * Outbound port for recording what was attempted against a user's records, and whether it was allowed.
+ *
+ * <p>Cross-cutting rather than owned by one context, like {@link DomainEventPublisher} beside it: every
+ * context records through it, and {@code common.domain.audit} holds the vocabulary they share.
+ *
+ * <p>Implementers write one method. The {@code recording} wrappers are defaults rather than call-site
+ * try/catch because <b>a trail that records only successes is not a trail</b> — an ownership check that
+ * refused, a rule that rejected a transition and a conflict that lost a race are the entries somebody
+ * will actually go looking for. Leaving that to each call site means it is written twenty times and
+ * forgotten once.
+ */
+public interface AuditTrail {
+
+    /** Records one attempt. Implementations must not throw: an audit failure must not fail the work. */
+    void record(AuditEvent event);
+
+    /**
+     * Runs an operation that produces something, and records how it ended either way.
+     *
+     * <p>The exception is rethrown untouched, so the caller's contract and the HTTP status mapping are
+     * unchanged — this observes the operation, it does not handle it.
+     *
+     * @param action      what is being attempted
+     * @param actorUserId the user attempting it
+     * @param resourceId  the record acted on, or {@code null} when there is not one yet
+     * @param operation   the work to run and observe
+     * @return whatever the operation returned
+     */
+    default <T> T recording(AuditAction action, UUID actorUserId, UUID resourceId, Supplier<T> operation) {
+        try {
+            T result = operation.get();
+            record(AuditEvent.allowed(action, actorUserId, resourceId));
+            return result;
+        } catch (RuntimeException thrown) {
+            record(AuditEvent.from(action, actorUserId, resourceId, thrown));
+            throw thrown;
+        }
+    }
+
+    /** As {@link #recording(AuditAction, UUID, UUID, Supplier)}, for an operation that returns nothing. */
+    default void recording(AuditAction action, UUID actorUserId, UUID resourceId, Runnable operation) {
+        recording(action, actorUserId, resourceId, () -> {
+            operation.run();
+            return null;
+        });
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/common/observability/JobMetrics.java
+++ b/backend/src/main/java/com/healthupgrades/common/observability/JobMetrics.java
@@ -16,9 +16,10 @@ import org.springframework.stereotype.Component;
  * it still working", and {@code scheduled.job.duration} answers "is it about to stop finishing before
  * the next one starts".
  *
- * <p><b>The failure is rethrown, not handled.</b> Spring's scheduler already logs a task that threw, at
+ * <p><b>The failure is not caught at all.</b> Spring's scheduler already logs a task that threw, at
  * ERROR, through its default error handler — catching it here to log it again would produce two entries
- * for one fault and hide the stack trace behind a summary. This only counts it on the way past.
+ * for one fault and hide the stack trace behind a summary. Nothing is caught here, so nothing can be
+ * swallowed or silently reclassified on the way past.
  *
  * <p>The job name is a tag, so it is a closed set by construction: the constants live beside the
  * {@code @Scheduled} methods that use them and there are three of them. Nothing per-user or per-record
@@ -40,16 +41,22 @@ public class JobMetrics {
      *
      * @param job  the job's stable name, used as a metric tag
      * @param work the job body
-     * @throws RuntimeException whatever the job threw, untouched, so the scheduler still reports it
+     * @throws RuntimeException whatever the job threw, untouched, so the scheduler still reports it. An
+     *         {@link Error} propagates the same way and is counted as a failure, not as a clean run
      */
     public void timed(String job, Runnable work) {
         Timer.Sample sample = Timer.start(meterRegistry);
-        String outcome = OK;
+        // Pessimistic, and set to OK only once the body has actually returned. Deciding the outcome in a
+        // catch means choosing which throwables to catch, and anything not chosen - an Error, so
+        // NoClassDefFoundError, ExceptionInInitializerError and OutOfMemoryError - would walk past the
+        // assignment into the finally below and be counted as a clean run. That is the exact failure
+        // this class exists to surface: a scheduled job answers nobody with a 500, so this counter is
+        // the only signal there is, and it would sit at zero failures while the sweep had not worked
+        // for a week.
+        String outcome = FAILED;
         try {
             work.run();
-        } catch (RuntimeException thrown) {
-            outcome = FAILED;
-            throw thrown;
+            outcome = OK;
         } finally {
             sample.stop(Timer.builder(DURATION)
                     .description("How long a scheduled run took")

--- a/backend/src/main/java/com/healthupgrades/common/observability/JobMetrics.java
+++ b/backend/src/main/java/com/healthupgrades/common/observability/JobMetrics.java
@@ -1,0 +1,66 @@
+package com.healthupgrades.common.observability;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Times a scheduled run and counts how it ended.
+ *
+ * <p>Scheduled work is the part of this application nobody is watching. A request that fails answers
+ * somebody with a 500; a nightly sweep that has been throwing for a week looks exactly like a nightly
+ * sweep with nothing to do. These two meters are the difference, and they are the reason the jobs get
+ * instrumented at all: {@code scheduled.job.runs} split by outcome answers "is it still running, and is
+ * it still working", and {@code scheduled.job.duration} answers "is it about to stop finishing before
+ * the next one starts".
+ *
+ * <p><b>The failure is rethrown, not handled.</b> Spring's scheduler already logs a task that threw, at
+ * ERROR, through its default error handler — catching it here to log it again would produce two entries
+ * for one fault and hide the stack trace behind a summary. This only counts it on the way past.
+ *
+ * <p>The job name is a tag, so it is a closed set by construction: the constants live beside the
+ * {@code @Scheduled} methods that use them and there are three of them. Nothing per-user or per-record
+ * may join it — see {@code docs/ADRs/ADR-012-metrics-through-a-prometheus-scrape-endpoint.md}.
+ */
+@Component
+@RequiredArgsConstructor
+public class JobMetrics {
+
+    private static final String RUNS = "scheduled.job.runs";
+    private static final String DURATION = "scheduled.job.duration";
+    private static final String OK = "ok";
+    private static final String FAILED = "failed";
+
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * Runs a scheduled job, recording how long it took and whether it finished.
+     *
+     * @param job  the job's stable name, used as a metric tag
+     * @param work the job body
+     * @throws RuntimeException whatever the job threw, untouched, so the scheduler still reports it
+     */
+    public void timed(String job, Runnable work) {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = OK;
+        try {
+            work.run();
+        } catch (RuntimeException thrown) {
+            outcome = FAILED;
+            throw thrown;
+        } finally {
+            sample.stop(Timer.builder(DURATION)
+                    .description("How long a scheduled run took")
+                    .tag("job", job)
+                    .register(meterRegistry));
+            Counter.builder(RUNS)
+                    .description("Scheduled runs, by job and how they ended")
+                    .tag("job", job)
+                    .tag("outcome", outcome)
+                    .register(meterRegistry)
+                    .increment();
+        }
+    }
+}

--- a/backend/src/main/java/com/healthupgrades/common/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/healthupgrades/common/security/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -25,6 +26,7 @@ import java.io.IOException;
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider tokenProvider;
@@ -65,6 +67,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             userDetails = userDetailsService.loadUserByUsername(email);
         } catch (UsernameNotFoundException ex) {
+            // WARN, not DEBUG: the signature verified, so this token was issued by us and is being
+            // presented for an account that no longer exists. Ordinary expiry does not reach here.
+            // Nothing identifies the subject — the email is the only handle we have and it is personal
+            // data (NFR-6) — so this is a rate signal, joined to its request by the trace id.
+            log.warn("A validly signed token names an account that no longer exists; request left anonymous");
             return;
         }
         UsernamePasswordAuthenticationToken auth =

--- a/backend/src/main/java/com/healthupgrades/common/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/healthupgrades/common/security/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.healthupgrades.common.security;
 
+import lombok.extern.slf4j.Slf4j;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,6 +22,7 @@ import java.util.Date;
  * rather than weakening every token silently.
  */
 @Component
+@Slf4j
 public class JwtTokenProvider {
 
     private final SecretKey secretKey;
@@ -87,6 +89,12 @@ public class JwtTokenProvider {
             // A rejected token is an expected outcome on a public endpoint, not a fault: the caller's
             // contract is a boolean, and the reason is withheld on purpose — telling an unauthenticated
             // caller whether a token expired or was forged is free information for an attacker.
+            //
+            // Withheld from the caller, not from us. DEBUG, because an expired token is the most
+            // ordinary thing that happens here and this would otherwise be a line per stale tab. The
+            // exception's type distinguishes "expired" from "forged"; its message is not logged,
+            // because a JJWT message can quote the malformed token back.
+            log.debug("Rejected a token: {}", e.getClass().getSimpleName());
             return false;
         }
     }

--- a/backend/src/main/java/com/healthupgrades/common/websocket/JwtChannelInterceptor.java
+++ b/backend/src/main/java/com/healthupgrades/common/websocket/JwtChannelInterceptor.java
@@ -4,6 +4,7 @@ import com.healthupgrades.common.security.JwtTokenProvider;
 import com.healthupgrades.user.application.port.in.UserQuery;
 import com.healthupgrades.user.domain.model.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtChannelInterceptor implements ChannelInterceptor {
 
     private final JwtTokenProvider tokenProvider;
@@ -42,15 +44,24 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
         if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
             String authHeader = accessor.getFirstNativeHeader("Authorization");
             if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+                // DEBUG for all three refusals: /ws is a public endpoint and a reconnecting client with
+                // a stale token is routine. The reason is recorded because the three are diagnosed
+                // differently — a missing header is a client bug, an unknown user is a deleted account.
+                // Spring turns the exception into a refused connection and does not log one itself.
+                log.debug("Refused a STOMP CONNECT: no bearer token");
                 throw new IllegalArgumentException("Missing or malformed Authorization header on STOMP CONNECT");
             }
             String token = authHeader.substring(7);
             if (!tokenProvider.validateToken(token)) {
+                log.debug("Refused a STOMP CONNECT: the token did not validate");
                 throw new IllegalArgumentException("Invalid JWT on STOMP CONNECT");
             }
             String email = tokenProvider.extractEmail(token);
             User user = userQuery.findByEmail(email)
-                    .orElseThrow(() -> new IllegalArgumentException("Unknown user on STOMP CONNECT"));
+                    .orElseThrow(() -> {
+                        log.warn("Refused a STOMP CONNECT: a validly signed token names an account that no longer exists");
+                        return new IllegalArgumentException("Unknown user on STOMP CONNECT");
+                    });
             accessor.setUser(new StompPrincipal(user.getId().toString()));
         }
         return message;

--- a/backend/src/main/java/com/healthupgrades/healtharea/application/HealthAreaService.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/application/HealthAreaService.java
@@ -36,8 +36,7 @@ public class HealthAreaService implements HealthAreaQuery {
      */
     @Transactional
     public HealthArea create(UUID userId, HealthAreaDetails details) {
-        // No resource id yet: the area does not exist until the save below returns.
-        return auditTrail.recording(AuditAction.AREA_CREATE, userId, null, () -> {
+        return auditTrail.recordingCreation(AuditAction.AREA_CREATE, userId, () -> {
             HealthArea area = HealthArea.builder()
                     .userId(userId)
                     .name(details.name())
@@ -47,7 +46,7 @@ public class HealthAreaService implements HealthAreaQuery {
                     .color(details.color())
                     .build();
             return repository.save(area);
-        });
+        }, HealthArea::getId);
     }
 
     /**

--- a/backend/src/main/java/com/healthupgrades/healtharea/application/HealthAreaService.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/application/HealthAreaService.java
@@ -1,6 +1,8 @@
 package com.healthupgrades.healtharea.application;
 
 import com.healthupgrades.common.domain.exception.ResourceNotFoundException;
+import com.healthupgrades.common.domain.audit.AuditAction;
+import com.healthupgrades.common.domain.port.out.AuditTrail;
 import com.healthupgrades.healtharea.application.port.in.HealthAreaDetails;
 import com.healthupgrades.healtharea.application.port.in.HealthAreaQuery;
 import com.healthupgrades.healtharea.domain.model.HealthArea;
@@ -23,6 +25,7 @@ import java.util.UUID;
 public class HealthAreaService implements HealthAreaQuery {
 
     private final HealthAreaRepositoryPort repository;
+    private final AuditTrail auditTrail; // records the attempt, allowed or refused
 
     /**
      * Creates a health area owned by the given user.
@@ -33,15 +36,18 @@ public class HealthAreaService implements HealthAreaQuery {
      */
     @Transactional
     public HealthArea create(UUID userId, HealthAreaDetails details) {
-        HealthArea area = HealthArea.builder()
-                .userId(userId)
-                .name(details.name())
-                .description(details.description())
-                .priority(details.priority())
-                .icon(details.icon())
-                .color(details.color())
-                .build();
-        return repository.save(area);
+        // No resource id yet: the area does not exist until the save below returns.
+        return auditTrail.recording(AuditAction.AREA_CREATE, userId, null, () -> {
+            HealthArea area = HealthArea.builder()
+                    .userId(userId)
+                    .name(details.name())
+                    .description(details.description())
+                    .priority(details.priority())
+                    .icon(details.icon())
+                    .color(details.color())
+                    .build();
+            return repository.save(area);
+        });
     }
 
     /**
@@ -67,13 +73,15 @@ public class HealthAreaService implements HealthAreaQuery {
      */
     @Transactional
     public HealthArea update(UUID userId, UUID id, HealthAreaDetails details) {
-        HealthArea area = getOwnedArea(userId, id);
-        area.setName(details.name());
-        area.setDescription(details.description());
-        area.setPriority(details.priority());
-        area.setIcon(details.icon());
-        area.setColor(details.color());
-        return repository.save(area);
+        return auditTrail.recording(AuditAction.AREA_UPDATE, userId, id, () -> {
+            HealthArea area = getOwnedArea(userId, id);
+            area.setName(details.name());
+            area.setDescription(details.description());
+            area.setPriority(details.priority());
+            area.setIcon(details.icon());
+            area.setColor(details.color());
+            return repository.save(area);
+        });
     }
 
     /**
@@ -89,7 +97,8 @@ public class HealthAreaService implements HealthAreaQuery {
      */
     @Transactional
     public void delete(UUID userId, UUID id) {
-        repository.delete(getOwnedArea(userId, id));
+        auditTrail.recording(AuditAction.AREA_DELETE, userId, id,
+                () -> repository.delete(getOwnedArea(userId, id)));
     }
 
     /**

--- a/backend/src/main/java/com/healthupgrades/notification/adapter/in/scheduling/NotificationScheduler.java
+++ b/backend/src/main/java/com/healthupgrades/notification/adapter/in/scheduling/NotificationScheduler.java
@@ -25,7 +25,6 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -75,23 +74,27 @@ public class NotificationScheduler {
                     .collect(Collectors.groupingBy(HealthUpgrade::getUserId));
 
             // A count, not a list of user ids: the point is whether the nudge went out at a plausible
-            // volume, and who was nudged is in their own notification list.
-            AtomicInteger nudged = new AtomicInteger();
-            activeByUser.forEach((userId, upgrades) -> {
+            // volume, and who was nudged is in their own notification list. A plain int in a plain loop -
+            // this map is walked on one thread, and an atomic would advertise a concurrency requirement
+            // that does not exist and send the next reader looking for it.
+            int nudged = 0;
+            for (Map.Entry<UUID, List<HealthUpgrade>> nudgeable : activeByUser.entrySet()) {
+                UUID userId = nudgeable.getKey();
+                List<HealthUpgrade> upgrades = nudgeable.getValue();
                 boolean alreadyNudged = notificationRepository.existsByUserIdAndTypeAndCreatedAtAfter(
                         userId, NotificationType.CHECKIN_REMINDER, today.atStartOfDay());
                 boolean loggedToday = !progressQuery.findByUserIdAndDate(userId, today).isEmpty();
                 if (!alreadyNudged && !loggedToday) {
-                    nudged.incrementAndGet();
+                    nudged++;
                     notificationService.create(userId, NotificationType.CHECKIN_REMINDER, NotificationCategory.REMINDER,
                             "Daily check-in ⏳",
                             "You have " + upgrades.size() + " active upgrade" + (upgrades.size() == 1 ? "" : "s")
                                     + " to track today.", null);
                 }
-            });
+            }
 
             log.info("{} {} {}", keyValue("job", CHECKIN_JOB),
-                    keyValue("usersWithActiveUpgrades", activeByUser.size()), keyValue("nudged", nudged.get()));
+                    keyValue("usersWithActiveUpgrades", activeByUser.size()), keyValue("nudged", nudged));
         });
     }
 
@@ -135,10 +138,16 @@ public class NotificationScheduler {
                 }
             }
 
-            // due != fired means a reminder outlived the upgrade it hangs off - a real inconsistency,
-            // and invisible before this line because the loop skips it in silence.
             log.info("{} {} {}", keyValue("job", REMINDERS_JOB), keyValue("due", due.size()),
                     keyValue("fired", fired));
+
+            // A reminder that outlived the upgrade it hangs off. Degraded but still serving, which
+            // ADR-010 defines as WARN - leaving it as two INFO fields nobody diffs would report a real
+            // inconsistency at the level reserved for things going normally.
+            int orphaned = due.size() - fired;
+            if (orphaned > 0) {
+                log.warn("{} {}", keyValue("event", "reminder.orphaned"), keyValue("count", orphaned));
+            }
         });
     }
 

--- a/backend/src/main/java/com/healthupgrades/notification/adapter/in/scheduling/NotificationScheduler.java
+++ b/backend/src/main/java/com/healthupgrades/notification/adapter/in/scheduling/NotificationScheduler.java
@@ -1,5 +1,6 @@
 package com.healthupgrades.notification.adapter.in.scheduling;
 
+import com.healthupgrades.common.observability.JobMetrics;
 import com.healthupgrades.notification.application.NotificationService;
 import com.healthupgrades.notification.domain.model.NotificationCategory;
 import com.healthupgrades.notification.domain.model.NotificationType;
@@ -11,8 +12,11 @@ import com.healthupgrades.upgrade.application.port.in.UpgradeQuery;
 import com.healthupgrades.upgrade.domain.model.HealthUpgrade;
 import com.healthupgrades.upgrade.domain.model.UpgradeStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
 
 import java.time.Clock;
 import java.time.DayOfWeek;
@@ -21,6 +25,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -40,13 +45,19 @@ import java.util.stream.Collectors;
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class NotificationScheduler {
+
+    /** Stable across releases: these are metric tags and log fields, so they are a contract. */
+    private static final String CHECKIN_JOB = "notification.daily-checkin";
+    private static final String REMINDERS_JOB = "notification.reminder-dispatch";
 
     private final UpgradeQuery upgradeQuery; // inbound port: upgrades
     private final ProgressQuery progressQuery; // inbound port: progress entries
     private final ReminderQuery reminderQuery; // inbound port: enabled reminders
     private final NotificationRepositoryPort notificationRepository; // own outbound port (dedup guards)
     private final NotificationService notificationService; // own application service (create + push)
+    private final JobMetrics jobMetrics; // times each run and counts how it ended
     private final Clock clock; // injectable clock for deterministic scheduling
 
     /**
@@ -58,20 +69,29 @@ public class NotificationScheduler {
      */
     @Scheduled(cron = "${app.notifications.schedules.daily-checkin}")
     public void notifyDailyCheckin() {
-        LocalDate today = LocalDate.now(clock);
-        Map<UUID, List<HealthUpgrade>> activeByUser = upgradeQuery.findByStatus(UpgradeStatus.ACTIVE).stream()
-                .collect(Collectors.groupingBy(HealthUpgrade::getUserId));
+        jobMetrics.timed(CHECKIN_JOB, () -> {
+            LocalDate today = LocalDate.now(clock);
+            Map<UUID, List<HealthUpgrade>> activeByUser = upgradeQuery.findByStatus(UpgradeStatus.ACTIVE).stream()
+                    .collect(Collectors.groupingBy(HealthUpgrade::getUserId));
 
-        activeByUser.forEach((userId, upgrades) -> {
-            boolean alreadyNudged = notificationRepository.existsByUserIdAndTypeAndCreatedAtAfter(
-                    userId, NotificationType.CHECKIN_REMINDER, today.atStartOfDay());
-            boolean loggedToday = !progressQuery.findByUserIdAndDate(userId, today).isEmpty();
-            if (!alreadyNudged && !loggedToday) {
-                notificationService.create(userId, NotificationType.CHECKIN_REMINDER, NotificationCategory.REMINDER,
-                        "Daily check-in ⏳",
-                        "You have " + upgrades.size() + " active upgrade" + (upgrades.size() == 1 ? "" : "s")
-                                + " to track today.", null);
-            }
+            // A count, not a list of user ids: the point is whether the nudge went out at a plausible
+            // volume, and who was nudged is in their own notification list.
+            AtomicInteger nudged = new AtomicInteger();
+            activeByUser.forEach((userId, upgrades) -> {
+                boolean alreadyNudged = notificationRepository.existsByUserIdAndTypeAndCreatedAtAfter(
+                        userId, NotificationType.CHECKIN_REMINDER, today.atStartOfDay());
+                boolean loggedToday = !progressQuery.findByUserIdAndDate(userId, today).isEmpty();
+                if (!alreadyNudged && !loggedToday) {
+                    nudged.incrementAndGet();
+                    notificationService.create(userId, NotificationType.CHECKIN_REMINDER, NotificationCategory.REMINDER,
+                            "Daily check-in ⏳",
+                            "You have " + upgrades.size() + " active upgrade" + (upgrades.size() == 1 ? "" : "s")
+                                    + " to track today.", null);
+                }
+            });
+
+            log.info("{} {} {}", keyValue("job", CHECKIN_JOB),
+                    keyValue("usersWithActiveUpgrades", activeByUser.size()), keyValue("nudged", nudged.get()));
         });
     }
 
@@ -88,27 +108,38 @@ public class NotificationScheduler {
      */
     @Scheduled(cron = "${app.notifications.schedules.reminders}")
     public void dispatchReminders() {
-        LocalTime now = LocalTime.now(clock);
-        DayOfWeek today = LocalDate.now(clock).getDayOfWeek();
+        jobMetrics.timed(REMINDERS_JOB, () -> {
+            LocalTime now = LocalTime.now(clock);
+            DayOfWeek today = LocalDate.now(clock).getDayOfWeek();
 
-        // Whether a reminder is due is the reminder's own question to answer, not this adapter's.
-        List<Reminder> due = reminderQuery.findEnabled().stream()
-                .filter(r -> r.isDueAt(today, now))
-                .toList();
-        if (due.isEmpty()) return;
+            // Whether a reminder is due is the reminder's own question to answer, not this adapter's.
+            List<Reminder> due = reminderQuery.findEnabled().stream()
+                    .filter(r -> r.isDueAt(today, now))
+                    .toList();
+            // Nothing due is the answer in fifty-nine minutes out of sixty. Logging it would write a
+            // line a minute, all night, and bury the runs that did something.
+            if (due.isEmpty()) return;
 
-        // Bulk-load the related upgrades in one query instead of one lookup per reminder.
-        List<UUID> upgradeIds = due.stream().map(Reminder::getUpgradeId).distinct().toList();
-        Map<UUID, HealthUpgrade> upgrades = upgradeQuery.findAllById(upgradeIds).stream()
-                .collect(Collectors.toMap(HealthUpgrade::getId, Function.identity()));
+            // Bulk-load the related upgrades in one query instead of one lookup per reminder.
+            List<UUID> upgradeIds = due.stream().map(Reminder::getUpgradeId).distinct().toList();
+            Map<UUID, HealthUpgrade> upgrades = upgradeQuery.findAllById(upgradeIds).stream()
+                    .collect(Collectors.toMap(HealthUpgrade::getId, Function.identity()));
 
-        for (Reminder reminder : due) {
-            HealthUpgrade u = upgrades.get(reminder.getUpgradeId());
-            if (u != null) {
-                notificationService.create(u.getUserId(), NotificationType.REMINDER, NotificationCategory.REMINDER,
-                        "Reminder ⏰", "Time for \"" + u.getTitle() + "\".", u.getId());
+            int fired = 0;
+            for (Reminder reminder : due) {
+                HealthUpgrade u = upgrades.get(reminder.getUpgradeId());
+                if (u != null) {
+                    fired++;
+                    notificationService.create(u.getUserId(), NotificationType.REMINDER, NotificationCategory.REMINDER,
+                            "Reminder ⏰", "Time for \"" + u.getTitle() + "\".", u.getId());
+                }
             }
-        }
+
+            // due != fired means a reminder outlived the upgrade it hangs off - a real inconsistency,
+            // and invisible before this line because the loop skips it in silence.
+            log.info("{} {} {}", keyValue("job", REMINDERS_JOB), keyValue("due", due.size()),
+                    keyValue("fired", fired));
+        });
     }
 
 }

--- a/backend/src/main/java/com/healthupgrades/notification/adapter/out/messaging/StompNotificationPushAdapter.java
+++ b/backend/src/main/java/com/healthupgrades/notification/adapter/out/messaging/StompNotificationPushAdapter.java
@@ -4,8 +4,12 @@ import com.healthupgrades.notification.adapter.in.web.NotificationWebMapper;
 import com.healthupgrades.notification.domain.model.Notification;
 import com.healthupgrades.notification.domain.port.out.NotificationPushPort;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
+
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
 
 import java.util.UUID;
 
@@ -18,6 +22,7 @@ import java.util.UUID;
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class StompNotificationPushAdapter implements NotificationPushPort {
 
     /** STOMP user-destination the frontend subscribes to (resolved per-connection via the principal). */
@@ -26,10 +31,29 @@ public class StompNotificationPushAdapter implements NotificationPushPort {
     private final SimpMessagingTemplate messagingTemplate; // Spring STOMP messaging
     private final NotificationWebMapper mapper; // one rendering, shared with the REST transport
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     *
+     * <p><b>A failed push is degraded, not fatal, and that is a deliberate change of behaviour.</b>
+     * This runs from an {@code afterCommit} callback, so the notification is already durable and
+     * FR-32 — "readable afterwards regardless" — is already satisfied by the row. Letting the
+     * exception out failed the caller <em>after</em> its transaction had committed, and in
+     * {@code dispatchReminders} that meant one unreachable session cancelled everybody else's
+     * reminders for that minute. Nothing recorded it either way.
+     *
+     * <p>So it is caught, narrowly, and reported at WARN with the ids needed to find the notification
+     * that was not delivered. The catch handles rather than silences: the fact is stored, the failure
+     * is visible, and the user sees the notification on their next load.
+     */
     @Override
     public void push(UUID userId, Notification notification) {
-        // Routed to the session(s) whose STOMP principal name == userId (see JwtChannelInterceptor).
-        messagingTemplate.convertAndSendToUser(userId.toString(), USER_QUEUE, mapper.toDto(notification));
+        try {
+            // Routed to the session(s) whose STOMP principal name == userId (see JwtChannelInterceptor).
+            messagingTemplate.convertAndSendToUser(userId.toString(), USER_QUEUE, mapper.toDto(notification));
+        } catch (MessagingException undelivered) {
+            log.warn("{} {} {}", keyValue("event", "notification.push-failed"),
+                    keyValue("userId", userId), keyValue("notificationId", notification.getId()),
+                    undelivered);
+        }
     }
 }

--- a/backend/src/main/java/com/healthupgrades/reflection/application/ReflectionService.java
+++ b/backend/src/main/java/com/healthupgrades/reflection/application/ReflectionService.java
@@ -1,5 +1,7 @@
 package com.healthupgrades.reflection.application;
 
+import com.healthupgrades.common.domain.audit.AuditAction;
+import com.healthupgrades.common.domain.port.out.AuditTrail;
 import com.healthupgrades.common.domain.port.out.DomainEventPublisher;
 import com.healthupgrades.reflection.domain.event.ReflectionAdded;
 import com.healthupgrades.reflection.application.port.in.ReflectionDetails;
@@ -29,6 +31,7 @@ public class ReflectionService {
     private final ReflectionRepositoryPort repository;
     private final UpgradeQuery upgradeQuery;
     private final DomainEventPublisher eventPublisher;
+    private final AuditTrail auditTrail; // records the attempt, allowed or refused
     private final Clock clock; // decides the date a reflection defaults to
 
     /**
@@ -46,20 +49,24 @@ public class ReflectionService {
      */
     @Transactional
     public Reflection create(UUID userId, UUID upgradeId, ReflectionDetails details) {
-        upgradeQuery.getOwnedUpgrade(userId, upgradeId);
-        Reflection reflection = Reflection.builder()
-                .upgradeId(upgradeId)
-                .userId(userId)
-                .date(details.date() != null ? details.date() : LocalDate.now(clock))
-                .difficultyRating(details.difficultyRating())
-                .benefitRating(details.benefitRating())
-                .whatWorked(details.whatWorked())
-                .whatDidNotWork(details.whatDidNotWork())
-                .nextAdjustment(details.nextAdjustment())
-                .build();
-        reflection = repository.save(reflection);
-        eventPublisher.publish(new ReflectionAdded(reflection.getId(), upgradeId, userId, LocalDateTime.now()));
-        return reflection;
+        // Audited against the upgrade reflected on: the reflection has no id until it is saved, and
+        // the upgrade is the record whose history somebody would be reconstructing.
+        return auditTrail.recording(AuditAction.REFLECTION_CREATE, userId, upgradeId, () -> {
+            upgradeQuery.getOwnedUpgrade(userId, upgradeId);
+            Reflection reflection = Reflection.builder()
+                    .upgradeId(upgradeId)
+                    .userId(userId)
+                    .date(details.date() != null ? details.date() : LocalDate.now(clock))
+                    .difficultyRating(details.difficultyRating())
+                    .benefitRating(details.benefitRating())
+                    .whatWorked(details.whatWorked())
+                    .whatDidNotWork(details.whatDidNotWork())
+                    .nextAdjustment(details.nextAdjustment())
+                    .build();
+            Reflection saved = repository.save(reflection);
+            eventPublisher.publish(new ReflectionAdded(saved.getId(), upgradeId, userId, LocalDateTime.now()));
+            return saved;
+        });
     }
 
     /**

--- a/backend/src/main/java/com/healthupgrades/reminder/application/ReminderService.java
+++ b/backend/src/main/java/com/healthupgrades/reminder/application/ReminderService.java
@@ -1,5 +1,7 @@
 package com.healthupgrades.reminder.application;
 
+import com.healthupgrades.common.domain.audit.AuditAction;
+import com.healthupgrades.common.domain.port.out.AuditTrail;
 import com.healthupgrades.common.domain.exception.ResourceNotFoundException;
 import com.healthupgrades.reminder.application.port.in.ReminderQuery;
 import com.healthupgrades.reminder.application.port.in.ReminderSchedule;
@@ -27,6 +29,7 @@ public class ReminderService implements ReminderQuery {
 
     private final ReminderRepositoryPort repository;
     private final UpgradeQuery upgradeQuery;
+    private final AuditTrail auditTrail; // records the attempt, allowed or refused
 
     /**
      * Attaches a reminder to an owned upgrade.
@@ -41,10 +44,13 @@ public class ReminderService implements ReminderQuery {
      */
     @Transactional
     public Reminder create(UUID userId, UUID upgradeId, ReminderSchedule schedule) {
-        upgradeQuery.getOwnedUpgrade(userId, upgradeId); // ownership check (throws if not owned)
-        Reminder reminder = Reminder.create(upgradeId, schedule.reminderTime(),
-                ReminderDays.of(schedule.days()), schedule.enabled() == null || schedule.enabled());
-        return repository.save(reminder);
+        // Audited against the upgrade it hangs off, which is also what ownership is decided by.
+        return auditTrail.recording(AuditAction.REMINDER_CREATE, userId, upgradeId, () -> {
+            upgradeQuery.getOwnedUpgrade(userId, upgradeId); // ownership check (throws if not owned)
+            Reminder reminder = Reminder.create(upgradeId, schedule.reminderTime(),
+                    ReminderDays.of(schedule.days()), schedule.enabled() == null || schedule.enabled());
+            return repository.save(reminder);
+        });
     }
 
     /**
@@ -73,10 +79,12 @@ public class ReminderService implements ReminderQuery {
      */
     @Transactional
     public Reminder update(UUID userId, UUID reminderId, ReminderSchedule schedule) {
-        Reminder reminder = getOwnedReminder(userId, reminderId);
-        reminder.reschedule(schedule.reminderTime(), ReminderDays.of(schedule.days()));
-        if (schedule.enabled() != null) reminder.changeEnabled(schedule.enabled());
-        return repository.save(reminder);
+        return auditTrail.recording(AuditAction.REMINDER_UPDATE, userId, reminderId, () -> {
+            Reminder reminder = getOwnedReminder(userId, reminderId);
+            reminder.reschedule(schedule.reminderTime(), ReminderDays.of(schedule.days()));
+            if (schedule.enabled() != null) reminder.changeEnabled(schedule.enabled());
+            return repository.save(reminder);
+        });
     }
 
     /**
@@ -88,8 +96,10 @@ public class ReminderService implements ReminderQuery {
      */
     @Transactional
     public void delete(UUID userId, UUID reminderId) {
-        Reminder reminder = getOwnedReminder(userId, reminderId);
-        repository.delete(reminder);
+        auditTrail.recording(AuditAction.REMINDER_DELETE, userId, reminderId, () -> {
+            Reminder reminder = getOwnedReminder(userId, reminderId);
+            repository.delete(reminder);
+        });
     }
 
     /** Single ownership guard: a reminder is the caller's only if the upgrade it hangs off is. */

--- a/backend/src/main/java/com/healthupgrades/tracking/application/TrackingService.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/application/TrackingService.java
@@ -1,5 +1,7 @@
 package com.healthupgrades.tracking.application;
 
+import com.healthupgrades.common.domain.audit.AuditAction;
+import com.healthupgrades.common.domain.port.out.AuditTrail;
 import com.healthupgrades.common.domain.port.out.DomainEventPublisher;
 import com.healthupgrades.tracking.domain.event.ProgressEntryRecorded;
 import com.healthupgrades.tracking.domain.event.StreakAchieved;
@@ -47,6 +49,7 @@ public class TrackingService implements TrackingConfigQuery, ProgressQuery, Stre
     private final StreakCalculator streakCalculator; // pure domain service
     private final ProgressEvaluationService evaluationService; // pure domain service
     private final DomainEventPublisher eventPublisher; // in-process domain events
+    private final AuditTrail auditTrail; // records the attempt, allowed or refused
     private final Clock clock; // single source of "today" for defaulting and streaks
 
     /**
@@ -63,16 +66,20 @@ public class TrackingService implements TrackingConfigQuery, ProgressQuery, Stre
      */
     @Transactional
     public TrackingConfig saveConfig(UUID userId, UUID upgradeId, TrackingConfigDetails details) {
-        upgradeQuery.getOwnedUpgrade(userId, upgradeId); // ownership check (throws if not owned)
-        TrackingConfig config = configRepository.findByUpgradeId(upgradeId).orElse(
-                TrackingConfig.builder().upgradeId(upgradeId).build()
-        );
-        config.setTrackingType(details.trackingType());
-        config.setFrequency(details.frequency());
-        config.setTargetNumericValue(details.targetNumericValue());
-        config.setTargetUnit(details.targetUnit());
-        config.setRequiredDaily(details.requiredDaily());
-        return configRepository.save(config);
+        // Audited against the upgrade, not the config row: changing how an upgrade is measured changes
+        // what its past progress means, and the upgrade is what somebody would be reading back.
+        return auditTrail.recording(AuditAction.TRACKING_CONFIGURE, userId, upgradeId, () -> {
+            upgradeQuery.getOwnedUpgrade(userId, upgradeId); // ownership check (throws if not owned)
+            TrackingConfig config = configRepository.findByUpgradeId(upgradeId).orElse(
+                    TrackingConfig.builder().upgradeId(upgradeId).build()
+            );
+            config.setTrackingType(details.trackingType());
+            config.setFrequency(details.frequency());
+            config.setTargetNumericValue(details.targetNumericValue());
+            config.setTargetUnit(details.targetUnit());
+            config.setRequiredDaily(details.requiredDaily());
+            return configRepository.save(config);
+        });
     }
 
     /**
@@ -105,44 +112,48 @@ public class TrackingService implements TrackingConfigQuery, ProgressQuery, Stre
      */
     @Transactional
     public ProgressEntry recordProgress(UUID userId, UUID upgradeId, ProgressEntryDetails details) {
-        upgradeQuery.getOwnedUpgrade(userId, upgradeId);
-        LocalDate date = details.date() != null ? details.date() : LocalDate.now(clock);
+        // The duplicate-per-day refusal (BR-6) is one of the entries worth having in the trail, so the
+        // recording has to bracket the check rather than follow it.
+        return auditTrail.recording(AuditAction.PROGRESS_RECORD, userId, upgradeId, () -> {
+            upgradeQuery.getOwnedUpgrade(userId, upgradeId);
+            LocalDate date = details.date() != null ? details.date() : LocalDate.now(clock);
 
-        if (progressRepository.existsByUpgradeIdAndDate(upgradeId, date)) {
-            throw new DuplicateProgressException("Progress already recorded for date: " + date);
-        }
+            if (progressRepository.existsByUpgradeIdAndDate(upgradeId, date)) {
+                throw new DuplicateProgressException("Progress already recorded for date: " + date);
+            }
 
-        ProgressEntry entry = ProgressEntry.builder()
-                .upgradeId(upgradeId)
-                .userId(userId)
-                .date(date)
-                .completed(details.completed())
-                .numericValue(details.numericValue())
-                .unit(details.unit())
-                .rating(details.rating())
-                .note(details.note())
-                .build();
+            ProgressEntry entry = ProgressEntry.builder()
+                    .upgradeId(upgradeId)
+                    .userId(userId)
+                    .date(date)
+                    .completed(details.completed())
+                    .numericValue(details.numericValue())
+                    .unit(details.unit())
+                    .rating(details.rating())
+                    .note(details.note())
+                    .build();
 
-        // When a tracking config exists, the server decides whether the entry counts as "completed"
-        // by evaluating it against the configured target (e.g. numericValue >= target), instead of
-        // trusting the client. This keeps streaks and completion rates honest.
-        TrackingConfig config = configRepository.findByUpgradeId(upgradeId).orElse(null);
-        if (config != null) {
-            entry.setCompleted(evaluationService.isSuccessful(entry, config));
-        }
+            // When a tracking config exists, the server decides whether the entry counts as "completed"
+            // by evaluating it against the configured target (e.g. numericValue >= target), instead of
+            // trusting the client. This keeps streaks and completion rates honest.
+            TrackingConfig config = configRepository.findByUpgradeId(upgradeId).orElse(null);
+            if (config != null) {
+                entry.setCompleted(evaluationService.isSuccessful(entry, config));
+            }
 
-        entry = progressRepository.save(entry);
-        eventPublisher.publish(new ProgressEntryRecorded(entry.getId(), upgradeId, userId, date, LocalDateTime.now()));
+            ProgressEntry saved = progressRepository.save(entry);
+            eventPublisher.publish(new ProgressEntryRecorded(saved.getId(), upgradeId, userId, date, LocalDateTime.now()));
 
-        List<ProgressEntry> allEntries = progressRepository.findByUpgradeIdOrderByDateDesc(upgradeId);
-        int streak = streakCalculator.calculateCurrentStreak(allEntries, LocalDate.now(clock));
-        // Every seventh day only. Announcing each consecutive day would make the milestone worthless
-        // and would put a notification in the user's list once a day per tracked upgrade.
-        if (streak > 0 && streak % 7 == 0) {
-            eventPublisher.publish(new StreakAchieved(upgradeId, userId, streak, LocalDateTime.now()));
-        }
+            List<ProgressEntry> allEntries = progressRepository.findByUpgradeIdOrderByDateDesc(upgradeId);
+            int streak = streakCalculator.calculateCurrentStreak(allEntries, LocalDate.now(clock));
+            // Every seventh day only. Announcing each consecutive day would make the milestone worthless
+            // and would put a notification in the user's list once a day per tracked upgrade.
+            if (streak > 0 && streak % 7 == 0) {
+                eventPublisher.publish(new StreakAchieved(upgradeId, userId, streak, LocalDateTime.now()));
+            }
 
-        return entry;
+            return saved;
+        });
     }
 
     /**

--- a/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/scheduling/UpgradeOverdueScheduler.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/scheduling/UpgradeOverdueScheduler.java
@@ -1,13 +1,17 @@
 package com.healthupgrades.upgrade.adapter.in.scheduling;
 
 import com.healthupgrades.common.domain.port.out.DomainEventPublisher;
+import com.healthupgrades.common.observability.JobMetrics;
 import com.healthupgrades.upgrade.domain.event.UpgradeOverdueDetected;
 import com.healthupgrades.upgrade.application.port.in.UpgradeQuery;
 import com.healthupgrades.upgrade.domain.model.HealthUpgrade;
 import com.healthupgrades.upgrade.domain.model.UpgradeStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
 
 import java.time.Clock;
 import java.time.LocalDate;
@@ -25,23 +29,43 @@ import java.time.LocalDateTime;
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class UpgradeOverdueScheduler {
+
+    /** Stable across releases: it is a metric tag and a log field, so it is a contract, not a label. */
+    private static final String JOB = "upgrade.overdue-scan";
 
     private final UpgradeQuery upgradeQuery; // own context's read view
     private final DomainEventPublisher eventPublisher; // outbound port
+    private final JobMetrics jobMetrics; // times the run and counts how it ended
     private final Clock clock; // injectable clock keeps "today" deterministic
 
-    /** Publishes {@link UpgradeOverdueDetected} for every active upgrade now past its target date. */
+    /**
+     * Publishes {@link UpgradeOverdueDetected} for every active upgrade now past its target date.
+     *
+     * <p>The INFO line is what makes a nightly sweep visible at all: without it, a run that scanned
+     * nothing because a query silently stopped matching is indistinguishable from a run with nothing to
+     * find. Counts only — an upgrade's title is the user's own words about their health.
+     */
     @Scheduled(cron = "${app.upgrades.schedules.overdue}")
     public void detectOverdueUpgrades() {
-        LocalDate today = LocalDate.now(clock);
-        LocalDateTime detectedAt = LocalDateTime.now(clock);
+        jobMetrics.timed(JOB, () -> {
+            LocalDate today = LocalDate.now(clock);
+            LocalDateTime detectedAt = LocalDateTime.now(clock);
 
-        for (HealthUpgrade upgrade : upgradeQuery.findByStatus(UpgradeStatus.ACTIVE)) {
-            if (upgrade.isOverdue(today)) {
-                eventPublisher.publish(
-                        new UpgradeOverdueDetected(upgrade.getId(), upgrade.getUserId(), detectedAt));
+            int scanned = 0;
+            int announced = 0;
+            for (HealthUpgrade upgrade : upgradeQuery.findByStatus(UpgradeStatus.ACTIVE)) {
+                scanned++;
+                if (upgrade.isOverdue(today)) {
+                    announced++;
+                    eventPublisher.publish(
+                            new UpgradeOverdueDetected(upgrade.getId(), upgrade.getUserId(), detectedAt));
+                }
             }
-        }
+
+            log.info("{} {} {}", keyValue("job", JOB), keyValue("scanned", scanned),
+                    keyValue("announced", announced));
+        });
     }
 }

--- a/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeService.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeService.java
@@ -1,6 +1,8 @@
 package com.healthupgrades.upgrade.application;
 import com.healthupgrades.upgrade.domain.service.UpgradeSchedulingService;
 
+import com.healthupgrades.common.domain.audit.AuditAction;
+import com.healthupgrades.common.domain.port.out.AuditTrail;
 import com.healthupgrades.common.domain.port.out.DomainEventPublisher;
 import com.healthupgrades.common.domain.exception.ResourceNotFoundException;
 import com.healthupgrades.upgrade.domain.event.*;
@@ -34,6 +36,7 @@ public class UpgradeService implements UpgradeQuery {
     private final UpgradeRepositoryPort repository; // outbound persistence port
     private final UpgradeSchedulingService schedulingService; // pure domain invariant
     private final DomainEventPublisher eventPublisher; // in-process domain events
+    private final AuditTrail auditTrail; // records the attempt, allowed or refused
     private final Clock clock; // decides the start date an activation defaults to
 
     /**
@@ -46,12 +49,15 @@ public class UpgradeService implements UpgradeQuery {
      */
     @Transactional
     public HealthUpgrade create(UUID userId, UpgradeDetails details) {
-        HealthUpgrade upgrade = HealthUpgrade.create(userId, details.areaId(), details.title(), details.description(),
-                details.type(), details.difficulty(), details.plannedStartDate(), details.targetEndDate(),
-                details.motivation(), details.successCriteria());
-        upgrade = repository.save(upgrade);
-        eventPublisher.publish(new HealthUpgradeCreated(upgrade.getId(), userId, upgrade.getTitle(), LocalDateTime.now()));
-        return upgrade;
+        // No resource id to record against: the upgrade does not exist until the save below returns.
+        return auditTrail.recording(AuditAction.UPGRADE_CREATE, userId, null, () -> {
+            HealthUpgrade created = HealthUpgrade.create(userId, details.areaId(), details.title(), details.description(),
+                    details.type(), details.difficulty(), details.plannedStartDate(), details.targetEndDate(),
+                    details.motivation(), details.successCriteria());
+            HealthUpgrade saved = repository.save(created);
+            eventPublisher.publish(new HealthUpgradeCreated(saved.getId(), userId, saved.getTitle(), LocalDateTime.now()));
+            return saved;
+        });
     }
 
     /**
@@ -92,17 +98,19 @@ public class UpgradeService implements UpgradeQuery {
      */
     @Transactional
     public HealthUpgrade update(UUID userId, UUID id, UpgradeDetails details) {
-        HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
-        boolean difficultyChanges = details.difficulty() != null && details.difficulty() != upgrade.getDifficulty();
-        if (difficultyChanges) {
-            // Fail before mutating anything.
-            validateHardLimit(userId, details.difficulty(), upgrade.getStatus() == UpgradeStatus.ACTIVE);
-        }
+        return auditTrail.recording(AuditAction.UPGRADE_UPDATE, userId, id, () -> {
+            HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
+            boolean difficultyChanges = details.difficulty() != null && details.difficulty() != upgrade.getDifficulty();
+            if (difficultyChanges) {
+                // Fail before mutating anything.
+                validateHardLimit(userId, details.difficulty(), upgrade.getStatus() == UpgradeStatus.ACTIVE);
+            }
 
-        upgrade.updateDetails(details.areaId(), details.title(), details.description(), details.type(),
-                details.targetEndDate(), details.motivation(), details.successCriteria());
-        if (difficultyChanges) upgrade.changeDifficulty(details.difficulty());
-        return repository.save(upgrade);
+            upgrade.updateDetails(details.areaId(), details.title(), details.description(), details.type(),
+                    details.targetEndDate(), details.motivation(), details.successCriteria());
+            if (difficultyChanges) upgrade.changeDifficulty(details.difficulty());
+            return repository.save(upgrade);
+        });
     }
 
     /**
@@ -131,8 +139,10 @@ public class UpgradeService implements UpgradeQuery {
      */
     @Transactional
     public void delete(UUID userId, UUID id) {
-        HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
-        repository.delete(upgrade);
+        auditTrail.recording(AuditAction.UPGRADE_DELETE, userId, id, () -> {
+            HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
+            repository.delete(upgrade);
+        });
     }
 
     /**
@@ -147,11 +157,13 @@ public class UpgradeService implements UpgradeQuery {
      */
     @Transactional
     public HealthUpgrade plan(UUID userId, UUID id, LocalDate plannedStartDate) {
-        HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
-        upgrade.plan(plannedStartDate);
-        upgrade = repository.save(upgrade);
-        eventPublisher.publish(new HealthUpgradePlanned(upgrade.getId(), userId, plannedStartDate, LocalDateTime.now()));
-        return upgrade;
+        return auditTrail.recording(AuditAction.UPGRADE_PLAN, userId, id, () -> {
+            HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
+            upgrade.plan(plannedStartDate);
+            HealthUpgrade saved = repository.save(upgrade);
+            eventPublisher.publish(new HealthUpgradePlanned(saved.getId(), userId, plannedStartDate, LocalDateTime.now()));
+            return saved;
+        });
     }
 
     /**
@@ -170,12 +182,14 @@ public class UpgradeService implements UpgradeQuery {
      */
     @Transactional
     public HealthUpgrade activate(UUID userId, UUID id, LocalDate startDate) {
-        HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
-        validateHardLimit(userId, upgrade.getDifficulty(), true); // activation always claims a slot
-        upgrade.activate(startDate != null ? startDate : LocalDate.now(clock));
-        upgrade = repository.save(upgrade);
-        eventPublisher.publish(new HealthUpgradeActivated(upgrade.getId(), userId, upgrade.getActualStartDate(), LocalDateTime.now()));
-        return upgrade;
+        return auditTrail.recording(AuditAction.UPGRADE_ACTIVATE, userId, id, () -> {
+            HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
+            validateHardLimit(userId, upgrade.getDifficulty(), true); // activation always claims a slot
+            upgrade.activate(startDate != null ? startDate : LocalDate.now(clock));
+            HealthUpgrade saved = repository.save(upgrade);
+            eventPublisher.publish(new HealthUpgradeActivated(saved.getId(), userId, saved.getActualStartDate(), LocalDateTime.now()));
+            return saved;
+        });
     }
 
     /**
@@ -189,11 +203,13 @@ public class UpgradeService implements UpgradeQuery {
      */
     @Transactional
     public HealthUpgrade pause(UUID userId, UUID id) {
-        HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
-        upgrade.pause();
-        upgrade = repository.save(upgrade);
-        eventPublisher.publish(new HealthUpgradePaused(upgrade.getId(), userId, LocalDateTime.now()));
-        return upgrade;
+        return auditTrail.recording(AuditAction.UPGRADE_PAUSE, userId, id, () -> {
+            HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
+            upgrade.pause();
+            HealthUpgrade saved = repository.save(upgrade);
+            eventPublisher.publish(new HealthUpgradePaused(saved.getId(), userId, LocalDateTime.now()));
+            return saved;
+        });
     }
 
     /**
@@ -207,11 +223,13 @@ public class UpgradeService implements UpgradeQuery {
      */
     @Transactional
     public HealthUpgrade complete(UUID userId, UUID id) {
-        HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
-        upgrade.complete();
-        upgrade = repository.save(upgrade);
-        eventPublisher.publish(new HealthUpgradeCompleted(upgrade.getId(), userId, LocalDateTime.now()));
-        return upgrade;
+        return auditTrail.recording(AuditAction.UPGRADE_COMPLETE, userId, id, () -> {
+            HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
+            upgrade.complete();
+            HealthUpgrade saved = repository.save(upgrade);
+            eventPublisher.publish(new HealthUpgradeCompleted(saved.getId(), userId, LocalDateTime.now()));
+            return saved;
+        });
     }
 
     /**
@@ -226,11 +244,13 @@ public class UpgradeService implements UpgradeQuery {
      */
     @Transactional
     public HealthUpgrade abandon(UUID userId, UUID id) {
-        HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
-        upgrade.abandon();
-        upgrade = repository.save(upgrade);
-        eventPublisher.publish(new HealthUpgradeAbandoned(upgrade.getId(), userId, LocalDateTime.now()));
-        return upgrade;
+        return auditTrail.recording(AuditAction.UPGRADE_ABANDON, userId, id, () -> {
+            HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
+            upgrade.abandon();
+            HealthUpgrade saved = repository.save(upgrade);
+            eventPublisher.publish(new HealthUpgradeAbandoned(saved.getId(), userId, LocalDateTime.now()));
+            return saved;
+        });
     }
 
     /**
@@ -245,17 +265,19 @@ public class UpgradeService implements UpgradeQuery {
      */
     @Transactional
     public HealthUpgrade reschedule(UUID userId, UUID id, LocalDate newDate) {
-        HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
-        UpgradeStatus statusBefore = upgrade.getStatus();
-        upgrade.reschedule(newDate);
-        upgrade = repository.save(upgrade);
+        return auditTrail.recording(AuditAction.UPGRADE_RESCHEDULE, userId, id, () -> {
+            HealthUpgrade upgrade = getOwnedUpgrade(userId, id);
+            UpgradeStatus statusBefore = upgrade.getStatus();
+            upgrade.reschedule(newDate);
+            HealthUpgrade saved = repository.save(upgrade);
 
-        // Rescheduling an abandoned upgrade revives it into PLANNED. That is a real lifecycle transition
-        // and has to be announced, or listeners see the upgrade silently reappear as planned.
-        if (upgrade.getStatus() == UpgradeStatus.PLANNED && statusBefore != UpgradeStatus.PLANNED) {
-            eventPublisher.publish(new HealthUpgradePlanned(upgrade.getId(), userId, newDate, LocalDateTime.now()));
-        }
-        return upgrade;
+            // Rescheduling an abandoned upgrade revives it into PLANNED. That is a real lifecycle
+            // transition and has to be announced, or listeners see it silently reappear as planned.
+            if (saved.getStatus() == UpgradeStatus.PLANNED && statusBefore != UpgradeStatus.PLANNED) {
+                eventPublisher.publish(new HealthUpgradePlanned(saved.getId(), userId, newDate, LocalDateTime.now()));
+            }
+            return saved;
+        });
     }
 
     // ---- UpgradeQuery (inbound port) ----

--- a/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeService.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/application/UpgradeService.java
@@ -49,15 +49,14 @@ public class UpgradeService implements UpgradeQuery {
      */
     @Transactional
     public HealthUpgrade create(UUID userId, UpgradeDetails details) {
-        // No resource id to record against: the upgrade does not exist until the save below returns.
-        return auditTrail.recording(AuditAction.UPGRADE_CREATE, userId, null, () -> {
+        return auditTrail.recordingCreation(AuditAction.UPGRADE_CREATE, userId, () -> {
             HealthUpgrade created = HealthUpgrade.create(userId, details.areaId(), details.title(), details.description(),
                     details.type(), details.difficulty(), details.plannedStartDate(), details.targetEndDate(),
                     details.motivation(), details.successCriteria());
             HealthUpgrade saved = repository.save(created);
             eventPublisher.publish(new HealthUpgradeCreated(saved.getId(), userId, saved.getTitle(), LocalDateTime.now()));
             return saved;
-        });
+        }, HealthUpgrade::getId);
     }
 
     /**

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -49,6 +49,26 @@ app:
       reminders: ${NOTIFY_REMINDERS_CRON:0 * * * * *}    # every minute — user reminder dispatch
 
 management:
+  endpoints:
+    web:
+      exposure:
+        # Explicit and closed. Boot's default exposes health alone, which is safe by accident rather
+        # than by decision: adding a dependency that contributes an endpoint would publish it, and
+        # /actuator/** is permitAll. Naming the three wanted here means nothing else can arrive
+        # unannounced. See ADR-012.
+        include: health,info,prometheus
+  endpoint:
+    health:
+      # Splits /actuator/health into /liveness (is the process alive) and /readiness (can it serve).
+      # A restart fixes the first and never the second, which is why an orchestrator needs both and
+      # why the compose health-check polls readiness rather than the aggregate.
+      probes:
+        enabled: true
+  observations:
+    key-values:
+      # Tags every metric and observation with the service, so two deployments are separable in one
+      # scrape target without parsing anything.
+      application: ${spring.application.name}
   tracing:
     sampling:
       # Every request is sampled. The trace id reaches the log line either way - Micrometer writes the

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -59,5 +59,8 @@ management:
 
 logging:
   level:
-    # DEBUG for this application's own packages only; everything else stays at Spring's default INFO.
-    com.healthupgrades: DEBUG
+    # INFO is what a deployment should run at: DEBUG is written for a developer reading along, and
+    # this application's DEBUG lines fire per domain event - every minute, from dispatchReminders.
+    # LOG_LEVEL_APP turns it up for one run without a code change. Everything outside this package
+    # stays at Spring's default INFO.
+    com.healthupgrades: ${LOG_LEVEL_APP:INFO}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -64,10 +64,18 @@ management:
       # why the compose health-check polls readiness rather than the aggregate.
       probes:
         enabled: true
+  metrics:
+    tags:
+      # Every *meter*. This is the one that reaches jvm.*, hikaricp.*, audit.events and
+      # scheduled.job.runs; observations.key-values below does not, whatever its name suggests -
+      # Boot's own metadata reads "applied to every observation", and only the meters derived from an
+      # observation (http.server.requests) pick those up. Without this, scraping two deployments into
+      # one target leaves every metric but the HTTP ones colliding unlabelled.
+      application: ${spring.application.name}
   observations:
     key-values:
-      # Tags every metric and observation with the service, so two deployments are separable in one
-      # scrape target without parsing anything.
+      # Kept as well as, not instead of: this is what tags the observations themselves, and therefore
+      # the spans, which metrics.tags does not touch.
       application: ${spring.application.name}
   tracing:
     sampling:

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Two output formats for one set of log statements: Boot's readable console pattern for a developer,
+  and JSON for a container whose log is read by a machine before a person. The `json-logs` profile
+  selects between them; docker-compose sets it, a local `mvn spring-boot:run` does not.
+
+  See docs/ADRs/ADR-010-structured-logging-a-level-policy-and-audit-as-a-log-stream.md.
+-->
+<configuration>
+
+    <!--
+      LOAD-BEARING, and the reason this file is a risk rather than a formality. Boot's defaults.xml
+      defines CONSOLE_LOG_PATTERN, and that pattern interpolates ${LOG_CORRELATION_PATTERN} - the
+      property LogCorrelationEnvironmentPostProcessor fills with the trace and span id. Replacing it
+      with a hand-written <pattern> compiles, runs, and silently un-correlates every plain-text line,
+      which is precisely the ADR-007 regression this project would not notice for months.
+      RequestCorrelationTest asserts the id still arrives, so the mistake fails a build instead.
+    -->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!--
+      Read by the JSON encoder below so a log aggregator can separate two deployments of this service
+      without parsing the logger name. Matches the OpenTelemetry service.name the tracing bridge uses.
+    -->
+    <springProperty scope="context" name="serviceName" source="spring.application.name" defaultValue="unknown_service"/>
+
+    <springProfile name="!json-logs">
+        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="json-logs">
+        <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <!--
+                  The MDC is where Micrometer's Slf4JEventListener writes traceId and spanId, so
+                  including it is what carries correlation into the JSON. It is also why nothing else
+                  may be written to the MDC by hand: an unexpected key becomes a top-level field, and
+                  a field named after something personal is NFR-6 broken silently.
+                -->
+                <includeMdc>true</includeMdc>
+                <includeContext>false</includeContext>
+                <customFields>{"service":"${serviceName}"}</customFields>
+                <fieldNames>
+                    <timestamp>timestamp</timestamp>
+                    <version>[ignore]</version>
+                    <levelValue>[ignore]</levelValue>
+                </fieldNames>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="JSON"/>
+        </root>
+    </springProfile>
+
+</configuration>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -4,7 +4,7 @@
   and JSON for a container whose log is read by a machine before a person. The `json-logs` profile
   selects between them; docker-compose sets it, a local `mvn spring-boot:run` does not.
 
-  See docs/ADRs/ADR-010-structured-logging-a-level-policy-and-audit-as-a-log-stream.md.
+  See docs/ADRs/ADR-010-structured-logging-and-a-level-policy.md.
 -->
 <configuration>
 

--- a/backend/src/test/java/com/healthupgrades/ActuatorEndpointsIT.java
+++ b/backend/src/test/java/com/healthupgrades/ActuatorEndpointsIT.java
@@ -1,0 +1,119 @@
+package com.healthupgrades;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.healthupgrades.support.PostgresIT;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Checks the operational surface over a real socket: what answers, what it says, and — the part with
+ * teeth — what does <em>not</em> answer.
+ *
+ * <p>`/actuator/**` is `permitAll` in `SecurityConfig`, so the only thing standing between a reader and
+ * `/actuator/env` is the exposure list in `application.yml`. That list is one line and nothing else in
+ * the build reads it, which makes it exactly the sort of configuration that gets widened during a
+ * debugging session and never narrowed again. The negative assertions below are the guard: adding an
+ * endpoint to the list is then a deliberate act that has to change a test, not an accident.
+ *
+ * <p>An integration test rather than a slice, because the thing being asserted is the composition —
+ * Boot's endpoint auto-configuration, the exposure property, the security chain and the servlet
+ * mapping. A `@WebMvcTest` would have to stub every one of those and would then be asserting its own
+ * stubs.
+ *
+ * <p>{@code @AutoConfigureObservability} is required for the same reason it is in {@code CorrelationIT}:
+ * {@code @SpringBootTest} disables metrics export by default, so without it {@code /actuator/prometheus}
+ * would be absent for a reason that has nothing to do with this application's configuration.
+ */
+@AutoConfigureObservability
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ActuatorEndpointsIT extends PostgresIT {
+
+    private static final HttpClient client = HttpClient.newHttpClient();
+
+    private final ObjectMapper json = new ObjectMapper();
+
+    @LocalServerPort
+    private int port;
+
+    @Test
+    void GivenARunningApplication_WhenHealthIsPolled_ThenItReportsUp() throws Exception {
+        HttpResponse<String> response = get("/actuator/health");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(json.readTree(response.body()).path("status").asText()).isEqualTo("UP");
+    }
+
+    /**
+     * Liveness and readiness answer different questions, and the difference is what an orchestrator
+     * acts on: a failed liveness probe means restart the process, a failed readiness probe means stop
+     * sending it traffic. Restarting a process that cannot reach its database fixes nothing, which is
+     * why the aggregate endpoint is the wrong thing for either to poll.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"/actuator/health/liveness", "/actuator/health/readiness"})
+    void GivenARunningApplication_WhenAProbeIsPolled_ThenItAnswersSeparatelyFromTheAggregate(String probe)
+            throws Exception {
+        HttpResponse<String> response = get(probe);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(json.readTree(response.body()).path("status").asText()).isEqualTo("UP");
+    }
+
+    @Test
+    void GivenARunningApplication_WhenMetricsAreScraped_ThenTheFourSignalsAreThere() throws Exception {
+        // One request has already been served by the probes above, so the HTTP timer exists.
+        get("/actuator/health");
+
+        HttpResponse<String> response = get("/actuator/prometheus");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body())
+                .as("latency and error rate")
+                .contains("http_server_requests_seconds")
+                .as("saturation: the JVM and the connection pool")
+                .contains("jvm_memory_used_bytes")
+                .contains("hikaricp_connections");
+    }
+
+    @Test
+    void GivenAScrape_WhenTheApplicationTagIsRead_ThenEveryMetricNamesThisService() throws Exception {
+        HttpResponse<String> response = get("/actuator/prometheus");
+
+        assertThat(response.body()).contains("application=\"health-upgrades-tracker\"");
+    }
+
+    /**
+     * The assertion this class exists for. Each of these is a real exposure — `env` prints the resolved
+     * configuration including the JWT secret's property name and its neighbours, `heapdump` hands over
+     * the process memory, `loggers` lets a caller turn logging off, `beans` and `mappings` describe the
+     * whole application to anyone who asks. All are `permitAll` if they are exposed at all, so "not
+     * exposed" is the entire control.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"/actuator/env", "/actuator/heapdump", "/actuator/loggers",
+            "/actuator/beans", "/actuator/mappings", "/actuator/configprops", "/actuator/threaddump"})
+    void GivenAnEndpointThatWasNotExposed_WhenItIsRequested_ThenItIsNotThere(String endpoint) throws Exception {
+        assertThat(get(endpoint).statusCode())
+                .as("%s is readable by anyone the moment it is exposed", endpoint)
+                .isEqualTo(404);
+    }
+
+    private HttpResponse<String> get(String path) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + path))
+                .GET()
+                .build();
+        return client.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/ActuatorEndpointsIT.java
+++ b/backend/src/test/java/com/healthupgrades/ActuatorEndpointsIT.java
@@ -13,6 +13,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -86,11 +87,49 @@ class ActuatorEndpointsIT extends PostgresIT {
                 .contains("hikaricp_connections");
     }
 
-    @Test
-    void GivenAScrape_WhenTheApplicationTagIsRead_ThenEveryMetricNamesThisService() throws Exception {
-        HttpResponse<String> response = get("/actuator/prometheus");
+    /**
+     * Checked per metric family, not as one substring anywhere in the scrape.
+     *
+     * <p>The weaker form of this test passed while only {@code http_server_requests_seconds} carried
+     * the tag: it is derived from an observation, and {@code management.observations.key-values} tags
+     * observations rather than meters. Everything else — the JVM, the pool, and this application's own
+     * counters — was unlabelled, which is precisely the set that would collide if two deployments were
+     * scraped into one target. So the families here are deliberately three that are <em>not</em>
+     * observation-derived, plus the HTTP one to keep it honest.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"http_server_requests_seconds", "jvm_memory_used_bytes",
+            "hikaricp_connections", "audit_events_total"})
+    void GivenAScrape_WhenAMetricFamilyIsRead_ThenEveryOneOfItsSamplesNamesThisService(String family)
+            throws Exception {
+        get("/actuator/health"); // so the HTTP timer has something in it
+        refuseALogin(); // and so this application's own counter exists to be checked
 
-        assertThat(response.body()).contains("application=\"health-upgrades-tracker\"");
+        List<String> samples = get("/actuator/prometheus").body().lines()
+                .filter(line -> line.startsWith(family) && line.contains("{"))
+                .toList();
+
+        assertThat(samples).as("%s produced no samples to check", family).isNotEmpty();
+        assertThat(samples).allSatisfy(sample ->
+                assertThat(sample).contains("application=\"health-upgrades-tracker\""));
+    }
+
+    /**
+     * A wrong password, purely to bring {@code audit.events} into existence.
+     *
+     * <p>Micrometer registers a counter on its first increment, so a custom meter cannot be asserted
+     * against until something has counted. The scheduled-job counters would have done as well and are
+     * not used here: their crons make "has one run yet" a question of when the test happened to start.
+     * A refused login needs no seeded account — the credential is rejected either way.
+     */
+    private void refuseALogin() throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + "/api/auth/login"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(
+                        "{\"email\":\"nobody@example.com\",\"password\":\"wrong\"}"))
+                .build();
+        client.send(request, HttpResponse.BodyHandlers.ofString());
     }
 
     /**

--- a/backend/src/test/java/com/healthupgrades/AuditCommitIT.java
+++ b/backend/src/test/java/com/healthupgrades/AuditCommitIT.java
@@ -1,0 +1,156 @@
+package com.healthupgrades;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.healthupgrades.support.PostgresIT;
+import com.healthupgrades.upgrade.application.UpgradeService;
+import com.healthupgrades.upgrade.application.port.in.UpgradeDetails;
+import com.healthupgrades.upgrade.domain.model.HealthUpgrade;
+import com.healthupgrades.upgrade.domain.model.UpgradeType;
+import com.healthupgrades.upgrade.domain.port.out.UpgradeRepositoryPort;
+import com.healthupgrades.user.application.port.in.UserCommand;
+import com.healthupgrades.user.domain.model.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins <em>when</em> an {@code ALLOWED} audit entry is written, which turns out to be the whole of
+ * whether the trail can be believed.
+ *
+ * <p>Every audited use case is an {@code @Transactional} service method, and the recording happens
+ * inside the method body — so it runs while the transaction is still open, and the commit happens
+ * afterwards in the proxy. No repository adapter flushes, so a {@code @Version} clash or a unique
+ * constraint losing a race is decided <em>at commit</em>, after the body has returned. Writing the
+ * entry there would have the trail and the {@code audit.events} counter both report an edit that was
+ * then rolled back and answered to the caller as a 409.
+ *
+ * <p>That is not a failure any unit test can see: mocked repositories commit nothing, so the bug is
+ * invisible everywhere except against a real transaction manager. This class supplies one and forces
+ * the rollback deterministically, rather than racing two threads for an optimistic-lock clash and
+ * hoping.
+ */
+@SpringBootTest
+class AuditCommitIT extends PostgresIT {
+
+    private static final String AUDIT_LOGGER = "AUDIT";
+
+    @Autowired UpgradeService upgradeService;
+    @Autowired UpgradeRepositoryPort upgradeRepository;
+    @Autowired UserCommand userCommand;
+    @Autowired TransactionTemplate transactionTemplate;
+
+    private Logger auditLogger;
+    private ListAppender<ILoggingEvent> appender;
+    private UUID userId;
+
+    @BeforeEach
+    void captureTheAuditStream() {
+        userId = userCommand.save(User.builder()
+                .name("Someone")
+                .email(UUID.randomUUID() + "@example.com")
+                .passwordHash("$2a$10$abcdefghijklmnopqrstuvwxyz012345678901234567890123456")
+                .build()).getId();
+
+        auditLogger = (Logger) LoggerFactory.getLogger(AUDIT_LOGGER);
+        appender = new ListAppender<>();
+        appender.start();
+        auditLogger.addAppender(appender);
+    }
+
+    @AfterEach
+    void releaseTheAuditStream() {
+        auditLogger.detachAppender(appender);
+    }
+
+    @Test
+    void GivenWorkThatCommits_WhenItIsAudited_ThenTheEntryIsWrittenAndSaysAllowed() {
+        HealthUpgrade created = upgradeService.create(userId, details("Committed upgrade"));
+
+        assertThat(linesFor("upgrade.create"))
+                .singleElement(org.assertj.core.api.InstanceOfAssertFactories.STRING)
+                .contains("outcome=ALLOWED")
+                // The created id is on the entry: an entry that says somebody created something without
+                // saying what is the one question a creation entry exists to answer.
+                .contains("resourceId=" + created.getId());
+    }
+
+    @Test
+    void GivenTheTransactionRollsBackAfterTheWork_WhenItIsAudited_ThenNothingClaimsItWasAllowed() {
+        // The defect this class exists for. Before the entry was deferred to the commit, the body
+        // returning was enough to write ALLOWED and increment the counter — so a 409 from an optimistic
+        // lock, or a unique constraint lost at commit, left a trail saying the edit had succeeded.
+        UUID upgradeId = upgradeService.create(userId, details("Doomed upgrade")).getId();
+        appender.list.clear();
+
+        transactionTemplate.execute(status -> {
+            upgradeService.update(userId, upgradeId, details("Renamed inside a doomed transaction"));
+            status.setRollbackOnly();
+            return null;
+        });
+
+        assertThat(linesFor("upgrade.update"))
+                .as("an entry is still written — the attempt happened and should be recorded")
+                .isNotEmpty()
+                .as("but it must not claim the edit landed, because it did not")
+                .allSatisfy(line -> assertThat(line).doesNotContain("outcome=ALLOWED"));
+    }
+
+    @Test
+    void GivenTheTransactionRollsBack_WhenItIsAudited_ThenTheRecordIsUnchangedToMatch() {
+        // The other half of the same claim: the trail and the database agree about what happened.
+        UUID upgradeId = upgradeService.create(userId, details("Original title")).getId();
+
+        transactionTemplate.execute(status -> {
+            upgradeService.update(userId, upgradeId, details("Never persisted"));
+            status.setRollbackOnly();
+            return null;
+        });
+
+        assertThat(upgradeRepository.findByIdAndUserId(upgradeId, userId).orElseThrow().getTitle())
+                .isEqualTo("Original title");
+    }
+
+    @Test
+    void GivenARefusalInsideATransaction_WhenItIsAudited_ThenItIsWrittenWithoutWaitingForACommit() {
+        // Refusals are not deferred: they already describe an attempt that did not land, they are the
+        // security-relevant half, and a process that dies before commit should not take them with it.
+        UUID missing = UUID.randomUUID();
+
+        assertThat(catchThrowable(() -> upgradeService.pause(userId, missing))).isNotNull();
+
+        assertThat(linesFor("upgrade.pause"))
+                .singleElement(org.assertj.core.api.InstanceOfAssertFactories.STRING)
+                .contains("outcome=REFUSED");
+    }
+
+    private static Throwable catchThrowable(Runnable work) {
+        try {
+            work.run();
+            return null;
+        } catch (RuntimeException thrown) {
+            return thrown;
+        }
+    }
+
+    private List<String> linesFor(String action) {
+        return appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .filter(message -> message.contains("action=" + action + " "))
+                .toList();
+    }
+
+    private static UpgradeDetails details(String title) {
+        return new UpgradeDetails(null, title, null, UpgradeType.HABIT, null, null, null, null, null);
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/architecture/HexagonalArchitectureTest.java
+++ b/backend/src/test/java/com/healthupgrades/architecture/HexagonalArchitectureTest.java
@@ -33,6 +33,13 @@ class HexagonalArchitectureTest {
      * Everything else is listed explicitly rather than relying on the Spring ban alone: without them a
      * domain class could pick up Jackson serialisation, bean-validation constraints or servlet types and
      * nothing would notice.
+     *
+     * <p>{@code org.slf4j} and {@code io.micrometer} are on the list for the same reason, and neither is
+     * caught by any of the others. Logging and measuring are side effects, and side effects belong at
+     * the edges: a domain class that writes a log line is one that has quietly acquired an I/O
+     * dependency and a reason to be mocked. The audit trail is the shape this is meant to take instead —
+     * the domain declares {@code AuditTrail} as a port and an adapter decides that recording means
+     * writing a line ({@code ADR-011}).
      */
     @ArchTest
     static final ArchRule domain_is_free_of_framework_and_outer_layers =
@@ -43,6 +50,8 @@ class HexagonalArchitectureTest {
                             "jakarta.servlet..",
                             "com.fasterxml.jackson..",
                             "org.hibernate..",
+                            "org.slf4j..",
+                            "io.micrometer..",
                             "..adapter..", "..application..")
                     .as("the domain must not depend on frameworks, adapters, or the application layer");
 

--- a/backend/src/test/java/com/healthupgrades/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/auth/application/AuthServiceTest.java
@@ -175,6 +175,39 @@ class AuthServiceTest {
     }
 
     @Test
+    void GivenTokenIssuingFails_WhenAVisitorRegisters_ThenTheAttemptIsAuditedOnceAndNotTwice() {
+        // Recording ALLOWED before the token existed put one attempt in the trail under two outcomes -
+        // allowed and failed - and double-counted it in audit.events to match. A trail that can report
+        // one event twice, differently, is a trail nobody can total.
+        when(userQuery.existsByEmail(AUser.EMAIL)).thenReturn(false);
+        when(userCommand.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(tokenProvider.generateToken(AUser.EMAIL)).thenThrow(new IllegalStateException("secret too short"));
+
+        assertThatThrownBy(() -> service.register(AUser.NAME, AUser.EMAIL, RAW_PASSWORD))
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThat(auditTrail.recorded())
+                .filteredOn(event -> event.action() == AuditAction.AUTH_REGISTER)
+                .singleElement()
+                .satisfies(event -> assertThat(event.outcome()).isEqualTo(AuditOutcome.FAILED));
+    }
+
+    @Test
+    void GivenTokenIssuingFails_WhenTheUserLogsIn_ThenTheAttemptIsAuditedOnceAndNotTwice() {
+        when(authenticationManager.authenticate(any())).thenReturn(authenticated());
+        when(userQuery.findByEmail(AUser.EMAIL)).thenReturn(Optional.of(AUser.aUser().build()));
+        when(tokenProvider.generateToken(AUser.EMAIL)).thenThrow(new IllegalStateException("secret too short"));
+
+        assertThatThrownBy(() -> service.login(AUser.EMAIL, RAW_PASSWORD))
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThat(auditTrail.recorded())
+                .filteredOn(event -> event.action() == AuditAction.AUTH_LOGIN)
+                .singleElement()
+                .satisfies(event -> assertThat(event.outcome()).isEqualTo(AuditOutcome.FAILED));
+    }
+
+    @Test
     void GivenAnEmailAlreadyTaken_WhenAVisitorRegisters_ThenTheRefusalIsAuditedWithNoSubject() {
         when(userQuery.existsByEmail(AUser.EMAIL)).thenReturn(true);
 

--- a/backend/src/test/java/com/healthupgrades/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/auth/application/AuthServiceTest.java
@@ -3,6 +3,7 @@ package com.healthupgrades.auth.application;
 import com.healthupgrades.common.domain.exception.BusinessRuleException;
 import com.healthupgrades.common.security.JwtTokenProvider;
 import com.healthupgrades.support.AUser;
+import com.healthupgrades.support.RecordingAuditTrail;
 import com.healthupgrades.user.application.port.in.UserCommand;
 import com.healthupgrades.user.application.port.in.UserQuery;
 import com.healthupgrades.user.domain.model.User;
@@ -13,6 +14,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import com.healthupgrades.common.domain.audit.AuditAction;
+import com.healthupgrades.common.domain.audit.AuditEvent;
+import com.healthupgrades.common.domain.audit.AuditOutcome;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -54,10 +59,13 @@ class AuthServiceTest {
     private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     private AuthService service;
+    /** A real implementation, not a mock: AuditTrail.recording is a default method. */
+    private final RecordingAuditTrail auditTrail = new RecordingAuditTrail();
 
     @BeforeEach
     void setUp() {
-        service = new AuthService(userQuery, userCommand, passwordEncoder, tokenProvider, authenticationManager);
+        service = new AuthService(userQuery, userCommand, passwordEncoder, tokenProvider,
+                authenticationManager, auditTrail);
     }
 
     @Test
@@ -123,6 +131,58 @@ class AuthServiceTest {
                 .isInstanceOf(BadCredentialsException.class);
 
         verify(tokenProvider, never()).generateToken(any());
+    }
+
+    @Test
+    void GivenMatchingCredentials_WhenTheUserLogsIn_ThenTheSignInIsAuditedAgainstThem() {
+        User user = AUser.aUser().build();
+        when(authenticationManager.authenticate(any())).thenReturn(authenticated());
+        when(userQuery.findByEmail(AUser.EMAIL)).thenReturn(Optional.of(user));
+        when(tokenProvider.generateToken(AUser.EMAIL)).thenReturn("issued.jwt.token");
+
+        service.login(AUser.EMAIL, RAW_PASSWORD);
+
+        assertThat(auditTrail.only(AuditAction.AUTH_LOGIN)).hasValue(
+                new AuditEvent(AuditAction.AUTH_LOGIN, user.getId(), user.getId(), AuditOutcome.ALLOWED));
+    }
+
+    @Test
+    void GivenCredentialsThatDoNotMatch_WhenTheUserLogsIn_ThenTheRefusalIsAuditedWithNoSubject() {
+        when(authenticationManager.authenticate(any())).thenThrow(new BadCredentialsException("Bad credentials"));
+
+        assertThatThrownBy(() -> service.login(AUser.EMAIL, "wrong"))
+                .isInstanceOf(BadCredentialsException.class);
+
+        // Deliberately subject-less. The submitted email is personal data (NFR-6) and naming a user id
+        // would confirm the account exists, which is what handleBadCredentials refuses to do on the
+        // wire. What is left is a rate signal and a trace id — the honest limit of auditing an
+        // anonymous endpoint, and the reason this is asserted rather than left to a reader's goodwill.
+        assertThat(auditTrail.only(AuditAction.AUTH_LOGIN)).hasValue(
+                new AuditEvent(AuditAction.AUTH_LOGIN, null, null, AuditOutcome.REFUSED));
+    }
+
+    @Test
+    void GivenADatabaseOutageDuringLogin_WhenTheUserLogsIn_ThenItIsAuditedAsAFaultNotARefusal() {
+        // Spring wraps an outage in an AuthenticationException too. Counting it as a refusal would make
+        // "the database is down" indistinguishable from "somebody typed the wrong password".
+        when(authenticationManager.authenticate(any()))
+                .thenThrow(new AuthenticationServiceException("connection refused"));
+
+        assertThatThrownBy(() -> service.login(AUser.EMAIL, RAW_PASSWORD))
+                .isInstanceOf(AuthenticationServiceException.class);
+
+        assertThat(auditTrail.recorded(AuditAction.AUTH_LOGIN, AuditOutcome.FAILED)).isTrue();
+    }
+
+    @Test
+    void GivenAnEmailAlreadyTaken_WhenAVisitorRegisters_ThenTheRefusalIsAuditedWithNoSubject() {
+        when(userQuery.existsByEmail(AUser.EMAIL)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.register(AUser.NAME, AUser.EMAIL, RAW_PASSWORD))
+                .isInstanceOf(BusinessRuleException.class);
+
+        assertThat(auditTrail.only(AuditAction.AUTH_REGISTER)).hasValue(
+                new AuditEvent(AuditAction.AUTH_REGISTER, null, null, AuditOutcome.REFUSED));
     }
 
     @Test

--- a/backend/src/test/java/com/healthupgrades/common/adapter/out/audit/LoggingAuditTrailTest.java
+++ b/backend/src/test/java/com/healthupgrades/common/adapter/out/audit/LoggingAuditTrailTest.java
@@ -1,0 +1,140 @@
+package com.healthupgrades.common.adapter.out.audit;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.healthupgrades.common.domain.audit.AuditAction;
+import com.healthupgrades.common.domain.audit.AuditEvent;
+import com.healthupgrades.common.domain.audit.AuditOutcome;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import net.logstash.logback.argument.StructuredArgument;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins what the audit stream actually emits: the fields, the counter derived from the same call, and
+ * the absence of anything personal.
+ *
+ * <p>Asserted through a {@link ListAppender} on the {@code AUDIT} logger, which is the name the stream
+ * is addressed by — so this also fails if somebody renames the logger to the class, which would make
+ * every existing routing rule and saved query stop matching.
+ */
+class LoggingAuditTrailTest {
+
+    private static final String AUDIT_LOGGER = "AUDIT";
+
+    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final LoggingAuditTrail trail = new LoggingAuditTrail(meterRegistry);
+
+    private Logger auditLogger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void captureTheAuditStream() {
+        auditLogger = (Logger) LoggerFactory.getLogger(AUDIT_LOGGER);
+        appender = new ListAppender<>();
+        appender.start();
+        auditLogger.addAppender(appender);
+    }
+
+    @AfterEach
+    void releaseTheAuditStream() {
+        auditLogger.detachAppender(appender);
+    }
+
+    @Test
+    void GivenAnAllowedAttempt_WhenItIsRecorded_ThenTheStreamCarriesTheActorTheResourceAndTheOutcome() {
+        UUID actor = UUID.randomUUID();
+        UUID resource = UUID.randomUUID();
+
+        trail.record(AuditEvent.allowed(AuditAction.UPGRADE_ACTIVATE, actor, resource));
+
+        ILoggingEvent line = single();
+        // INFO, not DEBUG: an audit entry is a state transition, and a deployment runs at INFO.
+        assertThat(line.getLevel()).isEqualTo(Level.INFO);
+        assertThat(fieldsOf(line))
+                .containsEntry("action", "upgrade.activate")
+                .containsEntry("outcome", "ALLOWED")
+                .containsEntry("actorId", actor.toString())
+                .containsEntry("resourceId", resource.toString());
+    }
+
+    @Test
+    void GivenARefusedLoginWithNoSubject_WhenItIsRecorded_ThenTheFieldsAreStillPresentAndSayNone() {
+        trail.record(new AuditEvent(AuditAction.AUTH_LOGIN, null, null, AuditOutcome.REFUSED));
+
+        // "There is no actor" is a fact worth recording, and a stable field set is what keeps the
+        // stream queryable — so the fields are present and say so rather than being dropped.
+        assertThat(fieldsOf(single()))
+                .containsEntry("action", "auth.login")
+                .containsEntry("outcome", "REFUSED")
+                .containsEntry("actorId", "none")
+                .containsEntry("resourceId", "none");
+    }
+
+    @Test
+    void GivenAnAttempt_WhenItIsRecorded_ThenTheRenderedLineHoldsNothingButIdentifiersAndEnums() {
+        UUID actor = UUID.randomUUID();
+
+        trail.record(AuditEvent.allowed(AuditAction.REFLECTION_CREATE, actor, UUID.randomUUID()));
+
+        // A reflection's body is the most personal thing this application stores. It cannot reach the
+        // line because AuditEvent has nowhere to hold it (AuditEventTest), and this checks the other
+        // end: what is rendered is only what was passed in.
+        assertThat(single().getFormattedMessage())
+                .contains("action=reflection.create", "actorId=" + actor)
+                .doesNotContain("@", "null");
+    }
+
+    @Test
+    void GivenTwoAttemptsOnTheSameAction_WhenTheyAreRecorded_ThenTheCounterSeparatesThemByOutcome() {
+        UUID actor = UUID.randomUUID();
+        trail.record(AuditEvent.allowed(AuditAction.PROGRESS_RECORD, actor, UUID.randomUUID()));
+        trail.record(new AuditEvent(AuditAction.PROGRESS_RECORD, actor, UUID.randomUUID(), AuditOutcome.REFUSED));
+
+        assertThat(counted("progress.record", "ALLOWED")).isEqualTo(1);
+        assertThat(counted("progress.record", "REFUSED")).isEqualTo(1);
+    }
+
+    @Test
+    void GivenAnyAttempt_WhenItIsCounted_ThenNeitherTheActorNorTheResourceIsATag() {
+        trail.record(AuditEvent.allowed(AuditAction.AREA_CREATE, UUID.randomUUID(), UUID.randomUUID()));
+
+        // A user id as a label is an unbounded cardinality, and a metrics backend is the wrong place to
+        // look one up anyway — that is what the audit line is for.
+        assertThat(meterRegistry.find("audit.events").counter().getId().getTags())
+                .extracting("key")
+                .containsExactlyInAnyOrder("action", "outcome");
+    }
+
+    private ILoggingEvent single() {
+        assertThat(appender.list).hasSize(1);
+        return appender.list.get(0);
+    }
+
+    private double counted(String action, String outcome) {
+        return meterRegistry.get("audit.events").tag("action", action).tag("outcome", outcome).counter().count();
+    }
+
+    /** The structured fields the logstash encoder would turn into JSON keys. */
+    private static java.util.Map<String, Object> fieldsOf(ILoggingEvent event) {
+        java.util.Map<String, Object> fields = new java.util.LinkedHashMap<>();
+        Arrays.stream(event.getArgumentArray())
+                .filter(StructuredArgument.class::isInstance)
+                .forEach(argument -> {
+                    String rendered = argument.toString(); // "key=value"
+                    int split = rendered.indexOf('=');
+                    fields.put(rendered.substring(0, split), rendered.substring(split + 1));
+                });
+        return fields;
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/common/adapter/out/audit/LoggingAuditTrailTest.java
+++ b/backend/src/test/java/com/healthupgrades/common/adapter/out/audit/LoggingAuditTrailTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Pins what the audit stream actually emits: the fields, the counter derived from the same call, and
@@ -84,15 +85,21 @@ class LoggingAuditTrailTest {
     @Test
     void GivenAnAttempt_WhenItIsRecorded_ThenTheRenderedLineHoldsNothingButIdentifiersAndEnums() {
         UUID actor = UUID.randomUUID();
+        UUID resource = UUID.randomUUID();
 
-        trail.record(AuditEvent.allowed(AuditAction.REFLECTION_CREATE, actor, UUID.randomUUID()));
+        trail.record(AuditEvent.allowed(AuditAction.REFLECTION_CREATE, actor, resource));
 
         // A reflection's body is the most personal thing this application stores. It cannot reach the
-        // line because AuditEvent has nowhere to hold it (AuditEventTest), and this checks the other
-        // end: what is rendered is only what was passed in.
-        assertThat(single().getFormattedMessage())
-                .contains("action=reflection.create", "actorId=" + actor)
-                .doesNotContain("@", "null");
+        // line because AuditEvent has nowhere to hold it (AuditEventTest); this checks the other end,
+        // that the renderer adds nothing of its own.
+        //
+        // Asserted as an exact whole-line match rather than "does not contain an @". A UUID's alphabet
+        // is hex and dashes, so a doesNotContain of any word or symbol is a test that cannot fail -
+        // it reads like the NFR-6 guard and guards nothing. Pinning the whole line means anything new
+        // appearing in it has to come through here.
+        assertThat(single().getFormattedMessage()).isEqualTo(
+                "action=reflection.create outcome=ALLOWED resource=REFLECTION"
+                        + " actorId=" + actor + " resourceId=" + resource);
     }
 
     @Test
@@ -114,6 +121,29 @@ class LoggingAuditTrailTest {
         assertThat(meterRegistry.find("audit.events").counter().getId().getTags())
                 .extracting("key")
                 .containsExactlyInAnyOrder("action", "outcome");
+    }
+
+    @Test
+    void GivenAMeterRegistryThatFails_WhenAnAttemptIsRecorded_ThenTheAuditLineIsStillWrittenAndNothingThrows() {
+        // The port says implementations must not throw, and this is why it says so. AuditTrail.recording
+        // calls record() from inside its catch block, so an exception escaping here would *replace* the
+        // business exception - turning a BusinessRuleException that should be a 422 into a 500 with the
+        // real cause lost. The line is the half that matters, so a failing meter must not take it down.
+        LoggingAuditTrail brittle = new LoggingAuditTrail(new FailingMeterRegistry());
+
+        assertThatCode(() -> brittle.record(AuditEvent.allowed(AuditAction.UPGRADE_DELETE,
+                UUID.randomUUID(), UUID.randomUUID()))).doesNotThrowAnyException();
+
+        assertThat(appender.list).anySatisfy(event ->
+                assertThat(event.getFormattedMessage()).contains("action=upgrade.delete"));
+    }
+
+    /** A registry that refuses to register anything, standing in for a meter-id conflict. */
+    private static class FailingMeterRegistry extends SimpleMeterRegistry {
+        @Override
+        protected io.micrometer.core.instrument.Counter newCounter(io.micrometer.core.instrument.Meter.Id id) {
+            throw new IllegalStateException("a meter with that name already exists with different tags");
+        }
     }
 
     private ILoggingEvent single() {

--- a/backend/src/test/java/com/healthupgrades/common/domain/audit/AuditEventTest.java
+++ b/backend/src/test/java/com/healthupgrades/common/domain/audit/AuditEventTest.java
@@ -1,0 +1,70 @@
+package com.healthupgrades.common.domain.audit;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.RecordComponent;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Pins the shape of an audit entry, including the one property that keeps NFR-6 true by construction. */
+class AuditEventTest {
+
+    /**
+     * The requirement is "the application never logs personal data", and the way this trail meets it is
+     * that <em>there is nowhere to put any</em>. Asserting the field types rather than reviewing call
+     * sites is what makes that a property of the design: a future field of type {@code String} — a
+     * title, a note, an email — fails here, at the point somebody adds it, rather than in a log export
+     * six months later.
+     */
+    @Test
+    void GivenAnAuditEvent_WhenItsComponentsAreInspected_ThenNoneCanHoldFreeText() {
+        RecordComponent[] components = AuditEvent.class.getRecordComponents();
+
+        assertThat(components).isNotEmpty();
+        assertThat(components).allSatisfy(component ->
+                assertThat(component.getType().isEnum() || component.getType() == UUID.class)
+                        .as("%s is a %s; an audit event may only hold enums and identifiers",
+                                component.getName(), component.getType().getSimpleName())
+                        .isTrue());
+    }
+
+    @Test
+    void GivenNoAction_WhenAnEventIsBuilt_ThenItIsRejected() {
+        assertThatThrownBy(() -> new AuditEvent(null, UUID.randomUUID(), UUID.randomUUID(), AuditOutcome.ALLOWED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("action");
+    }
+
+    @Test
+    void GivenNoOutcome_WhenAnEventIsBuilt_ThenItIsRejected() {
+        assertThatThrownBy(() -> new AuditEvent(AuditAction.AUTH_LOGIN, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("outcome");
+    }
+
+    /** A refused login has no actor and no resource, deliberately — both have to be representable. */
+    @Test
+    void GivenNoActorAndNoResource_WhenAnEventIsBuilt_ThenItIsAccepted() {
+        AuditEvent event = new AuditEvent(AuditAction.AUTH_LOGIN, null, null, AuditOutcome.REFUSED);
+
+        assertThat(event.actorUserId()).isNull();
+        assertThat(event.resourceId()).isNull();
+    }
+
+    /** The dotted key is a log-query and metric contract, so it is asserted rather than assumed. */
+    @Test
+    void GivenAnAction_WhenItsKeyIsRead_ThenItIsTheStableDottedName() {
+        assertThat(AuditAction.UPGRADE_ACTIVATE.key()).isEqualTo("upgrade.activate");
+        assertThat(AuditAction.UPGRADE_ACTIVATE.resource()).isEqualTo(AuditedResource.HEALTH_UPGRADE);
+    }
+
+    @Test
+    void GivenEveryAction_WhenItsKeyIsRead_ThenTheKeysAreUniqueAndDotted() {
+        assertThat(AuditAction.values())
+                .allSatisfy(action -> assertThat(action.key()).matches("[a-z]+\\.[a-z]+"))
+                .extracting(AuditAction::key)
+                .doesNotHaveDuplicates();
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/common/domain/audit/AuditOutcomeTest.java
+++ b/backend/src/test/java/com/healthupgrades/common/domain/audit/AuditOutcomeTest.java
@@ -35,8 +35,15 @@ class AuditOutcomeTest {
                 .isEqualTo(AuditOutcome.REFUSED);
     }
 
+    /**
+     * Pins the classifier, not a live path. A version clash is decided at commit, after the service
+     * method has returned, so it never reaches {@code AuditOutcome.of} — {@code LoggingAuditTrail}
+     * records it on the rollback path instead ({@code AuditCommitIT}). This keeps the function total
+     * over the four exceptions that make up the domain's vocabulary for "no", so that a future throw
+     * site is classified correctly the day it appears rather than counted as a fault.
+     */
     @Test
-    void GivenALostConcurrentEdit_WhenTheOutcomeIsClassified_ThenItIsARefusal() {
+    void GivenTheDomainsOptimisticLockException_WhenItIsClassified_ThenItCountsAsARefusal() {
         assertThat(AuditOutcome.of(new OptimisticLockException("version clash")))
                 .isEqualTo(AuditOutcome.REFUSED);
     }

--- a/backend/src/test/java/com/healthupgrades/common/domain/audit/AuditOutcomeTest.java
+++ b/backend/src/test/java/com/healthupgrades/common/domain/audit/AuditOutcomeTest.java
@@ -1,0 +1,49 @@
+package com.healthupgrades.common.domain.audit;
+
+import com.healthupgrades.common.domain.exception.BusinessRuleException;
+import com.healthupgrades.common.domain.exception.DuplicateProgressException;
+import com.healthupgrades.common.domain.exception.OptimisticLockException;
+import com.healthupgrades.common.domain.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the line between "the system said no" and "the system broke".
+ *
+ * <p>It matters because the two are the same event to a caller — an exception on the way out — and
+ * completely different to whoever is watching. A dashboard where a user attempting an illegal
+ * transition looks identical to a database outage is a dashboard nobody can act on.
+ */
+class AuditOutcomeTest {
+
+    @Test
+    void GivenAViolatedRule_WhenTheOutcomeIsClassified_ThenItIsARefusal() {
+        assertThat(AuditOutcome.of(new BusinessRuleException("cannot reactivate a completed upgrade")))
+                .isEqualTo(AuditOutcome.REFUSED);
+    }
+
+    @Test
+    void GivenSomebodyElsesRecord_WhenTheOutcomeIsClassified_ThenItIsARefusal() {
+        assertThat(AuditOutcome.of(new ResourceNotFoundException("Upgrade not found")))
+                .isEqualTo(AuditOutcome.REFUSED);
+    }
+
+    @Test
+    void GivenASecondEntryForTheSameDay_WhenTheOutcomeIsClassified_ThenItIsARefusal() {
+        assertThat(AuditOutcome.of(new DuplicateProgressException("already recorded")))
+                .isEqualTo(AuditOutcome.REFUSED);
+    }
+
+    @Test
+    void GivenALostConcurrentEdit_WhenTheOutcomeIsClassified_ThenItIsARefusal() {
+        assertThat(AuditOutcome.of(new OptimisticLockException("version clash")))
+                .isEqualTo(AuditOutcome.REFUSED);
+    }
+
+    @Test
+    void GivenAFaultRatherThanADecision_WhenTheOutcomeIsClassified_ThenItIsAFailure() {
+        assertThat(AuditOutcome.of(new IllegalStateException("connection pool exhausted")))
+                .isEqualTo(AuditOutcome.FAILED);
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/common/domain/port/out/AuditTrailTest.java
+++ b/backend/src/test/java/com/healthupgrades/common/domain/port/out/AuditTrailTest.java
@@ -1,0 +1,77 @@
+package com.healthupgrades.common.domain.port.out;
+
+import com.healthupgrades.common.domain.audit.AuditAction;
+import com.healthupgrades.common.domain.audit.AuditEvent;
+import com.healthupgrades.common.domain.audit.AuditOutcome;
+import com.healthupgrades.common.domain.exception.BusinessRuleException;
+import com.healthupgrades.support.RecordingAuditTrail;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the wrapper every service records through.
+ *
+ * <p>The behaviour worth guarding is the failure half. A trail that records only what succeeded is not
+ * a trail — an ownership check that refused and a rule that rejected a transition are the entries
+ * somebody goes looking for — and it is the half that is easy to leave out and impossible to notice
+ * missing, because everything still works.
+ */
+class AuditTrailTest {
+
+    private final RecordingAuditTrail trail = new RecordingAuditTrail();
+    private final UUID actor = UUID.randomUUID();
+    private final UUID resource = UUID.randomUUID();
+
+    @Test
+    void GivenAnOperationThatSucceeds_WhenItIsRecorded_ThenItsResultIsReturnedAndTheAttemptAllowed() {
+        String result = trail.recording(AuditAction.UPGRADE_ACTIVATE, actor, resource, () -> "activated");
+
+        assertThat(result).isEqualTo("activated");
+        assertThat(trail.only(AuditAction.UPGRADE_ACTIVATE)).hasValue(
+                new AuditEvent(AuditAction.UPGRADE_ACTIVATE, actor, resource, AuditOutcome.ALLOWED));
+    }
+
+    @Test
+    void GivenARuleThatRefuses_WhenItIsRecorded_ThenTheRefusalIsKeptAndTheExceptionRethrown() {
+        BusinessRuleException refusal = new BusinessRuleException("a completed upgrade cannot be paused");
+
+        assertThatThrownBy(() -> trail.recording(AuditAction.UPGRADE_PAUSE, actor, resource, () -> {
+            throw refusal;
+        })).isSameAs(refusal); // rethrown untouched: this observes the operation, it does not handle it
+
+        assertThat(trail.only(AuditAction.UPGRADE_PAUSE)).hasValue(
+                new AuditEvent(AuditAction.UPGRADE_PAUSE, actor, resource, AuditOutcome.REFUSED));
+    }
+
+    @Test
+    void GivenAFaultRatherThanARefusal_WhenItIsRecorded_ThenTheAttemptIsRecordedAsFailed() {
+        assertThatThrownBy(() -> trail.recording(AuditAction.UPGRADE_UPDATE, actor, resource, () -> {
+            throw new IllegalStateException("connection pool exhausted");
+        })).isInstanceOf(IllegalStateException.class);
+
+        assertThat(trail.recorded(AuditAction.UPGRADE_UPDATE, AuditOutcome.FAILED)).isTrue();
+    }
+
+    @Test
+    void GivenAnOperationThatReturnsNothing_WhenItIsRecorded_ThenItStillRunsAndIsRecorded() {
+        StringBuilder ran = new StringBuilder();
+
+        trail.recording(AuditAction.UPGRADE_DELETE, actor, resource, () -> ran.append("deleted"));
+
+        assertThat(ran).hasToString("deleted");
+        assertThat(trail.recorded(AuditAction.UPGRADE_DELETE, AuditOutcome.ALLOWED)).isTrue();
+    }
+
+    @Test
+    void GivenAVoidOperationThatRefuses_WhenItIsRecorded_ThenTheRefusalIsKept() {
+        assertThatThrownBy(() -> trail.recording(AuditAction.AREA_DELETE, actor, resource, () -> {
+            throw new BusinessRuleException("nope");
+        })).isInstanceOf(BusinessRuleException.class);
+
+        assertThat(trail.recorded(AuditAction.AREA_DELETE, AuditOutcome.REFUSED)).isTrue();
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/common/observability/JobMetricsTest.java
+++ b/backend/src/test/java/com/healthupgrades/common/observability/JobMetricsTest.java
@@ -1,0 +1,80 @@
+package com.healthupgrades.common.observability;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the two meters that make scheduled work visible.
+ *
+ * <p>Scheduled work is the part of this application nobody is watching: a request that fails answers
+ * somebody with a 500, while a nightly sweep that has been throwing for a week looks exactly like a
+ * nightly sweep with nothing to do. The property that matters most here is that a failing run is still
+ * <em>counted</em> and still <em>thrown</em> — counted so it can be alerted on, thrown so Spring's own
+ * error handler still logs the stack trace rather than this class swallowing it into a summary.
+ */
+class JobMetricsTest {
+
+    private static final String JOB = "upgrade.overdue-scan";
+
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final JobMetrics jobMetrics = new JobMetrics(meterRegistry);
+
+    @Test
+    void GivenAJobThatFinishes_WhenItIsTimed_ThenItRunsAndIsCountedAsOk() {
+        StringBuilder ran = new StringBuilder();
+
+        jobMetrics.timed(JOB, () -> ran.append("swept"));
+
+        assertThat(ran).hasToString("swept");
+        assertThat(runs("ok")).isEqualTo(1);
+        assertThat(meterRegistry.get("scheduled.job.duration").tag("job", JOB).timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    void GivenAJobThatThrows_WhenItIsTimed_ThenItIsCountedAsFailedAndTheFaultStillEscapes() {
+        assertThatThrownBy(() -> jobMetrics.timed(JOB, () -> {
+            throw new IllegalStateException("the query blew up");
+        })).isInstanceOf(IllegalStateException.class);
+
+        assertThat(runs("failed")).isEqualTo(1);
+        assertThat(runs("ok")).isZero();
+    }
+
+    @Test
+    void GivenAJobThatThrows_WhenItIsTimed_ThenItsDurationIsStillRecorded() {
+        // A run that failed after thirty seconds is exactly the run worth knowing the duration of.
+        assertThatThrownBy(() -> jobMetrics.timed(JOB, () -> {
+            throw new IllegalStateException("the query blew up");
+        })).isInstanceOf(IllegalStateException.class);
+
+        assertThat(meterRegistry.get("scheduled.job.duration").tag("job", JOB).timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    void GivenTwoJobs_WhenBothAreTimed_ThenTheirCountsAreSeparate() {
+        jobMetrics.timed(JOB, () -> { });
+        jobMetrics.timed("notification.reminder-dispatch", () -> { });
+
+        assertThat(runs("ok")).isEqualTo(1);
+        assertThat(meterRegistry.get("scheduled.job.runs")
+                .tag("job", "notification.reminder-dispatch").tag("outcome", "ok").counter().count()).isEqualTo(1);
+    }
+
+    @Test
+    void GivenAnyRun_WhenItIsCounted_ThenTheOnlyTagsAreTheJobAndTheOutcome() {
+        jobMetrics.timed(JOB, () -> { });
+
+        assertThat(meterRegistry.get("scheduled.job.runs").counter().getId().getTags())
+                .extracting("key")
+                .containsExactlyInAnyOrder("job", "outcome");
+    }
+
+    private double runs(String outcome) {
+        return meterRegistry.find("scheduled.job.runs")
+                .tag("job", JOB).tag("outcome", outcome).counters().stream()
+                .mapToDouble(io.micrometer.core.instrument.Counter::count).sum();
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/common/observability/JobMetricsTest.java
+++ b/backend/src/test/java/com/healthupgrades/common/observability/JobMetricsTest.java
@@ -54,6 +54,22 @@ class JobMetricsTest {
     }
 
     @Test
+    void GivenAJobThatDiesOnAnError_WhenItIsTimed_ThenItIsCountedAsFailedRatherThanAsACleanRun() {
+        // The failure mode that makes this class worth having and is easiest to get wrong: an Error -
+        // NoClassDefFoundError from a missing transitive dependency, OutOfMemoryError, a static
+        // initialiser blowing up - is not a RuntimeException. Deciding the outcome in a catch means
+        // an Error walks past the assignment and gets counted as ok, holding the failure counter at
+        // zero while the sweep has not worked in a week. Nobody is answered with a 500 by a scheduled
+        // job, so that counter is the only signal there is.
+        assertThatThrownBy(() -> jobMetrics.timed(JOB, () -> {
+            throw new NoClassDefFoundError("com/example/Gone");
+        })).isInstanceOf(NoClassDefFoundError.class);
+
+        assertThat(runs("failed")).isEqualTo(1);
+        assertThat(runs("ok")).isZero();
+    }
+
+    @Test
     void GivenTwoJobs_WhenBothAreTimed_ThenTheirCountsAreSeparate() {
         jobMetrics.timed(JOB, () -> { });
         jobMetrics.timed("notification.reminder-dispatch", () -> { });

--- a/backend/src/test/java/com/healthupgrades/common/observability/LogOutputFormatTest.java
+++ b/backend/src/test/java/com/healthupgrades/common/observability/LogOutputFormatTest.java
@@ -1,0 +1,141 @@
+package com.healthupgrades.common.observability;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.encoder.Encoder;
+import ch.qos.logback.core.OutputStreamAppender;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins what {@code logback-spring.xml} renders, in both of the formats it selects between.
+ *
+ * <p>This exists because of a specific, quiet failure mode. {@link RequestCorrelationTest} proves the
+ * trace id reaches the <em>MDC</em>; nothing there notices if the log <em>output</em> stops printing it.
+ * Before this project had a Logback configuration file, Boot's stock {@code CONSOLE_LOG_PATTERN}
+ * interpolated {@code ${LOG_CORRELATION_PATTERN}} and the id appeared for free
+ * ({@code docs/ADRs/ADR-007}, §Decision). A configuration file that writes its own {@code <pattern>}
+ * instead of importing Boot's {@code defaults.xml} compiles, starts, logs happily — and correlates
+ * nothing. That is a regression nobody would find until they needed the logs.
+ *
+ * <p>The rig boots a real {@link org.springframework.boot.SpringApplication} so that Boot's own
+ * {@code LoggingApplicationListener} reads the shipped file exactly as it would in production, but with
+ * no auto-configuration, no web server and no datasource, so {@code mvn test} stays database-free. It
+ * then takes the configured appender's <em>encoder</em> and renders one event through it: asserting on
+ * bytes the encoder produced is what makes this a test of the format rather than of the MDC.
+ *
+ * <p>Logging initialization is JVM-global, so {@link #restoreDefaultLogging()} puts the context back on
+ * the plain-text configuration when the class finishes. Nothing else in the suite reads a root appender
+ * — the other tests attach a {@code ListAppender} to a named logger — so the blast radius is nil either
+ * way, but leaving a fork's logging in whichever state the last test wanted is a trap for the next one.
+ */
+class LogOutputFormatTest {
+
+    private static final String TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+    private static final String SPAN_ID = "00f067aa0ba902b7";
+    private static final String SERVICE_NAME = "health-upgrades-tracker";
+    private static final String MESSAGE = "handling";
+
+    @Test
+    void GivenTheDefaultProfile_WhenALineIsRendered_ThenItIsPlainTextCarryingTheTraceId() {
+        String rendered = renderOneLineUnderProfiles();
+
+        assertThat(rendered)
+                .contains(MESSAGE)
+                .contains(TRACE_ID)
+                .contains(SPAN_ID)
+                .doesNotStartWith("{");
+    }
+
+    @Test
+    void GivenTheJsonLogsProfile_WhenALineIsRendered_ThenItIsOneJsonObjectCarryingTheTraceId() throws Exception {
+        String rendered = renderOneLineUnderProfiles("json-logs");
+
+        JsonNode line = new ObjectMapper().readTree(rendered);
+        assertThat(line.path("message").asText()).isEqualTo(MESSAGE);
+        assertThat(line.path("level").asText()).isEqualTo("INFO");
+        // The MDC is the only route by which correlation reaches the JSON, so includeMdc is the
+        // json-logs equivalent of importing Boot's defaults.xml.
+        assertThat(line.path("traceId").asText()).isEqualTo(TRACE_ID);
+        assertThat(line.path("spanId").asText()).isEqualTo(SPAN_ID);
+        assertThat(line.path("service").asText()).isEqualTo(SERVICE_NAME);
+    }
+
+    @AfterAll
+    static void restoreDefaultLogging() {
+        renderOneLineUnderProfiles();
+    }
+
+    /**
+     * Boots an application under the given profiles so Boot configures Logback from the shipped
+     * {@code logback-spring.xml}, then renders one event through the resulting encoder.
+     *
+     * @param profiles the profiles to activate; none for the plain-text branch
+     * @return exactly what the encoder would have written to the console for that event
+     */
+    private static String renderOneLineUnderProfiles(String... profiles) {
+        try (ConfigurableApplicationContext ignored = new SpringApplicationBuilder(NoBeans.class)
+                .web(WebApplicationType.NONE)
+                .profiles(profiles)
+                .properties("spring.application.name=" + SERVICE_NAME,
+                        "spring.main.banner-mode=off")
+                .run()) {
+            return new String(configuredEncoder().encode(anEventInsideATrace()), StandardCharsets.UTF_8);
+        }
+    }
+
+    /** The encoder the shipped configuration actually installed on the root logger. */
+    private static Encoder<ILoggingEvent> configuredEncoder() {
+        Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        Iterator<Appender<ILoggingEvent>> appenders = root.iteratorForAppenders();
+        assertThat(appenders).as("the root logger has an appender to read the format from").hasNext();
+
+        Appender<ILoggingEvent> appender = appenders.next();
+        assertThat(appender)
+                .as("the configured appender writes through an encoder")
+                .isInstanceOf(OutputStreamAppender.class);
+        return ((OutputStreamAppender<ILoggingEvent>) appender).getEncoder();
+    }
+
+    /**
+     * An event carrying the MDC keys Micrometer's {@code Slf4JEventListener} writes while a request is
+     * being traced. {@link LoggingEvent} reads the MDC when the map is first asked for, which is during
+     * encoding, so the keys have to still be set at that point rather than at construction.
+     */
+    private static ILoggingEvent anEventInsideATrace() {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        MDC.put("traceId", TRACE_ID);
+        MDC.put("spanId", SPAN_ID);
+        try {
+            LoggingEvent event = new LoggingEvent(
+                    LogOutputFormatTest.class.getName(), context.getLogger(LogOutputFormatTest.class),
+                    Level.INFO, MESSAGE, null, null);
+            event.getMDCPropertyMap();
+            return event;
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    /** A context with nothing in it: this test needs Boot's logging initialization, not its beans. */
+    @SpringBootConfiguration
+    static class NoBeans {
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/healtharea/application/HealthAreaServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/healtharea/application/HealthAreaServiceTest.java
@@ -7,8 +7,10 @@ import com.healthupgrades.healtharea.domain.port.out.HealthAreaRepositoryPort;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import com.healthupgrades.support.RecordingAuditTrail;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
@@ -44,6 +46,8 @@ class HealthAreaServiceTest {
     private final UUID otherUserId = UUID.randomUUID();
 
     @Mock HealthAreaRepositoryPort repository;
+    /** A real implementation, not a mock: AuditTrail.recording is a default method. */
+    @Spy RecordingAuditTrail auditTrail = new RecordingAuditTrail();
 
     @InjectMocks HealthAreaService service;
 

--- a/backend/src/test/java/com/healthupgrades/notification/adapter/in/scheduling/NotificationSchedulerTest.java
+++ b/backend/src/test/java/com/healthupgrades/notification/adapter/in/scheduling/NotificationSchedulerTest.java
@@ -9,6 +9,8 @@ import com.healthupgrades.tracking.domain.model.ProgressEntry;
 import com.healthupgrades.upgrade.application.port.in.UpgradeQuery;
 import com.healthupgrades.upgrade.domain.model.HealthUpgrade;
 import com.healthupgrades.upgrade.domain.model.UpgradeStatus;
+import com.healthupgrades.common.observability.JobMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,6 +55,8 @@ class NotificationSchedulerTest {
     private final Clock fixedClock = Clock.fixed(Instant.parse("2026-06-24T09:00:00Z"), ZoneOffset.UTC);
     private static final LocalDate TODAY = LocalDate.of(2026, 6, 24);
     private NotificationScheduler scheduler;
+    /** A real one, not a mock: JobMetrics.timed runs the job, so a stub would run nothing. */
+    private final JobMetrics jobMetrics = new JobMetrics(new SimpleMeterRegistry());
 
     private final UUID userId = UUID.randomUUID();
     private final UUID upgradeId = UUID.randomUUID();
@@ -60,7 +64,7 @@ class NotificationSchedulerTest {
     @BeforeEach
     void setUp() {
         scheduler = new NotificationScheduler(upgradeQuery, progressQuery, reminderQuery,
-                notificationRepository, notificationService, fixedClock);
+                notificationRepository, notificationService, jobMetrics, fixedClock);
     }
 
     @Test

--- a/backend/src/test/java/com/healthupgrades/notification/adapter/out/messaging/StompNotificationPushAdapterTest.java
+++ b/backend/src/test/java/com/healthupgrades/notification/adapter/out/messaging/StompNotificationPushAdapterTest.java
@@ -10,14 +10,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -69,6 +72,20 @@ class StompNotificationPushAdapterTest {
                 .as("the entity must not be pushed raw — the frontend reads the DTO")
                 .isInstanceOf(NotificationDto.class)
                 .isEqualTo(mapper.toDto(notification));
+    }
+
+    @Test
+    void GivenNoReachableSession_WhenANotificationIsPushed_ThenTheCallerIsNotFailed() {
+        // This runs from an afterCommit callback, so the notification is already durable and FR-32's
+        // "readable afterwards regardless" is already satisfied. Letting the exception out failed the
+        // caller after its transaction had committed — and in dispatchReminders that meant one
+        // unreachable session cancelled everybody else's reminders for that minute.
+        doThrow(new MessageDeliveryException("no session"))
+                .when(messagingTemplate).convertAndSendToUser(anyString(), anyString(), any(Object.class));
+
+        assertThatCode(() -> new StompNotificationPushAdapter(messagingTemplate, mapper)
+                .push(userId, aNotification()))
+                .doesNotThrowAnyException();
     }
 
     private Notification aNotification() {

--- a/backend/src/test/java/com/healthupgrades/reflection/application/ReflectionServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/reflection/application/ReflectionServiceTest.java
@@ -5,6 +5,7 @@ import com.healthupgrades.common.domain.port.out.DomainEventPublisher;
 import com.healthupgrades.reflection.application.port.in.ReflectionDetails;
 import com.healthupgrades.reflection.domain.event.ReflectionAdded;
 import com.healthupgrades.reflection.domain.model.Reflection;
+import com.healthupgrades.support.RecordingAuditTrail;
 import com.healthupgrades.reflection.domain.port.out.ReflectionRepositoryPort;
 import com.healthupgrades.support.AnUpgrade;
 import com.healthupgrades.upgrade.application.port.in.UpgradeQuery;
@@ -57,10 +58,12 @@ class ReflectionServiceTest {
     @Mock DomainEventPublisher eventPublisher;
 
     private ReflectionService service;
+    /** A real implementation, not a mock: AuditTrail.recording is a default method. */
+    private final RecordingAuditTrail auditTrail = new RecordingAuditTrail();
 
     @BeforeEach
     void setUp() {
-        service = new ReflectionService(repository, upgradeQuery, eventPublisher, fixedClock);
+        service = new ReflectionService(repository, upgradeQuery, eventPublisher, auditTrail, fixedClock);
     }
 
     @Test

--- a/backend/src/test/java/com/healthupgrades/reminder/application/ReminderServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/reminder/application/ReminderServiceTest.java
@@ -11,8 +11,10 @@ import com.healthupgrades.upgrade.application.port.in.UpgradeQuery;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import com.healthupgrades.support.RecordingAuditTrail;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalTime;
@@ -48,6 +50,8 @@ class ReminderServiceTest {
 
     @Mock ReminderRepositoryPort repository;
     @Mock UpgradeQuery upgradeQuery;
+    /** A real implementation, not a mock: AuditTrail.recording is a default method. */
+    @Spy RecordingAuditTrail auditTrail = new RecordingAuditTrail();
 
     @InjectMocks ReminderService service;
 

--- a/backend/src/test/java/com/healthupgrades/support/RecordingAuditTrail.java
+++ b/backend/src/test/java/com/healthupgrades/support/RecordingAuditTrail.java
@@ -1,0 +1,49 @@
+package com.healthupgrades.support;
+
+import com.healthupgrades.common.domain.audit.AuditAction;
+import com.healthupgrades.common.domain.audit.AuditEvent;
+import com.healthupgrades.common.domain.audit.AuditOutcome;
+import com.healthupgrades.common.domain.port.out.AuditTrail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * An {@link AuditTrail} that keeps what it was told, for a test to assert against.
+ *
+ * <p>This exists instead of a Mockito mock for a reason worth knowing before anyone swaps it back:
+ * {@code AuditTrail.recording} is a {@code default} method, and a mock stubs those too — so
+ * {@code recording(...)} would return {@code null} without ever running the operation it was given,
+ * and every service under test would quietly stop doing its work while its test still passed. Keeping
+ * a real implementation means the wrapper, including the branch that records a refusal, is exercised
+ * by every service test rather than only by its own.
+ */
+public class RecordingAuditTrail implements AuditTrail {
+
+    private final List<AuditEvent> recorded = new ArrayList<>();
+
+    @Override
+    public void record(AuditEvent event) {
+        recorded.add(event);
+    }
+
+    /** Everything recorded so far, in order. */
+    public List<AuditEvent> recorded() {
+        return List.copyOf(recorded);
+    }
+
+    /** The only event recorded for {@code action}, or empty when there is none. */
+    public Optional<AuditEvent> only(AuditAction action) {
+        List<AuditEvent> matches = recorded.stream().filter(e -> e.action() == action).toList();
+        if (matches.size() > 1) {
+            throw new AssertionError(action + " was recorded " + matches.size() + " times, expected at most one");
+        }
+        return matches.stream().findFirst();
+    }
+
+    /** Whether {@code action} was recorded with {@code outcome}. */
+    public boolean recorded(AuditAction action, AuditOutcome outcome) {
+        return recorded.stream().anyMatch(e -> e.action() == action && e.outcome() == outcome);
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/tracking/application/TrackingServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/tracking/application/TrackingServiceTest.java
@@ -13,6 +13,7 @@ import com.healthupgrades.tracking.domain.event.StreakAchieved;
 import com.healthupgrades.tracking.domain.model.Frequency;
 import com.healthupgrades.tracking.domain.model.ProgressEntry;
 import com.healthupgrades.tracking.domain.service.ProgressEvaluationService;
+import com.healthupgrades.support.RecordingAuditTrail;
 import com.healthupgrades.tracking.domain.service.StreakCalculator;
 import com.healthupgrades.tracking.domain.model.TrackingConfig;
 import com.healthupgrades.tracking.domain.model.TrackingType;
@@ -70,6 +71,8 @@ class TrackingServiceTest {
     private final LocalDate today = LocalDate.of(2026, 3, 15);
 
     private TrackingService service;
+    /** A real implementation, not a mock: AuditTrail.recording is a default method. */
+    private final RecordingAuditTrail auditTrail = new RecordingAuditTrail();
 
     private final UUID userId = UUID.randomUUID();
     private final UUID upgradeId = UUID.randomUUID();
@@ -77,7 +80,7 @@ class TrackingServiceTest {
     @BeforeEach
     void setUp() {
         service = new TrackingService(configRepository, progressRepository, upgradeQuery,
-                streakCalculator, evaluationService, eventPublisher, fixedClock);
+                streakCalculator, evaluationService, eventPublisher, auditTrail, fixedClock);
     }
 
     // ---- Recording progress ----

--- a/backend/src/test/java/com/healthupgrades/upgrade/adapter/in/scheduling/UpgradeOverdueSchedulerTest.java
+++ b/backend/src/test/java/com/healthupgrades/upgrade/adapter/in/scheduling/UpgradeOverdueSchedulerTest.java
@@ -5,6 +5,8 @@ import com.healthupgrades.upgrade.domain.event.UpgradeOverdueDetected;
 import com.healthupgrades.upgrade.application.port.in.UpgradeQuery;
 import com.healthupgrades.upgrade.domain.model.HealthUpgrade;
 import com.healthupgrades.upgrade.domain.model.UpgradeStatus;
+import com.healthupgrades.common.observability.JobMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,11 +51,13 @@ class UpgradeOverdueSchedulerTest {
     private UpgradeOverdueScheduler scheduler;
 
     private final UUID userId = UUID.randomUUID();
+    /** A real one, not a mock: JobMetrics.timed runs the job, so a stub would run nothing. */
+    private final JobMetrics jobMetrics = new JobMetrics(new SimpleMeterRegistry());
     private final UUID upgradeId = UUID.randomUUID();
 
     @BeforeEach
     void setUp() {
-        scheduler = new UpgradeOverdueScheduler(upgradeQuery, eventPublisher, fixedClock);
+        scheduler = new UpgradeOverdueScheduler(upgradeQuery, eventPublisher, jobMetrics, fixedClock);
     }
 
     private HealthUpgrade activeUpgradeEnding(LocalDate targetEndDate) {

--- a/backend/src/test/java/com/healthupgrades/upgrade/application/UpgradeServiceTest.java
+++ b/backend/src/test/java/com/healthupgrades/upgrade/application/UpgradeServiceTest.java
@@ -5,6 +5,9 @@ import com.healthupgrades.upgrade.domain.event.HealthUpgradeActivated;
 import com.healthupgrades.upgrade.domain.event.HealthUpgradeCompleted;
 import com.healthupgrades.upgrade.domain.event.HealthUpgradeCreated;
 import com.healthupgrades.upgrade.domain.event.HealthUpgradePlanned;
+import com.healthupgrades.common.domain.audit.AuditAction;
+import com.healthupgrades.common.domain.audit.AuditEvent;
+import com.healthupgrades.common.domain.audit.AuditOutcome;
 import com.healthupgrades.common.domain.exception.BusinessRuleException;
 import com.healthupgrades.common.domain.exception.ResourceNotFoundException;
 import com.healthupgrades.upgrade.application.port.in.UpgradeDetails;
@@ -13,6 +16,7 @@ import com.healthupgrades.upgrade.domain.model.HealthUpgrade;
 import com.healthupgrades.upgrade.domain.model.UpgradeStatus;
 import com.healthupgrades.upgrade.domain.model.UpgradeType;
 import com.healthupgrades.upgrade.domain.port.out.UpgradeRepositoryPort;
+import com.healthupgrades.support.RecordingAuditTrail;
 import com.healthupgrades.upgrade.domain.service.UpgradeSchedulingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,6 +61,8 @@ class UpgradeServiceTest {
     private final UpgradeSchedulingService schedulingService = new UpgradeSchedulingService();
 
     private UpgradeService service;
+    /** A real implementation, not a mock: AuditTrail.recording is a default method. */
+    private final RecordingAuditTrail auditTrail = new RecordingAuditTrail();
 
     private final UUID userId = UUID.randomUUID();
     private final UUID upgradeId = UUID.randomUUID();
@@ -65,7 +71,7 @@ class UpgradeServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new UpgradeService(repository, schedulingService, eventPublisher, fixedClock);
+        service = new UpgradeService(repository, schedulingService, eventPublisher, auditTrail, fixedClock);
     }
 
     private HealthUpgrade upgradeWith(UpgradeStatus status, Difficulty difficulty) {
@@ -392,5 +398,45 @@ class UpgradeServiceTest {
         when(repository.findByIdAndUserId(upgradeId, userId)).thenReturn(Optional.empty());
 
         assertThat(service.findOwned(userId, upgradeId)).isEmpty();
+    }
+
+    // ---- The audit trail ----
+
+    @Test
+    void GivenARunningUpgrade_WhenItIsCompleted_ThenTheTransitionIsAuditedAgainstItsOwner() {
+        HealthUpgrade upgrade = upgradeWith(UpgradeStatus.ACTIVE, Difficulty.EASY);
+        when(repository.findByIdAndUserId(upgradeId, userId)).thenReturn(Optional.of(upgrade));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.complete(userId, upgradeId);
+
+        assertThat(auditTrail.only(AuditAction.UPGRADE_COMPLETE)).hasValue(
+                new AuditEvent(AuditAction.UPGRADE_COMPLETE, userId, upgradeId, AuditOutcome.ALLOWED));
+    }
+
+    @Test
+    void GivenACompletedUpgrade_WhenItIsPaused_ThenTheRefusalIsAuditedRatherThanLost() {
+        // The half of the trail that is easy to leave out: nothing changed, nothing was published, and
+        // an attempt to move a terminal upgrade is exactly the entry somebody would come looking for.
+        when(repository.findByIdAndUserId(upgradeId, userId))
+                .thenReturn(Optional.of(upgradeWith(UpgradeStatus.COMPLETED, Difficulty.EASY)));
+
+        assertThatThrownBy(() -> service.pause(userId, upgradeId))
+                .isInstanceOf(BusinessRuleException.class);
+
+        assertThat(auditTrail.only(AuditAction.UPGRADE_PAUSE)).hasValue(
+                new AuditEvent(AuditAction.UPGRADE_PAUSE, userId, upgradeId, AuditOutcome.REFUSED));
+    }
+
+    @Test
+    void GivenAnUpgradeOwnedBySomebodyElse_WhenItIsDeleted_ThenTheRefusedAttemptIsAudited() {
+        // BR-15 reports a foreign record as absent, so the response says nothing happened. The trail is
+        // the only place that records somebody having reached for a record that was not theirs.
+        when(repository.findByIdAndUserId(upgradeId, userId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.delete(userId, upgradeId))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        assertThat(auditTrail.recorded(AuditAction.UPGRADE_DELETE, AuditOutcome.REFUSED)).isTrue();
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,10 @@ services:
       DB_USERNAME: ${POSTGRES_USER:-healthupgrades}
       DB_PASSWORD: ${POSTGRES_PASSWORD:-healthupgrades}
       JWT_SECRET: ${JWT_SECRET:-change-this-secret-in-production-must-be-256-bits-long-random}
+      # Selects the JSON encoder in logback-spring.xml. A container's log is read by a machine before
+      # a person, and `docker logs` is the only sink here - there is no file appender and no volume.
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-json-logs}
+      LOG_LEVEL_APP: ${LOG_LEVEL_APP:-INFO}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,10 @@ services:
       # a person, and `docker logs` is the only sink here - there is no file appender and no volume.
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-json-logs}
       LOG_LEVEL_APP: ${LOG_LEVEL_APP:-INFO}
+      # Boot prints its banner straight to stdout before the logging system exists, so logback cannot
+      # format it: nine unparseable lines ahead of every restart's JSON. Off here and nowhere else -
+      # a local run still gets it, and there it is a person reading rather than a parser.
+      SPRING_MAIN_BANNER_MODE: "off"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,15 +41,9 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    healthcheck:
-      # Readiness rather than the aggregate: this answers "can it serve traffic", which is what the
-      # frontend's depends_on below is actually waiting for. start_period covers JVM start and the
-      # Flyway migration, during which an unhealthy answer is correct.
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health/readiness || exit 1"]
-      interval: 30s
-      timeout: 10s
-      start_period: 60s
-      retries: 5
+    # No healthcheck here: backend/Dockerfile declares one against the readiness probe and compose uses
+    # the image's. Restating it gave two sources of truth for one probe, and they had already drifted
+    # apart on the day they were written - the image said timeout 5s / 3 retries, this said 10s / 5.
 
   frontend:
     build:
@@ -58,12 +52,7 @@ services:
     container_name: healthupgrades-frontend
     ports:
       - "3000:80"
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost/ || exit 1"]
-      interval: 30s
-      timeout: 5s
-      start_period: 10s
-      retries: 3
+    # As above: frontend/Dockerfile declares the probe.
     depends_on:
       # Waits for the API to be ready, not merely started. A plain depends_on let nginx come up while
       # Flyway was still migrating, so the first page load proxied to a backend that could not answer.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,13 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health || exit 1"]
+      # Readiness rather than the aggregate: this answers "can it serve traffic", which is what the
+      # frontend's depends_on below is actually waiting for. start_period covers JVM start and the
+      # Flyway migration, during which an unhealthy answer is correct.
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health/readiness || exit 1"]
       interval: 30s
       timeout: 10s
+      start_period: 60s
       retries: 5
 
   frontend:
@@ -50,8 +54,17 @@ services:
     container_name: healthupgrades-frontend
     ports:
       - "3000:80"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
     depends_on:
-      - backend
+      # Waits for the API to be ready, not merely started. A plain depends_on let nginx come up while
+      # Flyway was still migrating, so the first page load proxied to a backend that could not answer.
+      backend:
+        condition: service_healthy
 
 volumes:
   postgres_data:

--- a/docs/ADRs/ADR-007-request-correlation-through-micrometer-tracing.md
+++ b/docs/ADRs/ADR-007-request-correlation-through-micrometer-tracing.md
@@ -1,6 +1,6 @@
 # ADR-007: Correlation ids come from Micrometer Tracing, not from a hand-rolled request id
 
-- **Status:** Accepted
+- **Status:** Accepted — superseded in part by [ADR-010](ADR-010-structured-logging-and-a-level-policy.md)
 - **Date:** 2026-08-24
 - **Scope:** `backend/` — logging, the error wire contract, the STOMP channels and the scheduled jobs.
   One new compile dependency. No change to any domain type.

--- a/docs/ADRs/ADR-010-structured-logging-and-a-level-policy.md
+++ b/docs/ADRs/ADR-010-structured-logging-and-a-level-policy.md
@@ -98,8 +98,11 @@ something that says more.
   security, JPA, actuator and tracing auto-configuration at once, and ADR-007 depends on
   auto-configuration defaults by design. That is its own change with its own risk, and bundling it here
   would mean an observability regression and a framework upgrade in one unreviewable diff. *Revisit
-  when* Boot is next upgraded — at which point this dependency and most of `logback-spring.xml` are
-  deleted, not migrated.
+  when* Boot is next upgraded — at which point most of `logback-spring.xml` is deleted rather than
+  migrated. **The dependency is not**, and that cost should not be discovered during the upgrade:
+  `LoggingAuditTrail`, both schedulers and `StompNotificationPushAdapter` import
+  `StructuredArguments.keyValue`, and Boot's built-in structured logging has no equivalent — those four
+  call sites need a replacement before the artifact can go.
 - **JSON in every environment, including locally.** One format, one way to be wrong. Rejected because a
   developer reads the console directly and JSON is materially harder to scan; the cost is paid every
   day for a property that matters only where a machine reads the log.

--- a/docs/ADRs/ADR-010-structured-logging-and-a-level-policy.md
+++ b/docs/ADRs/ADR-010-structured-logging-and-a-level-policy.md
@@ -1,0 +1,113 @@
+# ADR-010: Logs are JSON in a container and readable locally, and each level means one thing
+
+- **Status:** Accepted
+- **Date:** 2026-08-25
+- **Scope:** `backend/` — the log format, the level policy and the rule about what may appear in a log
+  line. One new compile dependency. No change to any domain type.
+- **Supersedes in part:** [ADR-007](ADR-007-request-correlation-through-micrometer-tracing.md), whose
+  Decision states the trace id arrives "with **no `logback-spring.xml`**". There is one now. Everything
+  else in ADR-007 stands, and the property it relied on is preserved deliberately — see below.
+
+## Context
+
+[ADR-007](ADR-007-request-correlation-through-micrometer-tracing.md) gave every log line a trace id so
+that a failure a user reports can be found. It recorded, in passing, that there were **five log
+statements in `src/main`**, in two classes. That number did not change afterwards.
+
+So the correlation works and there is almost nothing to correlate. `grep` across `src/main` finds no
+logger in any controller, any application service, either scheduler, any security class or any
+persistence adapter. A trace id resolves, at best, to one ERROR line and its stack trace: no record of
+what the request was trying to do, what state the aggregate was in, whether a transition was refused,
+or how long anything took.
+
+Two separate things were wrong, and they need separate answers. This ADR is about **the format and the
+policy**; [ADR-011](ADR-011-audit-as-a-log-stream.md) is about what is recorded when state changes.
+
+The format question is forced by where the logs go. `docker-compose` is the only deployment, so
+`docker logs` is the only sink; there is no file appender and no aggregator. A line there is read by a
+machine before it is read by a person, and a trace id, a level or an audit field is only queryable if
+it is a *field* rather than a substring of a message. The standing engineering guideline asks for
+structured logging outright.
+
+Spring Boot 3.2.5 cannot do this on its own. Built-in structured logging
+(`logging.structured.format.console`) arrived in Boot **3.4**.
+
+## Decision
+
+**Add `net.logstash.logback:logstash-logback-encoder` and select the format with a profile** in a new
+`backend/src/main/resources/logback-spring.xml`:
+
+- default — Boot's stock console pattern, unchanged, for a developer reading along;
+- `json-logs` — a `LogstashEncoder` writing one JSON object per line. `docker-compose` sets the profile,
+  so every container run is structured and no local run is.
+
+**The file imports Boot's `defaults.xml` rather than writing its own `<pattern>`.** This is the part
+worth stating explicitly, because getting it wrong is silent. `defaults.xml` defines
+`CONSOLE_LOG_PATTERN`, and that pattern interpolates `${LOG_CORRELATION_PATTERN}` — the property
+`LogCorrelationEnvironmentPostProcessor` fills with the trace and span id. A hand-written pattern
+compiles, starts, logs happily and correlates nothing. `LogOutputFormatTest` renders one event through
+the encoder the shipped file actually installs, in both formats, and asserts the id is in the output —
+so the mistake fails a build instead of being discovered the next time somebody needs the logs.
+
+**The version is pinned to 7.4 and the pin is ours to maintain.** `spring-boot-dependencies` does not
+manage this artifact. 7.4 is the last release built against logback 1.3/1.4; 8.x compiles against
+logback 1.5, and Boot 3.2.5 resolves logback **1.4.14**. Re-check on any Boot upgrade.
+
+**The default level for `com.healthupgrades` moves from `DEBUG` to `INFO`,** overridable per run through
+`LOG_LEVEL_APP`. `DEBUG` was the only logging configuration this project had, in the only configuration
+file it has, so it was the deployment setting too — including the DEBUG line
+`SpringDomainEventPublisher` writes for every domain event, which fires every minute from
+`dispatchReminders`.
+
+**Each level means one thing:**
+
+| Level | Meaning | What is written at it |
+|---|---|---|
+| ERROR | actionable now, by a person | an unexpected 5xx; a `@Scheduled` run that threw |
+| WARN | degraded, still serving | a real-time push that failed while the notification was stored; a valid signature naming an account that no longer exists |
+| INFO | a state transition | the audit stream (ADR-011); a scheduled run's outcome and duration |
+| DEBUG | for a developer reading along | domain-event publication; why a token was rejected; a 4xx rejection |
+
+**Nothing personal may appear in a log line.** NFR-6 already said the application does not log personal
+data; this states the operative rule for new statements: **log ids and enum values — never a title, an
+email address, a reflection body, a progress note or an IP address.** ADR-011's `AuditEvent` has no
+free-text field at all, so for the audit stream the type system enforces it rather than a reviewer.
+
+## Consequences
+
+**Easier.** A container's log is queryable by trace id, level, logger and service without parsing. A
+line is now worth writing, because writing one is the only way anybody will ever know what the system
+did. Turning DEBUG on for one run is an environment variable, not a deployment.
+
+**Harder.** There are two output formats, so there are two ways to be wrong, and the local one is the
+one nobody is looking at when it breaks. `LogOutputFormatTest` covers both for that reason. The file
+also has to boot a real `SpringApplication` to read the shipped configuration the way Boot does, which
+mutates JVM-global logging state; it restores the plain-text configuration when it finishes.
+
+The dependency is unmanaged, so a Boot upgrade can silently pair logback 1.5 with an encoder built for
+1.4. The failure would be at class-load, which is loud, but the pin needs a look on every upgrade.
+
+**`INFO` by default means the domain-event DEBUG line disappears from a default run.** That line was
+the only thing the scheduled jobs logged. ADR-011 and the scheduler statements replace it with
+something that says more.
+
+## Alternatives considered
+
+- **Upgrade Spring Boot to 3.4+ and use `logging.structured.format.console`.** No extra dependency, no
+  XML, and the right long-term answer. Rejected *for this change*: a minor-version Boot upgrade moves
+  security, JPA, actuator and tracing auto-configuration at once, and ADR-007 depends on
+  auto-configuration defaults by design. That is its own change with its own risk, and bundling it here
+  would mean an observability regression and a framework upgrade in one unreviewable diff. *Revisit
+  when* Boot is next upgraded — at which point this dependency and most of `logback-spring.xml` are
+  deleted, not migrated.
+- **JSON in every environment, including locally.** One format, one way to be wrong. Rejected because a
+  developer reads the console directly and JSON is materially harder to scan; the cost is paid every
+  day for a property that matters only where a machine reads the log.
+- **Keeping the plain-text pattern and no structured logging at all.** Defensible on the grounds that
+  trace ids already correlate lines and nothing ships logs anywhere. Rejected: the moment there is
+  somewhere to ship them, every line already written is unstructured, and the standing guideline asks
+  for structured output. *Revisit* is not offered — this is the cheap end of the decision.
+- **A file appender with a rolling policy.** Rejected: the process runs in a container, `docker logs`
+  is the sink, and a log file inside a container filesystem is a log nobody reads and a disk nobody
+  watches. `.gitignore` already ignores `*.log` and `logs/`. *Revisit when* there is a deployment that
+  is not a container.

--- a/docs/ADRs/ADR-011-audit-as-a-log-stream.md
+++ b/docs/ADRs/ADR-011-audit-as-a-log-stream.md
@@ -45,6 +45,20 @@ reviews the next call site. An upgrade's title, a reflection's body and an email
 audited because they cannot be represented, and `AuditEventTest` asserts it by inspecting the record's
 components, so a future `String` field fails at the moment somebody adds it.
 
+**An `ALLOWED` entry waits for the commit; a refusal does not.** Every audited use case is an
+`@Transactional` service method and the recording happens inside the body, so the work returns while the
+transaction is still open — the commit happens afterwards, in the proxy. No repository adapter flushes,
+so a `@Version` clash or a unique constraint losing a race is decided *at commit*, after the body has
+returned. Writing `ALLOWED` at that point would have the trail and the counter both report an edit that
+was then rolled back and answered to the caller as a 409. `LoggingAuditTrail` therefore defers the
+`ALLOWED` entry through the same `afterCommit` route `NotificationService` already uses, and records the
+attempt as `REFUSED` if the transaction rolls back instead — the reason is not knowable at that point,
+and the likely causes are the database declining the write, so calling every one of them `FAILED` would
+drown the signal that outcome exists to raise. Refusals and faults are written immediately: they already
+describe an attempt that did not land, they are the security-relevant half, and a process that dies
+before commit should not take them with it. The deferral lives in the adapter because
+`TransactionSynchronizationManager` is Spring, and ArchUnit keeps the domain free of it.
+
 **Refusals are recorded, and the wrapper is what guarantees it.** `AuditTrail.recording(...)` runs the
 operation, records `ALLOWED` on return and the classified failure on the way out, and rethrows untouched.
 It is a default method on the port rather than a try/catch at each call site because a trail that records
@@ -81,7 +95,10 @@ everything else in the log, joined to the request by the same trace id. Adding a
 is a constant in `AuditAction` and a wrapper around a body. Nothing about the schema, the migrations or
 the aggregates changed, so nothing about them can have broken.
 
-**Harder.** The trail's retention is the log's retention, and today that is whatever `docker logs`
+**Harder.** An `ALLOWED` entry is now written from a transaction callback rather than from the call
+that produced it, so the code that decides *what* is recorded and the code that decides *when* sit in
+two different files — `AuditCommitIT` exists to keep that seam honest, and it fails if the deferral is
+removed. The trail's retention is the log's retention, and today that is whatever `docker logs`
 keeps — which is not a compliance story, and is written here so nobody assumes it is one. `AuditAction`
 is a file in `common` that a context edits when it adds an operation, a coupling accepted so that the
 whole vocabulary can be read in one place. And twenty-one use-case bodies now sit inside a lambda, so a

--- a/docs/ADRs/ADR-011-audit-as-a-log-stream.md
+++ b/docs/ADRs/ADR-011-audit-as-a-log-stream.md
@@ -1,0 +1,118 @@
+# ADR-011: The audit trail is a log stream, not a table
+
+- **Status:** Accepted
+- **Date:** 2026-08-25
+- **Scope:** `backend/` — one outbound port, one adapter, and a recording call in every state-changing
+  use case. No new dependency. No migration. No change to any aggregate.
+
+## Context
+
+Nothing in this application recorded who did what. There is no `@EnableJpaAuditing`, no Envers, and no
+audit table in any of the five migrations. The seven entities carry `createdAt` and `updatedAt`, written
+by `@PrePersist`, and those are row state: they say when a row last changed and never who changed it,
+what it changed from, or that somebody tried something and was told no.
+
+The last of those matters most and is the easiest to miss. BR-15 reports another user's record as
+*absent* rather than forbidden, so an attempt to reach into somebody else's data is answered `404` and
+leaves no trace anywhere. The same was true of every refused transition, every duplicate progress entry
+and every rejected credential. The system's refusals were invisible, which is precisely the population a
+security review or an incident reconstruction is interested in.
+
+[ADR-010](ADR-010-structured-logging-and-a-level-policy.md) settled how log lines are formatted. This
+one settles what is written when state changes, and where it goes.
+
+## Decision
+
+**Audit entries are a structured log stream.** `AuditTrail` is an outbound port in
+`common/domain/port/out/`, beside `DomainEventPublisher` and for the same reason — every context records
+through it, and one trail is more useful than nine. `LoggingAuditTrail` writes to a logger named `AUDIT`
+at INFO through `StructuredArguments`, so one statement renders as `key=value` for a person reading the
+console and as first-class JSON fields for anything querying it.
+
+**A log stream rather than an `audit_log` table, and the reason is not effort.** An audit entry has to
+survive the transaction it observes. A refused transition rolls back, and a row written inside that
+transaction rolls back with it — losing exactly the entry somebody was looking for. Recording it outside
+the transaction instead means a second connection and a second failure mode, to store a record this
+application has no read path for and no requirement to query. The entry also arrives already correlated,
+because the trace id is on the line, so it leads back to the request that produced it without a foreign
+key. And with no table there is no retention policy to write and no erasure obligation to honour when an
+account is deleted.
+
+**An audit event has nowhere to put personal data.** `AuditEvent` is
+`(AuditAction, actorUserId, resourceId, AuditOutcome)` — two enums and two identifiers. NFR-6 says the
+application does not log personal data; this makes that a property of the type rather than of whoever
+reviews the next call site. An upgrade's title, a reflection's body and an email address cannot be
+audited because they cannot be represented, and `AuditEventTest` asserts it by inspecting the record's
+components, so a future `String` field fails at the moment somebody adds it.
+
+**Refusals are recorded, and the wrapper is what guarantees it.** `AuditTrail.recording(...)` runs the
+operation, records `ALLOWED` on return and the classified failure on the way out, and rethrows untouched.
+It is a default method on the port rather than a try/catch at each call site because a trail that records
+only successes is not a trail, and "record the failure too" written twenty-one times is written twenty.
+
+**Three outcomes, not two.** `REFUSED` is the system working — a rule, an ownership check or a conflict
+said no. `FAILED` is the system broken. Collapsing them would make the one alerting signal worth having
+indistinguishable from ordinary traffic. `AuditOutcome.of` classifies by the four exceptions in
+`common.domain.exception`, which are this application's vocabulary for "no". `AuthService` classifies its
+own, because a rejected credential is Spring Security's exception and would otherwise be counted a fault —
+the same distinction `GlobalExceptionHandler` already draws when it refuses to report a database outage
+to a user as a wrong password.
+
+**A refused login is recorded with no subject at all.** No actor, no resource. The submitted email is
+personal data, an IP address is personal data, and naming a user id would confirm the account exists —
+which is what the 401 handler deliberately refuses to do on the wire. What survives is a count and a
+trace id.
+
+**Notifications are not audited.** They are raised by schedulers and event listeners rather than by a
+person, and `dispatchReminders` alone runs every minute; auditing them would record the system talking to
+itself, at volume, under the heading of who did what. Marking one read is a display flag, not a change to
+the user's record.
+
+**The counter is derived in the adapter from the same call.** `audit.events{action,outcome}` is
+incremented where the line is written, because the event already carries exactly the bounded-cardinality
+labels a counter wants, and deriving it there means the count and the trail cannot disagree. Neither the
+actor nor the resource is a tag: a user id as a label is an unbounded cardinality, and a metrics backend
+is the wrong place to look one up.
+
+## Consequences
+
+**Easier.** "Who changed this, and what were they refused?" is answerable, in the same query language as
+everything else in the log, joined to the request by the same trace id. Adding an operation to the trail
+is a constant in `AuditAction` and a wrapper around a body. Nothing about the schema, the migrations or
+the aggregates changed, so nothing about them can have broken.
+
+**Harder.** The trail's retention is the log's retention, and today that is whatever `docker logs`
+keeps — which is not a compliance story, and is written here so nobody assumes it is one. `AuditAction`
+is a file in `common` that a context edits when it adds an operation, a coupling accepted so that the
+whole vocabulary can be read in one place. And twenty-one use-case bodies now sit inside a lambda, so a
+local that was reassigned had to be split in two.
+
+**A refused login is a rate signal, not an attribution.** It is deliberately impossible to tell from the
+trail *whose* account was targeted, so as written it will not support a lockout policy or an "unusual
+activity" alert. *Revisit when* rate limiting or lockout is implemented — at that point an identifier
+becomes necessary, and choosing one (a hash of the email, a truncated IP) is a privacy decision that
+deserves its own record rather than being smuggled in as a code change.
+
+## Alternatives considered
+
+- **An `audit_log` table written through a repository port.** Durable independently of log retention and
+  queryable in SQL, which is the real argument for it. Rejected for now: it rolls back with the refusal
+  it was recording unless it gets its own transaction, it needs a retention policy and an erasure path on
+  account deletion, and it stores something with no read path and no requirement behind it. *Revisit
+  when* a requirement appears that the log cannot meet — a compliance obligation, a user-visible history,
+  or anything that has to be queried transactionally alongside the data it describes.
+- **Hibernate Envers.** Full row-level history for nothing but an annotation, and genuinely the right
+  tool for "what did this record look like last Tuesday". Rejected because it answers a different
+  question: Envers records versions of rows, not attempts by people, and it cannot record the refusals —
+  which never reach the database — that are the reason this trail exists. It also doubles the schema.
+- **Auditing from a domain-event listener.** Almost free, since the events already exist and already
+  carry the user id. Rejected because domain events are published *after* a successful change, so the
+  entire refused population would be missing, and `backend/CLAUDE.md` already rules out per-event
+  listeners that exist only to write a line.
+- **Auditing in `GlobalExceptionHandler`, where every refusal already converges.** Tempting: one place,
+  total coverage of failures, zero call sites. Rejected because it only knows the HTTP request, so
+  entries would be keyed by method and URL — a vocabulary that changes whenever a route does — and it
+  would record no successes at all, leaving the trail split across two incompatible schemes.
+- **An AOP aspect over the application layer.** Rejected on the grounds ADR-007 rejected `@Observed` for
+  the scheduled jobs: a new starter and proxies around every service, and an aspect still cannot name the
+  resource id without an annotation on each method — which is the call site again, with indirection added.

--- a/docs/ADRs/ADR-012-metrics-through-a-prometheus-scrape-endpoint.md
+++ b/docs/ADRs/ADR-012-metrics-through-a-prometheus-scrape-endpoint.md
@@ -1,0 +1,106 @@
+# ADR-012: Metrics are exposed as a scrape endpoint, and the actuator surface is closed by name
+
+- **Status:** Accepted
+- **Date:** 2026-08-25
+- **Scope:** `backend/` — one compile dependency, the `management.*` configuration, and a `HEALTHCHECK`
+  in both images. No application code.
+
+## Context
+
+`spring-boot-starter-actuator` has been a direct dependency since before this change — it is what
+supplies the tracing auto-configuration [ADR-007](ADR-007-request-correlation-through-micrometer-tracing.md)
+relies on. Everything it collects was unreachable. There was no `management.endpoints.web.exposure`
+property at all, so Boot's default applied and `/actuator/health` was the only endpoint served: no
+request latency, no error rate, no JVM or connection-pool saturation, and no way to read this
+application's own counters. Micrometer was on the classpath with nowhere to publish to.
+
+`management.endpoint.health.probes.enabled` was also unset, so `/actuator/health/liveness` and
+`/actuator/health/readiness` did not exist. `docker-compose` polled the aggregate endpoint and neither
+image declared a `HEALTHCHECK` of its own, so the `frontend` service came up as soon as the `backend`
+container *started* — while Flyway was still migrating.
+
+There is a second thing in the same area worth deciding rather than inheriting. `SecurityConfig` makes
+`/actuator/**` `permitAll`, which is safe today only because Boot's default exposes one harmless
+endpoint. That is safety by accident: a dependency that contributes an endpoint, or one debugging
+session that widens the property and never narrows it, publishes `/actuator/env` — the resolved
+configuration — or `/actuator/heapdump` to anyone who asks.
+
+## Decision
+
+**Add `io.micrometer:micrometer-registry-prometheus` and serve `/actuator/prometheus`.** It is
+BOM-managed under Boot 3.2.5 (there is no `-simpleclient` split at this version; that arrives in 3.3),
+so no version is pinned. A **pull** endpoint is the reason this is not premature in the way ADR-007
+found an OTLP exporter to be: nothing has to exist for it to be useful, because it is a readable page
+rather than a stream that needs somewhere to go.
+
+**Five signals, four of them free.** Request latency and error rate
+(`http_server_requests_seconds{uri,status,outcome}`), JVM and connection-pool saturation
+(`jvm_memory_used_bytes`, `hikaricp_connections_pending`) come from actuator the moment a registry
+exists. The application's own are `audit.events{action,outcome}` — every attempt and how it ended
+([ADR-011](ADR-011-audit-as-a-log-stream.md)) — and `scheduled.job.runs{job,outcome}` with
+`scheduled.job.duration{job}`, because scheduled work is what nobody is watching.
+
+**No tag may be unbounded.** An action, an outcome, a job name and a status are closed sets; a user id,
+an upgrade title and a raw path are not. This is the same reasoning `StompTracingChannelInterceptor`
+already applies to span names, and it is a correctness rule rather than a style preference — a metrics
+backend does not degrade gracefully when a label has a million values, and a user id is not something
+anyone should be looking up there anyway. That is what the audit line is for.
+
+**The exposure list is explicit and closed:** `health,info,prometheus`. Naming what is wanted means
+nothing else can arrive unannounced, and `ActuatorEndpointsIT` asserts that seven endpoints worth
+having opinions about — `env`, `heapdump`, `loggers`, `beans`, `mappings`, `configprops`, `threaddump` —
+answer `404`. Widening the list is then an act that has to change a test.
+
+**`/actuator/**` stays `permitAll`.** With the surface closed by name, what remains readable is a health
+status, build info, and metric values. That is an exposure, and it is recorded here rather than waved
+away: endpoint URIs and traffic volumes are visible to anyone who can reach port 8080.
+
+**Liveness and readiness are enabled, and the health-checks poll readiness.** The two answer different
+questions and an orchestrator acts on them differently: a failed liveness probe means restart the
+process, a failed readiness probe means stop sending it traffic. Restarting a process that cannot reach
+its database fixes nothing, which is why polling the aggregate is wrong for either. Both images now
+declare a `HEALTHCHECK` so they are self-describing outside compose, with a `start_period` covering JVM
+start and the Flyway migration — during which an unhealthy answer is correct. The `frontend` service
+now waits for `service_healthy` rather than for the container to exist.
+
+## Consequences
+
+**Easier.** "Is it up, is it slow, is it failing, is the pool exhausted, did the nightly job run" are
+all answerable from one endpoint, by anything that speaks Prometheus, with no code change. Adding a
+counter is one `Counter.builder` call. An orchestrator can tell "restart me" from "don't route to me".
+
+**Harder.** `/actuator/prometheus` is readable by anyone who can reach the port, and the cardinality
+rule is a rule rather than a mechanism — nothing fails the build if somebody tags a counter with a user
+id, and the damage shows up in the metrics backend rather than here. The exposure list is now a thing
+to remember when adding an actuator-contributing dependency, which is the intended cost.
+
+**Nothing scrapes this.** The endpoint exists and is correct and no dashboard reads it. That is the
+deliberate stopping point: a Prometheus and a Grafana in `docker-compose` would be two more containers
+and a dashboard to maintain for a single-instance application with no on-call and no SLO. *Revisit
+when* there is a deployment somebody is paged for — at which point the endpoint is already there and
+the work is the scraper, not the instrumentation.
+
+## Alternatives considered
+
+- **Actuator only, exposing `/actuator/metrics` and adding no dependency.** The numbers are collected
+  and readable one metric at a time over JSON. Rejected because nothing can scrape that, so nobody
+  would ever look: it is instrumentation that exists to be able to say it exists.
+- **A separate management port (`management.server.port`), unpublished in compose.** The standard answer
+  to the exposure above, and genuinely better in a real deployment — the actuator surface simply is not
+  reachable from outside. Rejected here as a moving part bought too early: a second connector, a changed
+  health-check target, a security-config change and a documented integration point that changes again
+  the moment there is a real deployment. With the exposure list closed by name and asserted, the
+  remaining surface is a status, build info and counters. *Revisit when* this runs anywhere the API port
+  is reachable from outside a trusted network — that is the trigger, and it is the same one ADR-007
+  names for its trusted-proxy boundary, so the two should be done together.
+- **A Prometheus and Grafana stack in `docker-compose`.** Rejected: two containers and a dashboard to
+  maintain for a system with no on-call, no SLO and one instance. The threshold is a deployment somebody
+  is paged for.
+- **An OTLP metrics exporter, matching the OpenTelemetry tracing bridge.** Vendor-neutral and consistent
+  with ADR-007's choice of bridge. Rejected for the reason ADR-007 rejected the trace exporter and which
+  has not changed: a push exporter needs a collector to push to, and there is not one. A pull endpoint
+  has no such precondition, which is exactly why it is the one added now.
+- **`management.endpoint.health.show-details: always`.** Would put the database's status in the health
+  body. Rejected: `/actuator/health` is `permitAll`, and "which component is down" is information about
+  the deployment's internals. The default (`when-authorized`) leaves the aggregate status readable and
+  the breakdown not, which is the right split for an unauthenticated endpoint.

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -425,6 +425,10 @@ Stated because they are load-bearing, not because they are problems yet:
 - **A browser-side error can be shown but not recorded.** The SPA has no telemetry and no log sink, so
   `ErrorBoundary` can put a message on the screen and nothing else knows it happened. Adding a
   reporting endpoint is a decision about sending user data off the device, not a logging change.
+- **A commit-time rollback is audited as a refusal, whatever caused it.** An `ALLOWED` entry is
+  deferred to the commit, so work that rolls back is recorded — but `afterCompletion` does not say why,
+  and an optimistic-lock clash, a lost unique-constraint race and an infrastructure failure at commit
+  are indistinguishable there. All three are recorded `REFUSED`.
 - **A refused login is a rate signal, not an attribution.** The audit entry deliberately names no
   subject, so the trail cannot say whose account was targeted and will not support a lockout policy as
   written.

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -238,6 +238,18 @@ Three places are worth knowing about because they were silent and are no longer:
   durable; the failure is now reported at WARN and the caller carries on, where before one unreachable
   session cancelled everybody else's reminders for that minute.
 
+### In the browser
+
+The SPA has no log sink and no telemetry, which `architecture.md` states elsewhere as a position rather
+than an omission — so a browser-side failure can be *shown* and not *recorded*, and there is no
+`console` call in any committed file.
+
+What it can do is hand the user something to quote. `api/apiError.ts` decodes the backend's error
+contract once, reading the trace id from the error body and falling back to the `X-Trace-Id` header —
+a request refused inside the security chain carries the header alone. `ui/ErrorState` renders it.
+`ErrorBoundary`, mounted inside `ThemeProvider` and around the router, catches a render-time throw so
+it becomes a themed, reloadable message instead of a blank page.
+
 ### Audit
 
 `AuditTrail` is an outbound port in `common/domain/port/out/`, beside `DomainEventPublisher` and

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -181,6 +181,8 @@ without waiting.
 
 ---
 
+## Observability
+
 ### Correlation
 
 Every unit of work runs inside an observation, and the trace id it carries is what joins a failure
@@ -201,6 +203,24 @@ Nothing writes the MDC by hand. Correlation is a property of the runtime, so a n
 controller or job is correlated without its author doing anything.
 [ADR-007](../ADRs/ADR-007-request-correlation-through-micrometer-tracing.md) records why this is
 Micrometer Tracing rather than a hand-rolled request id.
+
+### Logging
+
+`docker logs` is the only sink. There is no file appender, no log volume and no aggregator, so a line
+that is not on stdout does not exist.
+
+`logback-spring.xml` renders that stdout in one of two formats, chosen by profile: Boot's readable
+console pattern by default, and one JSON object per line under `json-logs`, which `docker-compose`
+sets. The plain-text branch imports Boot's `defaults.xml` rather than defining a pattern, because that
+import is what carries `${LOG_CORRELATION_PATTERN}` — and therefore the trace id — into the output;
+`LogOutputFormatTest` renders through the real encoder in both formats so that losing it fails a build.
+
+Levels are load-bearing rather than decorative: **ERROR** is a fault a person must act on now, **WARN**
+is degraded but still serving, **INFO** is a state transition, and **DEBUG** is for a developer reading
+along. `com.healthupgrades` runs at INFO and is turned up for one run with `LOG_LEVEL_APP`. No log line
+carries personal data — ids and enum values only, never a title, an email, a note or an IP.
+[ADR-010](../ADRs/ADR-010-structured-logging-and-a-level-policy.md) records the format decision and the
+policy.
 
 ## External dependencies and integration points
 
@@ -336,6 +356,8 @@ Stated because they are load-bearing, not because they are problems yet:
 | Why the frontend tests with Vitest rather than Jest; why Vitest is pinned to 3; why there is still no accessibility gate | [ADR-004](../ADRs/ADR-004-frontend-test-harness.md) |
 | Why the integration tests start their own database instead of being handed one; why not H2 | [ADR-008](../ADRs/ADR-008-testcontainers-for-the-integration-test-database.md) |
 | Which of the four test levels a new test belongs at, and why coverage is reported rather than gated | [ADR-009](../ADRs/ADR-009-test-levels-boundaries-and-naming.md) |
+| Why correlation is Micrometer Tracing rather than a hand-rolled request id; why there is no exporter | [ADR-007](../ADRs/ADR-007-request-correlation-through-micrometer-tracing.md) |
+| Why logs are JSON in a container but not locally; what each level means; why nothing personal may be logged | [ADR-010](../ADRs/ADR-010-structured-logging-and-a-level-policy.md) |
 | Why every page shares one width; why the shell can be trusted not to overflow; why container queries and a native `<dialog>` were turned down | [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md) |
 | Day-to-day conventions when changing backend code | [`backend/CLAUDE.md`](../../backend/CLAUDE.md) |
 | Day-to-day conventions when changing frontend code | [`frontend/CLAUDE.md`](../../frontend/CLAUDE.md) |

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -222,6 +222,22 @@ carries personal data — ids and enum values only, never a title, an email, a n
 [ADR-010](../ADRs/ADR-010-structured-logging-and-a-level-policy.md) records the format decision and the
 policy.
 
+Three places are worth knowing about because they were silent and are no longer:
+
+- **The scheduled jobs.** Each run is wrapped by `JobMetrics`, which times it and counts its outcome,
+  and each writes one INFO line saying what it found and what it did. A sweep that has been throwing
+  for a week used to look exactly like a sweep with nothing to do. The failure is rethrown rather than
+  handled, because Spring's scheduler already logs a task that threw and two entries for one fault is
+  worse than one. `dispatchReminders` stays silent when nothing is due — otherwise it writes a line a
+  minute, all night, and buries the runs that did something.
+- **The security boundary.** A rejected token is DEBUG with its exception type and never its message,
+  which can quote the token back. A validly signed token naming an account that no longer exists is
+  WARN: the signature was ours, so this is not ordinary expiry. Neither line names a subject, because
+  the only handle available is the email.
+- **A failed real-time push.** It runs from an `afterCommit` callback, so the notification is already
+  durable; the failure is now reported at WARN and the caller carries on, where before one unreachable
+  session cancelled everybody else's reminders for that minute.
+
 ### Audit
 
 `AuditTrail` is an outbound port in `common/domain/port/out/`, beside `DomainEventPublisher` and

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -258,6 +258,28 @@ the entry to its request without a foreign key.
 [ADR-011](../ADRs/ADR-011-audit-as-a-log-stream.md) records the decision, what is deliberately not
 audited, and what would reverse it.
 
+### Metrics and health
+
+`/actuator/prometheus` is the whole of the monitoring surface: request latency and error rate, JVM and
+connection-pool saturation, `audit.events{action,outcome}` and `scheduled.job.runs{job,outcome}` with
+its duration timer. It is a pull endpoint, so it needs no collector to exist before it is useful — and
+nothing scrapes it today, which is a deliberate stopping point rather than an omission.
+
+**No metric tag may be unbounded.** An action, an outcome, a job name and a status are closed sets; a
+user id, an upgrade title and a raw path are not.
+
+The exposed endpoint set is stated by name — `health,info,prometheus` — because `/actuator/**` is
+`permitAll`, so the exposure list is the only thing standing between a reader and `/actuator/env`.
+`ActuatorEndpointsIT` asserts the negative: `env`, `heapdump`, `loggers`, `beans`, `mappings`,
+`configprops` and `threaddump` answer `404`.
+
+Liveness and readiness are separate, because an orchestrator acts on them differently — a failed
+liveness probe means restart the process, a failed readiness probe means stop sending it traffic, and
+restarting a process that cannot reach its database fixes nothing. Both images declare a `HEALTHCHECK`
+against readiness, and the frontend waits for the backend to be *healthy* rather than merely started.
+[ADR-012](../ADRs/ADR-012-metrics-through-a-prometheus-scrape-endpoint.md) records the decisions,
+including why the management endpoints are not on a separate port.
+
 ## External dependencies and integration points
 
 **There are no third-party APIs.** Nothing leaves the deployment: no payment provider, no email or
@@ -272,8 +294,9 @@ push service, no analytics, no AI service.
 
 Integration points a maintainer will need:
 
-- **`/actuator/health`** — the backend's health endpoint, unauthenticated, and what the compose
-  health-check polls.
+- **`/actuator/health`, `/actuator/health/{liveness,readiness}`, `/actuator/info`,
+  `/actuator/prometheus`** — the backend's operational surface, unauthenticated and closed to these by
+  name. The compose and image health-checks poll **readiness**. Nothing else under `/actuator` answers.
 - **Environment variables** — `DB_URL`, `DB_USERNAME`, `DB_PASSWORD`, `JWT_SECRET` are required in any
   real deployment; `CORS_ALLOWED_ORIGINS` and `VITE_API_URL` only matter when frontend and API are on
   different origins. The cron expressions are overridable per environment. `.env.example` lists them
@@ -395,6 +418,7 @@ Stated because they are load-bearing, not because they are problems yet:
 | Why correlation is Micrometer Tracing rather than a hand-rolled request id; why there is no exporter | [ADR-007](../ADRs/ADR-007-request-correlation-through-micrometer-tracing.md) |
 | Why logs are JSON in a container but not locally; what each level means; why nothing personal may be logged | [ADR-010](../ADRs/ADR-010-structured-logging-and-a-level-policy.md) |
 | Why the audit trail is a log stream rather than a table or Envers; why refusals are recorded; what is not audited | [ADR-011](../ADRs/ADR-011-audit-as-a-log-stream.md) |
+| Why metrics are a scrape endpoint and not an exporter or a Grafana stack; why the actuator surface is closed by name | [ADR-012](../ADRs/ADR-012-metrics-through-a-prometheus-scrape-endpoint.md) |
 | Why every page shares one width; why the shell can be trusted not to overflow; why container queries and a native `<dialog>` were turned down | [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md) |
 | Day-to-day conventions when changing backend code | [`backend/CLAUDE.md`](../../backend/CLAUDE.md) |
 | Day-to-day conventions when changing frontend code | [`frontend/CLAUDE.md`](../../frontend/CLAUDE.md) |

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -413,6 +413,21 @@ Stated because they are load-bearing, not because they are problems yet:
   so a container error dispatch to `/error` runs outside the observation scope entirely. Nothing logs
   on either path today. Closing the first means configuring an `AuthenticationEntryPoint`, which is its
   own wire-contract change.
+- **`docker logs` is the only sink, and its retention is the audit trail's retention.** There is no
+  file appender, no log volume and no aggregator, so a line that has aged out of the container's log
+  is gone — including the audit entries. That is adequate for diagnosis and is explicitly *not* a
+  compliance story ([ADR-011](../ADRs/ADR-011-audit-as-a-log-stream.md)).
+- **Nothing scrapes `/actuator/prometheus`, and no trace leaves the process.** The metrics endpoint is
+  correct and unread, and sampling is at 1.0 with no exporter configured. Both are deliberate stopping
+  points rather than omissions: the missing piece in each case is a deployment somebody is paged for
+  ([ADR-012](../ADRs/ADR-012-metrics-through-a-prometheus-scrape-endpoint.md),
+  [ADR-007](../ADRs/ADR-007-request-correlation-through-micrometer-tracing.md)).
+- **A browser-side error can be shown but not recorded.** The SPA has no telemetry and no log sink, so
+  `ErrorBoundary` can put a message on the screen and nothing else knows it happened. Adding a
+  reporting endpoint is a decision about sending user data off the device, not a logging change.
+- **A refused login is a rate signal, not an attribution.** The audit entry deliberately names no
+  subject, so the trail cannot say whose account was targeted and will not support a lockout policy as
+  written.
 
 ---
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -222,6 +222,26 @@ carries personal data — ids and enum values only, never a title, an email, a n
 [ADR-010](../ADRs/ADR-010-structured-logging-and-a-level-policy.md) records the format decision and the
 policy.
 
+### Audit
+
+`AuditTrail` is an outbound port in `common/domain/port/out/`, beside `DomainEventPublisher` and
+cross-cutting for the same reason. Every state-changing use case and both authentication outcomes record
+through it; `LoggingAuditTrail` writes them to a logger named `AUDIT` at INFO, and derives the
+`audit.events{action,outcome}` counter from the same call so the two cannot disagree.
+
+An entry is `(action, actorUserId, resourceId, outcome)` — two enums and two identifiers, with **nowhere
+to put free text**, which is how NFR-6 survives contact with twenty-one new call sites. Services record
+through `AuditTrail.recording(...)`, which brackets the operation and records the refusal as well as the
+success: BR-15 answers an attempt on somebody else's record with a `404`, so the trail is the only place
+that attempt exists at all. `REFUSED` (the system said no) and `FAILED` (the system broke) are separate
+outcomes because they need separate reactions.
+
+There is no audit table. An entry has to outlive the transaction it observes — a refused transition
+rolls back, and a row written inside it would roll back too — and the trace id already on the line joins
+the entry to its request without a foreign key.
+[ADR-011](../ADRs/ADR-011-audit-as-a-log-stream.md) records the decision, what is deliberately not
+audited, and what would reverse it.
+
 ## External dependencies and integration points
 
 **There are no third-party APIs.** Nothing leaves the deployment: no payment provider, no email or
@@ -358,6 +378,7 @@ Stated because they are load-bearing, not because they are problems yet:
 | Which of the four test levels a new test belongs at, and why coverage is reported rather than gated | [ADR-009](../ADRs/ADR-009-test-levels-boundaries-and-naming.md) |
 | Why correlation is Micrometer Tracing rather than a hand-rolled request id; why there is no exporter | [ADR-007](../ADRs/ADR-007-request-correlation-through-micrometer-tracing.md) |
 | Why logs are JSON in a container but not locally; what each level means; why nothing personal may be logged | [ADR-010](../ADRs/ADR-010-structured-logging-and-a-level-policy.md) |
+| Why the audit trail is a log stream rather than a table or Envers; why refusals are recorded; what is not audited | [ADR-011](../ADRs/ADR-011-audit-as-a-log-stream.md) |
 | Why every page shares one width; why the shell can be trusted not to overflow; why container queries and a native `<dialog>` were turned down | [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md) |
 | Day-to-day conventions when changing backend code | [`backend/CLAUDE.md`](../../backend/CLAUDE.md) |
 | Day-to-day conventions when changing frontend code | [`frontend/CLAUDE.md`](../../frontend/CLAUDE.md) |

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -2,9 +2,9 @@
 
 What UpHealther must do. This document records the requirements the project **currently meets** —
 each one is implemented, and the **test** that enforces it is named, so a claim here can be checked
-rather than trusted. Seventy of the seventy-seven entries below name a test — fifty-one distinct test
-classes and files between them. Four of the remaining seven name the command, workflow or script that
-*is* the check (NFR-11, NFR-12, NFR-13, NFR-18). The last three — FR-39, NFR-19 and NFR-20 — are
+rather than trusted. Seventy-one of the seventy-eight entries below name a test — fifty-two distinct
+test classes and files between them. Four of the remaining seven name the command, workflow or script
+that *is* the check (NFR-11, NFR-12, NFR-13, NFR-18). The last three — FR-39, NFR-19 and NFR-20 — are
 verified by hand and say so, because each is about a rendered width, a colour or an overflow, and jsdom
 has no layout engine to observe any of them; §6 records what closing that gap would take.
 
@@ -161,6 +161,7 @@ nothing is shared between accounts.
 | NFR-19 | Text meets a 4.5:1 contrast ratio and control boundaries 3:1, in both themes | the token values in `frontend/src/index.css` — computed, not automatically re-checked; see §6 |
 | NFR-20 | The interface does not scroll horizontally at any window width from 320px upward, whatever a user has stored in it | the shell's `min-w-0` floors and the truncation rules on every user-supplied string ([ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)) — checked by hand at 320, 360, 486, 684, 1040 and 1540px, see §6 |
 | NFR-21 | Every log line written while serving a request, running a scheduled job or handling a STOMP frame carries the same trace id; the id is returned as an `X-Trace-Id` response header and on the error body, and an inbound W3C `traceparent` is continued rather than replaced | `RequestCorrelationTest`, `CorrelationIT`, `StompTracingChannelInterceptorTest`, `ObservabilityConfig` ([ADR-007](../ADRs/ADR-007-request-correlation-through-micrometer-tracing.md)) |
+| NFR-22 | Log output is one JSON object per line in a container and Boot's readable pattern locally, and a line in either format carries its trace id | `LogOutputFormatTest`, `logback-spring.xml` ([ADR-010](../ADRs/ADR-010-structured-logging-and-a-level-policy.md)) |
 
 ---
 

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -2,7 +2,7 @@
 
 What UpHealther must do. This document records the requirements the project **currently meets** —
 each one is implemented, and the **test** that enforces it is named, so a claim here can be checked
-rather than trusted. Eighty of the eighty-seven entries below name a test — sixty distinct
+rather than trusted. Eighty of the eighty-seven entries below name a test — sixty-one distinct
 test classes and files between them. Four of the remaining seven name the command, workflow or script
 that *is* the check (NFR-11, NFR-12, NFR-13, NFR-18). The last three — FR-39, NFR-19 and NFR-20 — are
 verified by hand and say so, because each is about a rendered width, a colour or an overflow, and jsdom
@@ -162,7 +162,7 @@ nothing is shared between accounts.
 | NFR-20 | The interface does not scroll horizontally at any window width from 320px upward, whatever a user has stored in it | the shell's `min-w-0` floors and the truncation rules on every user-supplied string ([ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)) — checked by hand at 320, 360, 486, 684, 1040 and 1540px, see §6 |
 | NFR-21 | Every log line written while serving a request, running a scheduled job or handling a STOMP frame carries the same trace id; the id is returned as an `X-Trace-Id` response header and on the error body, and an inbound W3C `traceparent` is continued rather than replaced | `RequestCorrelationTest`, `CorrelationIT`, `StompTracingChannelInterceptorTest`, `ObservabilityConfig` ([ADR-007](../ADRs/ADR-007-request-correlation-through-micrometer-tracing.md)) |
 | NFR-22 | Log output is one JSON object per line in a container and Boot's readable pattern locally, and a line in either format carries its trace id | `LogOutputFormatTest`, `logback-spring.xml` ([ADR-010](../ADRs/ADR-010-structured-logging-and-a-level-policy.md)) |
-| NFR-23 | Every state-changing use case and every authentication outcome records who attempted what, against which record, and whether it was allowed — including the attempts that were refused | `AuditTrailTest`, `LoggingAuditTrailTest`, `UpgradeServiceTest`, `AuthServiceTest` ([ADR-011](../ADRs/ADR-011-audit-as-a-log-stream.md)) |
+| NFR-23 | Every state-changing use case and every authentication outcome records who attempted what, against which record, and whether it was allowed — including the attempts that were refused, and never claiming as allowed work whose transaction then rolled back | `AuditTrailTest`, `LoggingAuditTrailTest`, `AuditCommitIT`, `UpgradeServiceTest`, `AuthServiceTest` ([ADR-011](../ADRs/ADR-011-audit-as-a-log-stream.md)) |
 | NFR-24 | An audit entry cannot carry personal data, because it has nowhere to put any: every field is an enum or an identifier, and a refused login is recorded with no subject at all | `AuditEventTest`, `AuthServiceTest` |
 | NFR-25 | Every scheduled run records how long it took, whether it finished, and what it did, so a job that has stopped working is distinguishable from one with nothing to do | `JobMetricsTest`, `NotificationSchedulerTest`, `UpgradeOverdueSchedulerTest` |
 | NFR-26 | A real-time push that cannot be delivered degrades to the stored notification and is reported, rather than failing the work that raised it | `StompNotificationPushAdapterTest` |

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -2,7 +2,7 @@
 
 What UpHealther must do. This document records the requirements the project **currently meets** —
 each one is implemented, and the **test** that enforces it is named, so a claim here can be checked
-rather than trusted. Seventy-three of the eighty entries below name a test — fifty-five distinct
+rather than trusted. Seventy-five of the eighty-two entries below name a test — fifty-six distinct
 test classes and files between them. Four of the remaining seven name the command, workflow or script
 that *is* the check (NFR-11, NFR-12, NFR-13, NFR-18). The last three — FR-39, NFR-19 and NFR-20 — are
 verified by hand and say so, because each is about a rendered width, a colour or an overflow, and jsdom
@@ -164,6 +164,8 @@ nothing is shared between accounts.
 | NFR-22 | Log output is one JSON object per line in a container and Boot's readable pattern locally, and a line in either format carries its trace id | `LogOutputFormatTest`, `logback-spring.xml` ([ADR-010](../ADRs/ADR-010-structured-logging-and-a-level-policy.md)) |
 | NFR-23 | Every state-changing use case and every authentication outcome records who attempted what, against which record, and whether it was allowed — including the attempts that were refused | `AuditTrailTest`, `LoggingAuditTrailTest`, `UpgradeServiceTest`, `AuthServiceTest` ([ADR-011](../ADRs/ADR-011-audit-as-a-log-stream.md)) |
 | NFR-24 | An audit entry cannot carry personal data, because it has nowhere to put any: every field is an enum or an identifier, and a refused login is recorded with no subject at all | `AuditEventTest`, `AuthServiceTest` |
+| NFR-25 | Every scheduled run records how long it took, whether it finished, and what it did, so a job that has stopped working is distinguishable from one with nothing to do | `JobMetricsTest`, `NotificationSchedulerTest`, `UpgradeOverdueSchedulerTest` |
+| NFR-26 | A real-time push that cannot be delivered degrades to the stored notification and is reported, rather than failing the work that raised it | `StompNotificationPushAdapterTest` |
 
 ---
 

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -2,7 +2,7 @@
 
 What UpHealther must do. This document records the requirements the project **currently meets** —
 each one is implemented, and the **test** that enforces it is named, so a claim here can be checked
-rather than trusted. Seventy-nine of the eighty-six entries below name a test — fifty-nine distinct
+rather than trusted. Eighty of the eighty-seven entries below name a test — sixty distinct
 test classes and files between them. Four of the remaining seven name the command, workflow or script
 that *is* the check (NFR-11, NFR-12, NFR-13, NFR-18). The last three — FR-39, NFR-19 and NFR-20 — are
 verified by hand and say so, because each is about a rendered width, a colour or an overflow, and jsdom
@@ -170,6 +170,7 @@ nothing is shared between accounts.
 | NFR-28 | Latency, error rate, saturation, connection-pool depth and the domain's own counters are readable from one scrape endpoint, and no metric tag is unbounded | `ActuatorEndpointsIT`, `LoggingAuditTrailTest`, `JobMetricsTest` ([ADR-012](../ADRs/ADR-012-metrics-through-a-prometheus-scrape-endpoint.md)) |
 | NFR-29 | The actuator surface is closed by name: only health, info and the metrics scrape answer, and an endpoint that would expose configuration or process memory does not | `ActuatorEndpointsIT` (env, heapdump, loggers, beans, mappings, configprops, threaddump) |
 | NFR-30 | A request that fails shows the user the trace id that finds it in the log, from the error body or the response header, and offers none when the request never reached the server | `apiError.test.ts`, `ErrorState.test.tsx` |
+| NFR-31 | A render-time error shows a recoverable message rather than blanking the page | `ErrorBoundary.test.tsx` |
 
 ---
 

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -2,7 +2,7 @@
 
 What UpHealther must do. This document records the requirements the project **currently meets** —
 each one is implemented, and the **test** that enforces it is named, so a claim here can be checked
-rather than trusted. Seventy-one of the seventy-eight entries below name a test — fifty-two distinct
+rather than trusted. Seventy-three of the eighty entries below name a test — fifty-five distinct
 test classes and files between them. Four of the remaining seven name the command, workflow or script
 that *is* the check (NFR-11, NFR-12, NFR-13, NFR-18). The last three — FR-39, NFR-19 and NFR-20 — are
 verified by hand and say so, because each is about a rendered width, a colour or an overflow, and jsdom
@@ -162,6 +162,8 @@ nothing is shared between accounts.
 | NFR-20 | The interface does not scroll horizontally at any window width from 320px upward, whatever a user has stored in it | the shell's `min-w-0` floors and the truncation rules on every user-supplied string ([ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)) — checked by hand at 320, 360, 486, 684, 1040 and 1540px, see §6 |
 | NFR-21 | Every log line written while serving a request, running a scheduled job or handling a STOMP frame carries the same trace id; the id is returned as an `X-Trace-Id` response header and on the error body, and an inbound W3C `traceparent` is continued rather than replaced | `RequestCorrelationTest`, `CorrelationIT`, `StompTracingChannelInterceptorTest`, `ObservabilityConfig` ([ADR-007](../ADRs/ADR-007-request-correlation-through-micrometer-tracing.md)) |
 | NFR-22 | Log output is one JSON object per line in a container and Boot's readable pattern locally, and a line in either format carries its trace id | `LogOutputFormatTest`, `logback-spring.xml` ([ADR-010](../ADRs/ADR-010-structured-logging-and-a-level-policy.md)) |
+| NFR-23 | Every state-changing use case and every authentication outcome records who attempted what, against which record, and whether it was allowed — including the attempts that were refused | `AuditTrailTest`, `LoggingAuditTrailTest`, `UpgradeServiceTest`, `AuthServiceTest` ([ADR-011](../ADRs/ADR-011-audit-as-a-log-stream.md)) |
+| NFR-24 | An audit entry cannot carry personal data, because it has nowhere to put any: every field is an enum or an identifier, and a refused login is recorded with no subject at all | `AuditEventTest`, `AuthServiceTest` |
 
 ---
 

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -2,7 +2,7 @@
 
 What UpHealther must do. This document records the requirements the project **currently meets** —
 each one is implemented, and the **test** that enforces it is named, so a claim here can be checked
-rather than trusted. Seventy-five of the eighty-two entries below name a test — fifty-six distinct
+rather than trusted. Seventy-eight of the eighty-five entries below name a test — fifty-seven distinct
 test classes and files between them. Four of the remaining seven name the command, workflow or script
 that *is* the check (NFR-11, NFR-12, NFR-13, NFR-18). The last three — FR-39, NFR-19 and NFR-20 — are
 verified by hand and say so, because each is about a rendered width, a colour or an overflow, and jsdom
@@ -166,6 +166,9 @@ nothing is shared between accounts.
 | NFR-24 | An audit entry cannot carry personal data, because it has nowhere to put any: every field is an enum or an identifier, and a refused login is recorded with no subject at all | `AuditEventTest`, `AuthServiceTest` |
 | NFR-25 | Every scheduled run records how long it took, whether it finished, and what it did, so a job that has stopped working is distinguishable from one with nothing to do | `JobMetricsTest`, `NotificationSchedulerTest`, `UpgradeOverdueSchedulerTest` |
 | NFR-26 | A real-time push that cannot be delivered degrades to the stored notification and is reported, rather than failing the work that raised it | `StompNotificationPushAdapterTest` |
+| NFR-27 | Liveness and readiness are answerable separately, so "restart the process" and "stop routing to it" are distinguishable, and both images declare a health-check | `ActuatorEndpointsIT`, `backend/Dockerfile`, `docker-compose.yml` |
+| NFR-28 | Latency, error rate, saturation, connection-pool depth and the domain's own counters are readable from one scrape endpoint, and no metric tag is unbounded | `ActuatorEndpointsIT`, `LoggingAuditTrailTest`, `JobMetricsTest` ([ADR-012](../ADRs/ADR-012-metrics-through-a-prometheus-scrape-endpoint.md)) |
+| NFR-29 | The actuator surface is closed by name: only health, info and the metrics scrape answer, and an endpoint that would expose configuration or process memory does not | `ActuatorEndpointsIT` (env, heapdump, loggers, beans, mappings, configprops, threaddump) |
 
 ---
 

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -2,7 +2,7 @@
 
 What UpHealther must do. This document records the requirements the project **currently meets** —
 each one is implemented, and the **test** that enforces it is named, so a claim here can be checked
-rather than trusted. Seventy-eight of the eighty-five entries below name a test — fifty-seven distinct
+rather than trusted. Seventy-nine of the eighty-six entries below name a test — fifty-nine distinct
 test classes and files between them. Four of the remaining seven name the command, workflow or script
 that *is* the check (NFR-11, NFR-12, NFR-13, NFR-18). The last three — FR-39, NFR-19 and NFR-20 — are
 verified by hand and say so, because each is about a rendered width, a colour or an overflow, and jsdom
@@ -169,6 +169,7 @@ nothing is shared between accounts.
 | NFR-27 | Liveness and readiness are answerable separately, so "restart the process" and "stop routing to it" are distinguishable, and both images declare a health-check | `ActuatorEndpointsIT`, `backend/Dockerfile`, `docker-compose.yml` |
 | NFR-28 | Latency, error rate, saturation, connection-pool depth and the domain's own counters are readable from one scrape endpoint, and no metric tag is unbounded | `ActuatorEndpointsIT`, `LoggingAuditTrailTest`, `JobMetricsTest` ([ADR-012](../ADRs/ADR-012-metrics-through-a-prometheus-scrape-endpoint.md)) |
 | NFR-29 | The actuator surface is closed by name: only health, info and the metrics scrape answer, and an endpoint that would expose configuration or process memory does not | `ActuatorEndpointsIT` (env, heapdump, loggers, beans, mappings, configprops, threaddump) |
+| NFR-30 | A request that fails shows the user the trace id that finds it in the log, from the error body or the response header, and offers none when the request never reached the server | `apiError.test.ts`, `ErrorState.test.tsx` |
 
 ---
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -27,6 +27,10 @@ conventions to follow inside `frontend/`.
   a user can quote one string that finds their request in the log, and discarding it is what left a
   support conversation with nothing in it. `toApiError` reads the body first and the header second,
   because a request refused inside the security chain carries the header alone.
+- **`components/ErrorBoundary`** is mounted in `App.tsx` inside `ThemeProvider` and around the router:
+  inside so its fallback is themed, outside so a throw in any page is contained. It has to stay a
+  class — `getDerivedStateFromError` has no hooks equivalent. It shows and does not record: there is
+  no sink to record to, and adding one is a decision about sending user data off the device.
 - **Server state** is managed by TanStack Query (`@tanstack/react-query`); avoid duplicating it in
   local React state.
 - **Auth** flows through `contexts/AuthContext.tsx` (the context object lives in `contexts/authContextValue.ts`)

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -20,6 +20,13 @@ conventions to follow inside `frontend/`.
   `VITE_API_URL` only for a different-origin API). A request interceptor attaches the JWT from
   `localStorage['jwt_token']`; a response interceptor clears the token and redirects to `/login` on 401.
   All `src/api/*.ts` modules call through this client — add new endpoints there, not with raw axios.
+- **A failure is decoded once, in `src/api/apiError.ts`.** `toApiError(thrown)` turns anything a call
+  rejected with into `{ status, message, fieldErrors, traceId }`; render it with
+  `components/ui/ErrorState`. Do not write a hard-coded "Failed to load X." and drop the error — the
+  backend puts a **trace id** on every response (`X-Trace-Id`, and `traceId` on the error body) so that
+  a user can quote one string that finds their request in the log, and discarding it is what left a
+  support conversation with nothing in it. `toApiError` reads the body first and the header second,
+  because a request refused inside the security chain carries the header alone.
 - **Server state** is managed by TanStack Query (`@tanstack/react-query`); avoid duplicating it in
   local React state.
 - **Auth** flows through `contexts/AuthContext.tsx` (the context object lives in `contexts/authContextValue.ts`)

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,4 +9,8 @@ FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
+
+# nginx serves a static bundle, so "is it answering" is the whole of its health.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3     CMD wget -qO- http://localhost/ || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './contexts/AuthContext';
+import ErrorBoundary from './components/ErrorBoundary';
 import { ThemeProvider } from './contexts/ThemeProvider';
 import AppRouter from './router';
 
@@ -27,14 +28,21 @@ const queryClient = new QueryClient({
  * both. The theme sits outside them all because it depends on neither a session nor server state, and
  * because the login and register pages render outside `Layout` but still inside `App` — which is what
  * puts the theme toggle within reach before anyone has signed in.
+ *
+ * `ErrorBoundary` sits *inside* the theme and *outside* everything else: inside so its fallback is
+ * drawn in the theme the user chose, outside so a throw anywhere below it is contained. Before it,
+ * any render-time error unmounted the whole tree to a blank page with nothing to read and nothing to
+ * report.
  */
 const App: React.FC = () => (
   <ThemeProvider>
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <AppRouter />
-      </AuthProvider>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <AppRouter />
+        </AuthProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
   </ThemeProvider>
 );
 

--- a/frontend/src/api/apiError.test.ts
+++ b/frontend/src/api/apiError.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { AxiosError, AxiosHeaders } from 'axios';
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { toApiError } from './apiError';
+
+/**
+ * The one place the backend's error contract is decoded.
+ *
+ * The trace id is what these tests are really about. The API sets `X-Trace-Id` on every response and
+ * stamps `traceId` on every error body it builds (NFR-21), so that one string finds the request in the
+ * log. Every call site used to discard it. The two sources are both covered because they have
+ * different reach: a request refused inside the security chain never reaches the exception handler
+ * that writes the body, so it comes back with the header alone.
+ */
+describe('toApiError', () => {
+  const config = { headers: new AxiosHeaders() } as InternalAxiosRequestConfig;
+
+  function responded(status: number, data: unknown, headers: Record<string, string> = {}): AxiosError {
+    const response = { data, status, statusText: '', headers, config } as AxiosResponse;
+    return new AxiosError('Request failed', String(status), config, {}, response);
+  }
+
+  it('GivenAnErrorBodyCarryingATraceId_WhenItIsNormalised_ThenTheIdSurvives', () => {
+    const error = toApiError(responded(422, {
+      status: 422,
+      message: 'A completed upgrade cannot be paused',
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+    }));
+
+    expect(error.status).toBe(422);
+    expect(error.message).toBe('A completed upgrade cannot be paused');
+    expect(error.traceId).toBe('4bf92f3577b34da6a3ce929d0e0e4736');
+  });
+
+  it('GivenARejectionWithNoBody_WhenItIsNormalised_ThenTheHeaderSuppliesTheTraceId', () => {
+    // A request refused inside the security chain never reaches GlobalExceptionHandler, so it carries
+    // the header and not the body field. Without this fallback those failures would be unreportable.
+    const error = toApiError(responded(403, '', { 'x-trace-id': '00f067aa0ba902b74bf92f3577b34da6' }));
+
+    expect(error.traceId).toBe('00f067aa0ba902b74bf92f3577b34da6');
+  });
+
+  it('GivenAValidationFailure_WhenItIsNormalised_ThenTheFieldMessagesComeThrough', () => {
+    const error = toApiError(responded(400, {
+      message: 'Validation failed',
+      fieldErrors: { title: 'must not be blank' },
+    }));
+
+    expect(error.fieldErrors).toEqual({ title: 'must not be blank' });
+  });
+
+  it('GivenFieldErrorsThatAreNotMessages_WhenItIsNormalised_ThenTheyAreDropped', () => {
+    // Parsing untrusted input: a nested object where a string belongs would otherwise be rendered.
+    const error = toApiError(responded(400, { message: 'Nope', fieldErrors: { title: { nested: 1 } } }));
+
+    expect(error.fieldErrors).toBeUndefined();
+  });
+
+  it('GivenNoResponseAtAll_WhenItIsNormalised_ThenItSaysSoAndOffersNoTraceId', () => {
+    // A network failure or a timeout: nothing on the server ever saw the request, so there is no id
+    // to quote and offering one would send somebody searching a log for something that is not in it.
+    const error = toApiError(new AxiosError('Network Error', 'ERR_NETWORK', config, {}));
+
+    expect(error.message).toMatch(/could not reach the server/i);
+    expect(error.traceId).toBeUndefined();
+    expect(error.status).toBeUndefined();
+  });
+
+  it('GivenAProxyReturningHtml_WhenItIsNormalised_ThenItIsStillSafeToRender', () => {
+    const error = toApiError(responded(502, '<html><body>Bad Gateway</body></html>'));
+
+    expect(error.status).toBe(502);
+    expect(error.message).toBe('Something went wrong.');
+  });
+
+  it('GivenSomethingThatIsNotAnAxiosError_WhenItIsNormalised_ThenItsMessageIsKept', () => {
+    expect(toApiError(new Error('boom')).message).toBe('boom');
+    expect(toApiError('a string').message).toBe('Something went wrong.');
+  });
+
+  it('GivenAnEmptyTraceId_WhenItIsNormalised_ThenItIsAbsentRatherThanBlank', () => {
+    // So a caller can test for the id without also testing for ''.
+    const error = toApiError(responded(500, { message: 'Internal server error', traceId: '' }));
+
+    expect(error.traceId).toBeUndefined();
+  });
+});

--- a/frontend/src/api/apiError.test.ts
+++ b/frontend/src/api/apiError.test.ts
@@ -15,8 +15,18 @@ import { toApiError } from './apiError';
 describe('toApiError', () => {
   const config = { headers: new AxiosHeaders() } as InternalAxiosRequestConfig;
 
+  // Real AxiosHeaders, not a plain object: apiError.ts reads the header by lower-cased bracket access,
+  // and stubbing the container it reads from would make the fallback test assert against its own stub.
+  // If axios ever stopped answering to that access, security-chain rejections would silently lose the
+  // trace id and a plain-object test would stay green.
   function responded(status: number, data: unknown, headers: Record<string, string> = {}): AxiosError {
-    const response = { data, status, statusText: '', headers, config } as AxiosResponse;
+    const response = {
+      data,
+      status,
+      statusText: '',
+      headers: AxiosHeaders.from(headers),
+      config,
+    } as AxiosResponse;
     return new AxiosError('Request failed', String(status), config, {}, response);
   }
 

--- a/frontend/src/api/apiError.ts
+++ b/frontend/src/api/apiError.ts
@@ -1,0 +1,87 @@
+import axios from 'axios';
+
+/**
+ * A failed API call, in the shape the interface actually needs.
+ *
+ * `traceId` is the point of this module. The backend goes out of its way to produce one — it is on
+ * every log line, on the `X-Trace-Id` response header and on the body of every error it builds
+ * (NFR-21) — precisely so that somebody reporting a failure can quote one string that finds the
+ * request in the log. Discarding it, which is what every call site did before, threw away the only
+ * thing that made a bug report actionable.
+ */
+export interface ApiError {
+  /** HTTP status, or `undefined` when the request never got a response at all. */
+  status?: number;
+  /** The backend's own message where it gave one, otherwise a sentence the user can read. */
+  message: string;
+  /** Field name → message, populated only for a validation failure (a 400). */
+  fieldErrors?: Record<string, string>;
+  /** The id that finds this request in the log, when the response carried one. */
+  traceId?: string;
+}
+
+/** Shown when the request never reached the API, or reached it and produced nothing to quote. */
+const UNREACHABLE = 'Could not reach the server. Check your connection and try again.';
+const UNEXPLAINED = 'Something went wrong.';
+
+/**
+ * The backend's error body (`GlobalExceptionHandler.ErrorResponse`).
+ *
+ * Every field is optional here even though the server always sends `status`, `message` and `path`:
+ * this is parsing untrusted input, and a proxy returning its own HTML on a 502 is a real case.
+ */
+interface ErrorResponseBody {
+  message?: unknown;
+  fieldErrors?: unknown;
+  traceId?: unknown;
+}
+
+/** Header the backend echoes the trace id on, set before the chain runs so it survives a rejection. */
+const TRACE_ID_HEADER = 'x-trace-id';
+
+/**
+ * Normalises anything a failed call threw into an {@link ApiError}.
+ *
+ * One place decodes the wire contract, mirroring how `types/index.ts` mirrors the DTOs — so a change
+ * to the error body is a change to this file rather than to each of the pages that renders one.
+ *
+ * The trace id is read from the body first and the header second. Both carry it and they agree, but
+ * the two have different coverage: a request refused inside the security chain never reaches the
+ * exception handler that writes the body, and comes back with the header alone.
+ *
+ * @param thrown whatever the call rejected with — an axios error, an `Error`, or anything at all
+ * @returns a value that is always safe to render
+ */
+export function toApiError(thrown: unknown): ApiError {
+  if (!axios.isAxiosError(thrown)) {
+    return { message: thrown instanceof Error && thrown.message ? thrown.message : UNEXPLAINED };
+  }
+
+  const { response } = thrown;
+  if (!response) {
+    // No response at all: a network failure, a CORS rejection or a timeout. There is no trace id to
+    // quote because nothing on the server ever saw the request.
+    return { message: UNREACHABLE };
+  }
+
+  const body: ErrorResponseBody = (response.data ?? {}) as ErrorResponseBody;
+
+  return {
+    status: response.status,
+    message: typeof body.message === 'string' && body.message ? body.message : UNEXPLAINED,
+    fieldErrors: asFieldErrors(body.fieldErrors),
+    traceId: asTraceId(body.traceId) ?? asTraceId(response.headers?.[TRACE_ID_HEADER]),
+  };
+}
+
+/** Keeps only a string→string map, so a malformed body cannot put an object where a message goes. */
+function asFieldErrors(value: unknown): Record<string, string> | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const entries = Object.entries(value).filter(([, message]) => typeof message === 'string');
+  return entries.length > 0 ? (Object.fromEntries(entries) as Record<string, string>) : undefined;
+}
+
+/** Absent rather than empty, so a caller can test for it without also testing for `''`. */
+function asTraceId(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ErrorBoundary from './ErrorBoundary';
+
+/**
+ * The one construct that stops a render-time throw becoming a blank page.
+ *
+ * Nothing in the application can reach this by clicking, which is exactly why it needs a test: it is
+ * invisible until the day it matters, and the failure mode if it is wired wrong — the tree unmounts to
+ * white — is indistinguishable from the bug it was meant to contain.
+ *
+ * React logs a caught error to `console.error` itself, from inside the reconciler. That is React's
+ * output, not this application's, and it is silenced here so a passing run does not print a stack
+ * trace that looks like a failure.
+ */
+describe('ErrorBoundary', () => {
+  const Throws = () => {
+    throw new Error('render blew up');
+  };
+
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('GivenAChildThatRendersNormally_WhenTheBoundaryRenders_ThenItIsOutOfTheWay', () => {
+    render(<ErrorBoundary><p>the page</p></ErrorBoundary>);
+
+    expect(screen.getByText('the page')).toBeDefined();
+  });
+
+  it('GivenAChildThatThrows_WhenItRenders_ThenTheUserSeesAMessageRatherThanABlankPage', () => {
+    render(<ErrorBoundary><Throws /></ErrorBoundary>);
+
+    expect(screen.getByRole('alert').textContent).toContain('This page stopped working.');
+  });
+
+  it('GivenAChildThatThrows_WhenItRenders_ThenTheUserIsToldTheirDataIsSafe', () => {
+    // The first question somebody asks when a page breaks mid-edit, and the answer is yes: nothing
+    // here writes, so a render error cannot have lost anything.
+    render(<ErrorBoundary><Throws /></ErrorBoundary>);
+
+    expect(screen.getByRole('alert').textContent).toContain('Nothing you have saved is affected.');
+  });
+
+  it('GivenACaughtError_WhenTheFallbackRenders_ThenItOffersARecovery', () => {
+    const reload = vi.fn();
+    const realLocation = window.location;
+    Object.defineProperty(window, 'location', { value: { ...realLocation, reload }, writable: true });
+
+    try {
+      render(<ErrorBoundary><Throws /></ErrorBoundary>);
+      fireEvent.click(screen.getByRole('button', { name: 'Reload the page' }));
+
+      // A reload, not a re-render: whatever was inconsistent about the props or the cache still is,
+      // so clearing the error state would usually throw again immediately.
+      expect(reload).toHaveBeenCalledOnce();
+    } finally {
+      Object.defineProperty(window, 'location', { value: realLocation, writable: true });
+    }
+  });
+});

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import Button from './ui/Button';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  /** The error React caught, or `null` while the tree below is rendering normally. */
+  error: Error | null;
+}
+
+/**
+ * Catches a render-time error so it becomes a message instead of a blank page.
+ *
+ * Without one, React unmounts the entire tree when any component throws — the user is left looking at
+ * white, with nothing to read, nothing to click and nothing to report. This is the only construct that
+ * can prevent that, and it has to be a class: `getDerivedStateFromError` has no hooks equivalent.
+ *
+ * <p><b>It shows, it does not record.</b> There is no `console.error` and no reporting endpoint,
+ * deliberately. This repository has no `console` call in any committed file, and `architecture.md`
+ * states "no analytics" as a position rather than an omission — so a browser error here has no sink to
+ * go to, and inventing one is a decision about sending user data off the device, not a logging tweak.
+ * What the user gets instead is a page that says what happened and a reload that works. Errors that
+ * came from the API are a different story and do carry a trace id — see `ErrorState`.
+ *
+ * <p>Mounted inside `ThemeProvider` so the fallback is drawn in the theme the user chose, and around
+ * the router so a throw in any page is contained rather than taking the shell with it.
+ */
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  /**
+   * A full reload rather than clearing the error state.
+   *
+   * Re-rendering the same tree would usually throw again immediately, since whatever was inconsistent
+   * about the props or the cache is still inconsistent. Replacing the document is the one recovery
+   * that reliably works from here.
+   */
+  private reload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-4 bg-canvas px-6 text-center" role="alert">
+        <div className="text-5xl">⚠️</div>
+        <h1 className="text-xl font-semibold text-fg">This page stopped working.</h1>
+        <p className="max-w-md text-sm text-fg-subtle">
+          Nothing you have saved is affected. Reloading usually fixes it.
+        </p>
+        {/* The message, not the stack: a stack trace tells a user nothing and can quote internals. */}
+        {error.message && (
+          <p className="max-w-md text-xs text-fg-faint font-mono select-all">{error.message}</p>
+        )}
+        <Button type="button" onClick={this.reload} className="mt-2">
+          Reload the page
+        </Button>
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/ui/ErrorState.test.tsx
+++ b/frontend/src/components/ui/ErrorState.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ErrorState from './ErrorState';
+
+/**
+ * What a page shows instead of the data it could not load.
+ *
+ * The assertion that matters is the trace id reaching the screen. The backend produces one on every
+ * response specifically so a user can quote it, and before this component the seven pages that
+ * rendered a failure discarded it — leaving a bug report with nothing in it that could find the
+ * request in the log.
+ */
+describe('ErrorState', () => {
+  it('GivenAFailureCarryingATraceId_WhenItRenders_ThenTheIdIsOnTheScreen', () => {
+    render(<ErrorState title="Could not load your upgrades." error={{
+      message: 'Internal server error',
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+    }} />);
+
+    expect(screen.getByText('4bf92f3577b34da6a3ce929d0e0e4736')).toBeDefined();
+  });
+
+  it('GivenAFailureWithNoTraceId_WhenItRenders_ThenNoReferenceIsOffered', () => {
+    // A network failure never reached the server, so there is no id — and offering one would send
+    // somebody searching a log for something that was never written to it.
+    render(<ErrorState title="Could not load your upgrades." error={{ message: 'Could not reach the server.' }} />);
+
+    expect(screen.queryByText(/reference/i)).toBeNull();
+  });
+
+  it('GivenAFailure_WhenItRenders_ThenItAnnouncesItselfToAssistiveTechnology', () => {
+    render(<ErrorState title="Could not load your dashboard." error={{ message: 'Internal server error' }} />);
+
+    expect(screen.getByRole('alert').textContent).toContain('Could not load your dashboard.');
+  });
+
+  it('GivenNoFailureDetail_WhenItRenders_ThenTheTitleStillExplainsWhatHappened', () => {
+    // UpgradeDetailsPage renders this for "the upgrade came back empty", where there is no error.
+    render(<ErrorState title="Could not load this upgrade." />);
+
+    expect(screen.getByText('Could not load this upgrade.')).toBeDefined();
+  });
+});

--- a/frontend/src/components/ui/ErrorState.tsx
+++ b/frontend/src/components/ui/ErrorState.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import type { ApiError } from '../../api/apiError';
+
+/**
+ * @param title what failed, said plainly and without blame
+ * @param error the normalised failure, whose trace id is shown when there is one
+ */
+interface ErrorStateProps {
+  title: string;
+  error?: ApiError;
+}
+
+/**
+ * What a page shows instead of the data it could not load.
+ *
+ * The reason this exists rather than a hard-coded sentence per page is the **trace id**. The backend
+ * puts one on every log line, on the `X-Trace-Id` header and on the error body specifically so that a
+ * user reporting a failure can quote one string that finds their request. Seven pages used to render
+ * `Failed to load X.` and throw the response away, which left a support conversation with nothing in
+ * it — under any concurrent traffic, "it broke on the upgrades page" matches every failure that page
+ * has ever produced.
+ *
+ * The id is shown quietly: a user who does not care never has to read it, and one who is reporting a
+ * problem has something exact to paste. It is safe to display — a trace id identifies a request, never
+ * a person, and is not an authorization input anywhere (ADR-007).
+ */
+const ErrorState: React.FC<ErrorStateProps> = ({ title, error }) => (
+  <div className="flex flex-col items-center justify-center py-16 text-center" role="alert">
+    <div className="text-5xl mb-4">⚠️</div>
+    <h3 className="text-lg font-semibold text-danger-fg mb-1">{title}</h3>
+    {error?.message && <p className="text-sm text-fg-subtle max-w-sm">{error.message}</p>}
+    {error?.traceId && (
+      <p className="mt-4 text-xs text-fg-faint">
+        Reference:{' '}
+        {/* Selectable on its own so a double-click grabs the id and nothing around it. */}
+        <code className="select-all font-mono">{error.traceId}</code>
+      </p>
+    )}
+  </div>
+);
+
+export default ErrorState;

--- a/frontend/src/pages/ActiveUpgradesPage.tsx
+++ b/frontend/src/pages/ActiveUpgradesPage.tsx
@@ -9,6 +9,8 @@ import EmptyState from '../components/ui/EmptyState';
 import UpgradeCard from '../components/upgrade/UpgradeCard';
 import type { UpgradeStatus } from '../types';
 import PageContainer from '../components/ui/PageContainer';
+import ErrorState from '../components/ui/ErrorState';
+import { toApiError } from '../api/apiError';
 
 /**
  * The upgrades currently running, with the transitions available from `ACTIVE`.
@@ -27,7 +29,7 @@ const ActiveUpgradesPage: React.FC = () => {
   });
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-danger-fg text-center py-10">Failed to load upgrades.</p>;
+  if (error) return <ErrorState title="Could not load your upgrades." error={toApiError(error)} />;
 
   return (
     <PageContainer>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -11,6 +11,8 @@ import EmptyState from '../components/ui/EmptyState';
 import { performUpgradeAction } from '../api/upgrades';
 import type { UpgradeStatus } from '../types';
 import PageContainer from '../components/ui/PageContainer';
+import ErrorState from '../components/ui/ErrorState';
+import { toApiError } from '../api/apiError';
 
 /**
  * Landing page after sign-in: counts, the weekly rate, streaks, overdue warnings and today's upgrades.
@@ -35,7 +37,7 @@ const DashboardPage: React.FC = () => {
   };
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-danger-fg text-center py-10">Failed to load dashboard.</p>;
+  if (error) return <ErrorState title="Could not load your dashboard." error={toApiError(error)} />;
 
   // Rounded, not scaled: the API sends a percentage already (see DashboardDto.weeklyCompletionRate).
   const completionPct = Math.round(data?.weeklyCompletionRate ?? 0);

--- a/frontend/src/pages/HealthAreasPage.tsx
+++ b/frontend/src/pages/HealthAreasPage.tsx
@@ -11,6 +11,8 @@ import EmptyState from '../components/ui/EmptyState';
 import type { CreateHealthAreaRequest, HealthArea } from '../types';
 import PageContainer from '../components/ui/PageContainer';
 import { areaIconGlyph, DEFAULT_AREA_ICON, isIconGlyph } from '../components/ui/areaIcon';
+import ErrorState from '../components/ui/ErrorState';
+import { toApiError } from '../api/apiError';
 
 /**
  * Manages health areas — the folders upgrades are filed under.
@@ -78,7 +80,7 @@ const HealthAreasPage: React.FC = () => {
   };
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-danger-fg text-center py-10">Failed to load health areas.</p>;
+  if (error) return <ErrorState title="Could not load your health areas." error={toApiError(error)} />;
 
   return (
     <PageContainer>

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AxiosError, AxiosHeaders } from 'axios';
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import LoginPage from './LoginPage';
@@ -6,6 +8,25 @@ import { AuthContext, type AuthContextType } from '../contexts/authContextValue'
 import { ThemeProvider } from '../contexts/ThemeProvider';
 
 const login = vi.fn();
+
+/**
+ * What `login` actually rejects with: an axios error carrying a response.
+ *
+ * Previously these tests rejected with `new Error('401')`, which has no status on it. That was fine
+ * while every failure produced the same sentence, and stopped being fine the moment the page started
+ * telling a rejected credential apart from a server fault — the stub had no way to say which it was.
+ */
+function apiFailure(status: number, body: unknown = {}): AxiosError {
+  const config = { headers: new AxiosHeaders() } as InternalAxiosRequestConfig;
+  const response = {
+    data: body,
+    status,
+    statusText: '',
+    headers: new AxiosHeaders(),
+    config,
+  } as AxiosResponse;
+  return new AxiosError('Request failed', String(status), config, {}, response);
+}
 
 function contextWith(overrides: Partial<AuthContextType> = {}): AuthContextType {
   return {
@@ -76,7 +97,7 @@ describe('LoginPage', () => {
   });
 
   it('GivenCredentialsTheServerRejects_WhenTheFormIsSubmitted_ThenAnErrorIsShownAndNothingNavigates', async () => {
-    login.mockRejectedValue(new Error('401'));
+    login.mockRejectedValue(apiFailure(401, { message: 'Invalid credentials' }));
     renderLogin();
 
     await signIn();
@@ -85,10 +106,27 @@ describe('LoginPage', () => {
     expect(screen.queryByText('the dashboard')).toBeNull();
   });
 
+  it('GivenTheServerFails_WhenTheFormIsSubmitted_ThenTheUserIsNotToldTheirPasswordIsWrong', async () => {
+    // A database outage during login is a 500 with a trace id on the body, not a rejected credential.
+    // Answering it with "invalid email or password" sends the user to reset a password that was never
+    // the problem, and throws away the one string that would have found the fault in the log.
+    login.mockRejectedValue(apiFailure(500, {
+      message: 'Internal server error',
+      traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+    }));
+    renderLogin();
+
+    await signIn();
+
+    await waitFor(() => expect(screen.getByText(/Internal server error/)).toBeDefined());
+    expect(screen.getByText(/4bf92f3577b34da6a3ce929d0e0e4736/)).toBeDefined();
+    expect(screen.queryByText('Invalid email or password.')).toBeNull();
+  });
+
   it('GivenAnUnknownEmailAndAWrongPassword_WhenEachIsTried_ThenTheMessageIsTheSame', async () => {
     // Two different failures, one message. A different message per case is an account-enumeration
     // oracle that costs nothing to hand out.
-    login.mockRejectedValue(new Error('401'));
+    login.mockRejectedValue(apiFailure(401, { message: 'Invalid credentials' }));
     const { unmount } = renderLogin();
     await signIn('nobody@example.com', 'whatever');
     await waitFor(() => expect(screen.getByText('Invalid email or password.')).toBeDefined());

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,12 +4,15 @@ import { useAuth } from '../hooks/useAuth';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import ThemeToggle from '../components/theme/ThemeToggle';
+import { toApiError } from '../api/apiError';
 
 /**
  * Sign-in page, one of the two routes reachable without a session.
  *
  * The error message is deliberately the same whichever half of the credentials was wrong — saying
- * which would tell an attacker that an email is registered.
+ * which would tell an attacker that an email is registered. That guard applies to a **rejected
+ * credential** and nothing else: a 500 is not a wrong password, and answering one with "invalid email
+ * or password" sends the user to reset a password that was never the problem, with nothing to quote.
  *
  * Redirects to the dashboard when already signed in, which is what stops a user with a valid session
  * from landing here by typing the URL.
@@ -34,8 +37,19 @@ const LoginPage: React.FC = () => {
     try {
       await login(email, password);
       navigate('/dashboard', { replace: true });
-    } catch {
-      setError('Invalid email or password.');
+    } catch (thrown) {
+      const failure = toApiError(thrown);
+      // 401 is the only status that means "these credentials are not good", and it keeps the
+      // deliberately vague message. Anything else is ours, so say what the API said and hand over the
+      // trace id — this is the highest-traffic failure path in the application, and it was the one
+      // place a server fault was being reported to the user as their own mistake.
+      setError(
+        failure.status === 401
+          ? 'Invalid email or password.'
+          : failure.traceId
+            ? `${failure.message} (reference ${failure.traceId})`
+            : failure.message,
+      );
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/PlannedUpgradesPage.tsx
+++ b/frontend/src/pages/PlannedUpgradesPage.tsx
@@ -9,6 +9,8 @@ import Button from '../components/ui/Button';
 import { useNavigate } from 'react-router-dom';
 import type { UpgradeStatus } from '../types';
 import PageContainer from '../components/ui/PageContainer';
+import ErrorState from '../components/ui/ErrorState';
+import { toApiError } from '../api/apiError';
 
 /**
  * Upgrades committed to a start date but not yet running, soonest first.
@@ -33,7 +35,7 @@ const PlannedUpgradesPage: React.FC = () => {
   });
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-danger-fg text-center py-10">Failed to load upgrades.</p>;
+  if (error) return <ErrorState title="Could not load your upgrades." error={toApiError(error)} />;
 
   return (
     <PageContainer>

--- a/frontend/src/pages/ProgressHistoryPage.tsx
+++ b/frontend/src/pages/ProgressHistoryPage.tsx
@@ -9,6 +9,8 @@ import EmptyState from '../components/ui/EmptyState';
 import Badge from '../components/ui/Badge';
 import type { ProgressEntry, HealthUpgrade } from '../types';
 import PageContainer from '../components/ui/PageContainer';
+import ErrorState from '../components/ui/ErrorState';
+import { toApiError } from '../api/apiError';
 
 /**
  * The last seven days of progress across every upgrade, newest first.
@@ -27,7 +29,7 @@ const ProgressHistoryPage: React.FC = () => {
   const sorted = [...progress].sort((a: ProgressEntry, b: ProgressEntry) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   if (pLoading || uLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (pError || uError) return <p className="text-danger-fg text-center py-10">Failed to load progress history.</p>;
+  if (pError || uError) return <ErrorState title="Could not load this progress history." error={toApiError(pError ?? uError)} />;
 
   return (
     <PageContainer>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../hooks/useAuth';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import ThemeToggle from '../components/theme/ThemeToggle';
+import { toApiError } from '../api/apiError';
 
 /**
  * Account creation page, and the other route reachable without a session.
@@ -38,8 +39,13 @@ const RegisterPage: React.FC = () => {
     try {
       await register(name, email, password);
       navigate('/dashboard', { replace: true });
-    } catch {
-      setError('Registration failed. Email may already be in use.');
+    } catch (thrown) {
+      // Was a hard-coded "Email may already be in use." for every failure, including a 500 and a
+      // network outage - which sent people looking for an account they had never created. The API
+      // says what went wrong; the trace id is appended so a report about the ones it cannot explain
+      // is worth acting on.
+      const failure = toApiError(thrown);
+      setError(failure.traceId ? `${failure.message} (reference ${failure.traceId})` : failure.message);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/UpgradeBacklogPage.tsx
+++ b/frontend/src/pages/UpgradeBacklogPage.tsx
@@ -12,6 +12,8 @@ import EmptyState from '../components/ui/EmptyState';
 import UpgradeCard from '../components/upgrade/UpgradeCard';
 import type { CreateUpgradeRequest, UpgradeType, Difficulty, UpgradeStatus } from '../types';
 import PageContainer from '../components/ui/PageContainer';
+import ErrorState from '../components/ui/ErrorState';
+import { toApiError } from '../api/apiError';
 
 /**
  * The upgrade types offered when creating one: the eight kinds the product defines.
@@ -77,7 +79,7 @@ const UpgradeBacklogPage: React.FC = () => {
   const areaOptions = [{ value: '', label: 'No area' }, ...areas.map((a) => ({ value: a.id, label: a.name }))];
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error) return <p className="text-danger-fg text-center py-10">Failed to load the backlog.</p>;
+  if (error) return <ErrorState title="Could not load your backlog." error={toApiError(error)} />;
 
   return (
     <PageContainer>

--- a/frontend/src/pages/UpgradeDetailsPage.tsx
+++ b/frontend/src/pages/UpgradeDetailsPage.tsx
@@ -18,6 +18,8 @@ import Badge from '../components/ui/Badge';
 import { difficultyBadgeVariant } from '../components/upgrade/upgradeMeta';
 import type { CreateProgressRequest, CreateReflectionRequest, TrackingType, Frequency } from '../types';
 import PageContainer from '../components/ui/PageContainer';
+import ErrorState from '../components/ui/ErrorState';
+import { toApiError } from '../api/apiError';
 
 /** Today as `YYYY-MM-DD`, the date format the progress and reflection APIs expect. */
 const today = () => new Date().toISOString().split('T')[0];
@@ -120,7 +122,7 @@ const UpgradeDetailsPage: React.FC = () => {
   });
 
   if (isLoading) return <div className="flex justify-center py-20"><LoadingSpinner size="lg" /></div>;
-  if (error || !upgrade) return <p className="text-danger-fg text-center py-10">Failed to load this upgrade.</p>;
+  if (error || !upgrade) return <ErrorState title="Could not load this upgrade." error={error ? toApiError(error) : undefined} />;
 
   return (
     <PageContainer width="narrow" className="space-y-6">


### PR DESCRIPTION
Promotes `dev` to `main`. Ten commits, all of them the observability work reviewed and merged in #50.

Closes #49.

## What ships

The system could not be explained after the fact. [ADR-007](../blob/dev/docs/ADRs/ADR-007-request-correlation-through-micrometer-tracing.md)
had built correlation and noted, in passing, that there were **five log statements in `src/main`** — a
number that never moved. Nothing recorded who did what, actuator collected metrics nobody could reach,
there were no readiness or liveness probes, and the frontend threw away the trace id the backend went
out of its way to produce.

| | |
|---|---|
| **Logs** | `logback-spring.xml` — JSON in a container, Boot's readable pattern locally; `INFO` by default; a level policy where each level means one thing |
| **Audit** | An `AuditTrail` port written as a log stream: actor, action, resource, outcome, trace id — recording refusals, and never claiming as allowed work that then rolled back |
| **Metrics** | `/actuator/prometheus`, liveness and readiness, and an actuator surface closed by name |
| **Browser** | The trace id reaches the screen; a render error is a message rather than a blank page |

Four ADRs: [ADR-010](../blob/dev/docs/ADRs/ADR-010-structured-logging-and-a-level-policy.md),
[ADR-011](../blob/dev/docs/ADRs/ADR-011-audit-as-a-log-stream.md),
[ADR-012](../blob/dev/docs/ADRs/ADR-012-metrics-through-a-prometheus-scrape-endpoint.md), and ADR-007
marked superseded in part. Ten new requirements, NFR-22 … NFR-31, each naming its enforcing test.

## Trade-off accepted

The audit trail is a log stream, so its retention is `docker logs`' retention — adequate for
diagnosis and explicitly **not** a compliance story. A refused login is recorded with no subject at all,
which gives a rate signal and not an attribution. Nothing scrapes the metrics endpoint and no trace
leaves the process. Each is a deliberate stopping point with the trigger that should reopen it recorded
in its ADR, and all of them are collected in #51.

One behaviour change: a failed real-time STOMP push is now degraded rather than fatal. It runs from an
`afterCommit` callback, so the notification is already durable — while letting the exception out failed
the caller *after* its transaction had committed, and in `dispatchReminders` one unreachable session
cancelled everybody else's reminders for that minute.

## How it was verified

`mvn clean verify` — 465 unit + 39 integration. `vitest` — 126. `tsc`, `eslint --max-warnings 0`,
`check:colours` and the diagram drift check all clean. CI green on #50.

End to end against `docker-compose up --build`: compose brought the stack up `db healthy → backend
healthy → frontend`; a wrong password returned a `traceId` that was on its own audit line as
`outcome=REFUSED actorId=none` with no email anywhere; an illegal pause returned a `traceId` that
`grep` found as `action=upgrade.pause outcome=REFUSED` naming the actor and the record; seven actuator
endpoints answered 404; and the whole container log was 38 lines with 0 non-JSON.

#50 was reviewed at high effort and returned 14 findings, all legitimate and all fixed in `8e275b2` —
including two signals that reported the opposite of the truth (an `ALLOWED` audit entry written before
the commit, and a scheduled job dying on an `Error` counted as a clean run) and three tests that
certified properties they could not fail on.
