### PR TITLE
chore: record the file conventions, and correct the comments that misstate the auth path

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# https://editorconfig.org
+#
+# The only cross-editor statement of how these sources are written: the backend has no Spotless or
+# Checkstyle configuration and the frontend has no Prettier, so nothing else records the conventions
+# an editor would otherwise guess at. Every value here is descriptive — it matches what the tracked
+# files already contain rather than proposing a change to them.
+#
+# No max_line_length: the Java sources sit around 110 columns but a handful reach 149, and declaring a
+# limit the code does not keep would make this file a wish rather than a description.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.{java,sql,xml,py,conf}]
+indent_size = 4
+
+[*.{ts,tsx,js,cjs,mjs,json,css,html,yml,yaml}]
+indent_size = 2
+
+# Trailing spaces are not whitespace in Markdown — two of them are a hard line break, and trimming
+# them silently changes the rendered document.
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Line endings belong to the repository, not to each contributor's core.autocrlf setting.
+#
+# Every tracked file is already LF in the index; today that is a property of how the people who
+# committed them happened to have Git configured. This makes it a property of the repository instead,
+# so a checkout on Windows and a checkout in the Docker build produce byte-identical files. Nothing
+# tracked here is a .bat or .cmd, the two formats that genuinely need CRLF.
+* text=auto eol=lf

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -19,6 +19,9 @@ conventions to follow inside `frontend/`.
   `/api/...` call is same-origin and flows through the Vite dev proxy / nginx prod proxy (set
   `VITE_API_URL` only for a different-origin API). A request interceptor attaches the JWT from
   `localStorage['jwt_token']`; a response interceptor clears the token and redirects to `/login` on 401.
+  That interceptor is **not** what ends an expired session: the API refuses an expired token with 403,
+  not 401, so expiry is noticed by `AuthContext`'s mount-time `/api/auth/me` check on the next page
+  load instead ([#58](https://github.com/NaimElijah/UpHealther/issues/58)).
   All `src/api/*.ts` modules call through this client — add new endpoints there, not with raw axios.
 - **A failure is decoded once, in `src/api/apiError.ts`.** `toApiError(thrown)` turns anything a call
   rejected with into `{ status, message, fieldErrors, traceId }`; render it with

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -8,7 +8,11 @@ import client from './client';
  *
  * Neither is reachable by clicking through the application: one attaches a header, and the other fires
  * on a response the UI never renders. Both are load-bearing — the first is how every request is
- * authenticated, and the second is the only thing that ends a session whose token has expired.
+ * authenticated, and the second is how a session ends when the server rejects its token with 401.
+ *
+ * It is not what ends an *expired* session, despite reading that way: this API answers an expired
+ * token with 403, which the case below asserts is left alone. `AuthContext`'s mount-time check is
+ * what recovers, on the next page load. See #58.
  *
  * The adapter is replaced rather than the network stubbed, so the real interceptor chain runs and
  * nothing leaves the process. `window.location` is redefined because assigning to `href` in jsdom is a
@@ -92,8 +96,10 @@ describe('the shared API client', () => {
   });
 
   describe('turning a 401 into a logout', () => {
-    it('GivenAnExpiredToken_WhenTheServerAnswers401_ThenTheTokenIsClearedAndTheUserIsSentToLogin', async () => {
-      localStorage.setItem('jwt_token', 'expired.token');
+    it('GivenATokenTheServerRejects_WhenItAnswers401_ThenTheTokenIsClearedAndTheUserIsSentToLogin', async () => {
+      // Named for a rejected token rather than an expired one: expiry is answered 403 by this API, so
+      // "GivenAnExpiredToken" described a scenario the backend never produces (#58).
+      localStorage.setItem('jwt_token', 'rejected.token');
       withAdapter(failWith(401));
 
       await expect(client.get('/api/upgrades')).rejects.toBeDefined();
@@ -123,6 +129,9 @@ describe('the shared API client', () => {
     });
 
     it('GivenAForbiddenResponse_WhenTheServerAnswers403_ThenTheSessionIsLeftAlone', async () => {
+      // Pins today's behaviour rather than endorsing it: 403 is also what this API answers for an
+      // expired token, so leaving the session alone means an open tab keeps failing until it is
+      // reloaded. #58 decides whether the server moves to 401 or this branch learns about 403.
       localStorage.setItem('jwt_token', 'still.valid.token');
       withAdapter(failWith(403));
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,6 +4,9 @@
  * Two interceptors give it the app's auth behaviour: outgoing requests carry the stored JWT, and a 401
  * response clears the token and sends the user to the login page. Adding a second axios instance
  * elsewhere would bypass both.
+ *
+ * An expired token does not reach that second interceptor — the API refuses it with 403. See the
+ * interceptor's own comment below.
  */
 import axios from 'axios';
 
@@ -24,10 +27,16 @@ client.interceptors.request.use((config) => {
 });
 
 /**
- * Turns a 401 into a logout: the token is gone or expired, so clear it and go to the login page.
+ * Turns a 401 into a logout: the server has rejected the token, so clear it and go to the login page.
  *
  * A hard `location.href` assignment rather than a router navigation, deliberately — this runs outside
  * React, and replacing the document also drops any cached server state belonging to the old session.
+ *
+ * It does not fire on expiry, which is the case it reads as though it covers. The API configures no
+ * `AuthenticationEntryPoint`, so Spring Security refuses an anonymous request — and an expired token
+ * leaves the request anonymous — with 403 rather than 401 (see `AuthenticatedBoundaryTest`). A page
+ * load still recovers, because `AuthContext` clears the session on any failed `/api/auth/me`; a tab
+ * left open across the 24-hour expiry does not. Which side moves is tracked in #58.
  */
 client.interceptors.response.use(
   (r) => r,

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -11,7 +11,10 @@ import type { User } from '../types';
  * to render, and simultaneously checked against `/api/auth/me`. A token the server rejects clears the
  * session.
  *
- * A 401 on any later request is handled elsewhere, by the axios interceptor in `api/client.ts`.
+ * A 401 on any later request is handled elsewhere, by the axios interceptor in `api/client.ts`. That
+ * interceptor is not what ends an expired session, though: the API refuses an expired token with 403,
+ * not 401 (#58). The mount-time check below is — it clears the session on any failed `/api/auth/me`,
+ * so expiry is noticed on the next page load rather than on the request that hit it.
  */
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);


### PR DESCRIPTION
## Problem

Two gaps, both small and both about the repository telling the truth about itself.

1. **Nothing records the file conventions.** The backend has no Spotless or Checkstyle configuration
   and the frontend has no Prettier, so an editor opening a `.java` file and a `.tsx` file guesses at
   indentation, and the guess differs per editor. Separately, every tracked file is LF in the index
   today only because whoever committed it happened to have `core.autocrlf` set favourably — a
   contributor without it commits CRLF into a tree the Docker build then reads.

2. **Four places describe an auth path that never runs.** `SecurityConfig` configures no
   `AuthenticationEntryPoint`, so Spring Security refuses an anonymous request with 403 — and an
   expired token leaves the request anonymous (`JwtAuthenticationFilter`), so expiry is answered 403
   too. This is documented and asserted in `AuthenticatedBoundaryTest`. But the axios response
   interceptor acts on **401 only**, and its doc comment ("the token is gone or expired"),
   `AuthContext`'s, `client.test.ts`'s preamble and `frontend/CLAUDE.md` all read as though it is what
   ends an expired session. It is not. The existing 403 test pins the mismatch in place without
   saying so.

## Approach

- `.editorconfig` — values read off the tracked files rather than chosen, so no existing file changes.
  `max_line_length` is deliberately absent: the Java sources sit around 110 columns but a handful reach
  149, and a limit the code does not keep would describe an intention rather than the code.
- `.gitattributes` — `* text=auto eol=lf`, making the normalisation a property of the repository
  instead of per-machine config. Nothing tracked here is a `.bat` or `.cmd`, the two formats that
  genuinely need CRLF.
- The auth comments — corrected to say what actually happens, each pointing at #58.

## Trade-off accepted

**The 401/403 mismatch is documented, not fixed.** Fixing it is a decision — either the API grows an
`AuthenticationEntryPoint` and starts answering 401, or the interceptor learns about 403 — and that
decision belongs in #58, not in a chore PR. What this does instead is stop the comments claiming the
problem does not exist. The 403 test now says out loud that it pins today's behaviour rather than
endorsing it.

**No ADR.** File conventions are not an architectural decision under the repo's own rule for when an
ADR is warranted; #58's outcome is what will need one.

## What was done

| File | Change |
|---|---|
| `.editorconfig` | new — charset, EOL, final newline, trailing whitespace, per-extension indent |
| `.gitattributes` | new — `* text=auto eol=lf` |
| `frontend/src/api/client.ts` | doc comments only |
| `frontend/src/api/client.test.ts` | preamble + two comments; one test **renamed**, no assertion changed |
| `frontend/src/contexts/AuthContext.tsx` | doc comment only |
| `frontend/CLAUDE.md` | one clause on what actually ends an expired session |

The renamed test was `GivenAnExpiredToken_WhenTheServerAnswers401_…`, a scenario the backend never
produces; it is now `GivenATokenTheServerRejects_WhenItAnswers401_…`.

## How it was verified

- `git add --renormalize .` reports no change, so `.gitattributes` pins the current contents rather
  than rewriting them. The CRLF→LF warnings on commit are it doing its job on the working copy.
- `npm run lint` — clean (`--max-warnings 0`).
- `npx tsc --noEmit` — clean.
- `npm run test` — **126 passed, 18 files**, including the 9 in `client.test.ts` and 10 in
  `AuthContext.test.tsx`.

The backend was not built: nothing in this branch touches it.
