### PR TITLE
docs: restructure the README around evaluation before installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,409 +1,409 @@
-# UpHealther - Health Upgrades Planner & Tracker Assistant 🌱
+# UpHealther
 
-A full-stack health upgrade planning and tracking platform. Plan, activate, and track your health improvements — from drinking more water to meditating daily, from better sleep habits to product replacements.
+Plan a health change, then find out whether it actually happened — a tracker for habits,
+experiments, goals and one-off health actions, for people who want structure without a coach.
 
-## What is a Health Upgrade?
+[![CI](https://github.com/NaimElijah/UpHealther/actions/workflows/ci.yml/badge.svg)](https://github.com/NaimElijah/UpHealther/actions/workflows/ci.yml)
+[![Licence: source-available](https://img.shields.io/badge/licence-source--available-blue)](LICENSE)
 
-A **Health Upgrade** is more than a habit. It can be:
-- A new habit (drink 2L water daily)
-- A one-time action (book a dentist appointment)
-- A product replacement (replace toxic cleaning products)
-- A routine (morning meditation + stretch)
-- A goal (lose 5kg by summer)
-- An experiment (no caffeine after 2pm for two weeks)
-- A learning task (read about intermittent fasting)
-- A medical/preventive task (get bloodwork done)
+[Requirements](docs/requirements/requirements.md) ·
+[Architecture](docs/architecture/architecture.md) ·
+[Diagrams](docs/architecture/arch-diagrams/README.md) ·
+[Decisions](docs/ADRs/)
+
+**Contents:** [What and why](#what-and-why) · [Features](#features) · [Architecture](#architecture) ·
+[Tech stack](#tech-stack) · [Quick start](#quick-start) · [Configuration](#configuration) ·
+[Usage](#usage) · [Development](#development) · [Testing](#testing) · [Operations](#operations) ·
+[Project structure](#project-structure) · [Design decisions](#design-decisions) ·
+[Status and limitations](#status-and-limitations) · [Licence](#licence)
+
+```mermaid
+flowchart LR
+    user(["User's browser"])
+
+    subgraph frontend["Frontend container · nginx :80 → :3000"]
+        spa["React SPA<br/>static bundle"]
+        proxy["reverse proxy<br/>/api · /ws"]
+    end
+
+    subgraph backend["Backend container · Spring Boot :8080"]
+        rest["REST controllers"]
+        stomp["STOMP endpoint /ws"]
+        jobs["Scheduled jobs<br/>overdue · check-in · reminders"]
+        core["Domain + application core"]
+    end
+
+    db[("PostgreSQL 15<br/>schema owned by Flyway")]
+
+    user -->|"HTTP"| spa
+    user -->|"/api/**"| proxy
+    user -->|"WebSocket /ws"| proxy
+    proxy -->|"proxy_pass"| rest
+    proxy -->|"proxy_pass, upgraded"| stomp
+    rest --> core
+    jobs --> core
+    core -->|"push"| stomp
+    core -->|"JDBC"| db
+```
+
+## What and why
+
+People who decide to change a health habit rarely fail at the decision — they fail at knowing
+whether the change survived contact with a normal week. UpHealther models each intended change as
+an **upgrade** with an explicit lifecycle, so "did I actually do this?" is a query rather than a
+memory: an upgrade is planned, activated, checked in against, and finally completed or abandoned,
+and every one of those moves is a guarded transition rather than an editable status field.
+
+It is deliberately **not a medical application**. It gives no advice, diagnosis or treatment, and
+no feature may imply otherwise ([non-goal 5.1](docs/requirements/requirements.md#5-non-goals)).
 
 ## Features
 
-- 🔐 **JWT Authentication** — register, login, secure routes
-- 🗂️ **Health Areas** — organize upgrades by area (Fitness, Nutrition, Sleep, etc.)
-- 📋 **Upgrade Management** — full lifecycle: Idea → Planned → Active → Completed/Paused/Abandoned
-- 📊 **Progress Tracking** — boolean, numeric, text, or rating tracking
-- 🔥 **Streak Calculation** — track your current and longest streaks
-- 💡 **Reflections** — periodic reviews of what's working and what isn't
-- 📈 **Dashboard** — overview of today's tasks, active upgrades, completion rates, streaks
-- ✅ **Daily Check-in** — log progress for all active upgrades at once
-- 🏗️ **Domain Events** — clean internal event architecture
-- 🐳 **Docker Compose** — one-command startup
-
-## Tech Stack
-
-### Backend
-| Technology | Version |
-|-----------|---------|
-| Java | 21 |
-| Spring Boot | 3.2.x |
-| Spring Security + JWT | JJWT 0.12.x |
-| Spring Data JPA | - |
-| PostgreSQL | 15 |
-| Flyway | - |
-| Maven | 3.x |
-| JUnit 5 + Mockito | - |
-
-### Frontend
-| Technology | Version |
-|-----------|---------|
-| React | 18 |
-| TypeScript | 5 |
-| Vite | 5 |
-| TanStack Query | 5 |
-| React Router | 6 |
-| Tailwind CSS | 3 |
-| Axios | 1.6 |
+- Create an upgrade — habit, one-off action, experiment, goal, routine or product replacement — and
+  file it under a health area you define
+- Move it through a lifecycle the domain guards: `IDEA → PLANNED → ACTIVE ⇄ PAUSED → COMPLETED /
+  ABANDONED`, where an illegal move is a 422 with a reason rather than a silent write
+- Choose how each upgrade is measured — boolean, numeric, rating or text — and log a day against it;
+  the server scores the entry rather than trusting the client's `completed` flag
+- Check in on every active upgrade at once from a single daily page
+- Read current and longest streaks, today's and this week's entries, and a dashboard of what is
+  active, overdue and completed
+- Record reflections against an upgrade: what worked, what did not, what to adjust
+- Receive reminders and notifications, pushed live over a WebSocket and persisted so an offline
+  client still sees them
+- Switch between light and dark themes, applied before the first paint — no wrong-theme flash
 
 ## Architecture
 
-[`docs/requirements/requirements.md`](docs/requirements/requirements.md) states **what** the system
-must do — the capabilities, the business rules, and the non-goals — with the enforcing class or test
-named against each. [`docs/architecture/architecture.md`](docs/architecture/architecture.md) describes
-**how** it does it: components, how they communicate, the path a request takes end to end, external
-dependencies, and the structural decisions that are not visible from the file layout. Start with
-either; the summary below is the short version.
+Three processes and a browser, shown above. No message broker, no cache, no third-party service:
+every piece of state is in the one database, and every side effect is either a write to it or a
+message pushed to a connected browser.
 
-### Backend — Hexagonal (Ports & Adapters) + DDD
+The backend is **nine bounded contexts over a shared kernel** — `auth`, `user`, `healtharea`,
+`upgrade`, `tracking`, `reflection`, `reminder`, `dashboard`, `notification` — each a hexagon:
+adapters depend on the core, and the core depends on nothing outside itself. Three of them
+(`upgrade`, `healtharea`, `user`) depend on no other context at all, and the graph is acyclic.
+That graph is read off the `import` statements rather than drawn, and CI fails when it stops
+matching the code — see the
+[context map](docs/architecture/arch-diagrams/README.md#2-bounded-context-map).
 
-A bounded context (`auth, user, healtharea, upgrade, tracking, reflection, reminder, dashboard,
-notification`) follows this ports-and-adapters skeleton, taking the parts it needs — `auth` orchestrates
-over `user` and owns no aggregate, and `dashboard` is a read model with no outbound side:
+**One request, end to end.** `POST /api/upgrades/{id}/progress` arrives at nginx and is proxied to
+the API. `JwtAuthenticationFilter` validates the bearer token and re-loads the user, so a deleted
+account stops working immediately. `ProgressController` hands a command to `TrackingService`, which
+asks the `upgrade` context for the upgrade *scoped to that user* — ownership is enforced by the
+query being user-scoped, so another user's row is a 404 rather than a 403. The service rejects a
+duplicate entry for the same upgrade and date, scores the entry against its tracking configuration,
+and saves it through an outbound port the domain owns. Domain events are published `AFTER_COMMIT`,
+so nothing is pushed or persisted as a notification if the transaction rolls back.
 
-```
-com.healthupgrades.<context>/
-  domain/
-    model/          — JPA entities, enums, value objects (the aggregate + its state machine)
-    event/          — the domain events this context publishes (its published language)
-    service/        — pure, framework-free domain services
-    port/out/       — outbound ports (repository SPI, push)
-  application/
-    <X>Service      — @Transactional use-case orchestration
-    port/in/        — inbound query ports + the command/result records use cases speak
-    port/out/       — what this context needs another to supply (see UpgradeTrackingSummaryPort)
-  adapter/
-    in/web/         — REST controllers, request records, response DTOs, web mappers
-    in/{event,scheduling,composition}/ — event listeners, scheduled jobs, suppliers of another
-                                          context's outbound port
-    out/persistence/ — Spring Data *JpaRepository (package-private) + the adapter implementing the port
-    out/messaging/   — STOMP push adapter (notification)
+`HealthUpgrade` owns the state machine and has no setter for its status. `COMPLETED` is terminal;
+`ABANDONED` is not — rescheduling revives it. At most three `HARD` upgrades may be `ACTIVE` at once,
+checked both when activating one and when promoting a running one to `HARD`.
 
-com.healthupgrades.common/
-  domain/event/      — the DomainEvent marker only; events themselves live in their own context
-  domain/exception/  — shared exceptions
-  domain/port/out/   — DomainEventPublisher, the one genuinely cross-cutting outbound port
-  adapter/{in,out}/  — cross-cutting adapters (event publisher, global error handler)
-  security/          — JWT filter, SecurityConfig, SecurityUser, UserDetailsService
-  websocket/         — STOMP config + JWT channel interceptor
-```
+The layering is **enforced, not documented**: `HexagonalArchitectureTest` runs eleven ArchUnit rules
+on every `mvn test` — the domain stays framework-free, the application depends on no adapter, and
+Spring Data is confined to the persistence adapters.
 
-The boundaries are **enforced by ArchUnit** (`HexagonalArchitectureTest`, eleven rules, runs in `mvn test`):
-the domain stays framework-free (apart from JPA mappings), the application depends on no adapter in either
-direction, Spring Data is confined to the persistence adapters, controllers only to the web adapter, and
-bounded contexts interact only through published surfaces — and form an acyclic graph.
+Seven diagrams, outside in: [arch-diagrams](docs/architecture/arch-diagrams/README.md). The prose:
+[architecture.md](docs/architecture/architecture.md). The why: [ADRs](docs/ADRs/).
 
-See [`docs/ADRs/ADR-001-ddd-hexagonal-architecture.md`](docs/ADRs/ADR-001-ddd-hexagonal-architecture.md)
-for the original decision and
-[`docs/ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md`](docs/ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md)
-for the corrections that followed a conformance audit.
+## Tech stack
 
-### Domain Model
+| Layer | Technology | Version | Why |
+|---|---|---|---|
+| Language | Java | 21 | Records carry the command, port and DTO layer, which is most of the boundary code |
+| Framework | Spring Boot | 3.2.5 | Confined to the adapters; ArchUnit keeps it out of the domain |
+| Auth | Spring Security + JJWT | Boot-managed / 0.12.3 | Stateless bearer tokens, no server-side session to replicate |
+| Database | PostgreSQL | 15 | The partial unique constraint and optimistic locking the domain relies on are real constraints, not application checks |
+| Migrations | Flyway | 9.22.3 | Flyway owns the schema; Hibernate runs `ddl-auto: validate` and refuses to start against one that does not match |
+| Observability | Micrometer Tracing (OTel bridge), Prometheus registry, Logstash encoder | Boot-managed / 7.4 | W3C `traceparent` on the wire and vendor-neutral; JSON logs whose trace id is a field, not a substring |
+| Frontend | React + TypeScript | 18.3.1 / 5.9.3 | Enums mirrored from the backend, with a test that fails when they drift |
+| Build | Vite | 5.4.21 | Same `/api` proxy in dev as nginx serves in prod, so both sides behave identically |
+| Data fetching | TanStack Query | 5.100.10 | Cache invalidation per mutation instead of hand-rolled refetching |
+| Styling | Tailwind CSS | 3.4.19 | Semantic tokens only — `npm run check:colours` fails on a raw palette colour |
+| Real-time | STOMP over WebSocket | 7.3.0 | Push reuses the JWT via a channel interceptor rather than a second auth scheme |
+| Tests | JUnit 5, ArchUnit, Testcontainers / Vitest | 1.3.0 / 1.21.4 / 3.2.7 | Real PostgreSQL in the integration suite; architecture rules as ordinary tests |
 
-**HealthUpgrade state machine:**
-```
-IDEA → PLANNED → ACTIVE ⇄ PAUSED
-                ACTIVE → COMPLETED
-                ACTIVE → ABANDONED
-```
+## Quick start
 
-**Business rules:**
-- A completed upgrade cannot be reactivated or paused
-- An abandoned upgrade cannot be reactivated without rescheduling
-- Max 3 HARD difficulty upgrades can be active simultaneously
-- Duplicate progress entries for the same upgrade+date are rejected (HTTP 409)
-- Optimistic locking prevents concurrent edit conflicts (HTTP 409)
-
-### Domain Services
-
-- **StreakCalculator** — counts consecutive days with successful progress
-- **ProgressEvaluationService** — checks if a progress entry meets the tracking target
-- **DashboardAggregationService** — builds the dashboard summary
-- **UpgradeSchedulingService** — enforces the 3 HARD upgrade limit
-
-### Domain Events (in-process)
-
-Events are published through a `DomainEventPublisher` outbound port (a Spring-backed adapter over
-`ApplicationEventPublisher`), so the application layer stays decoupled from the framework's event bus:
-- `HealthUpgradeCreated`, `HealthUpgradePlanned`, `HealthUpgradeActivated`
-- `HealthUpgradePaused`, `HealthUpgradeCompleted`, `HealthUpgradeAbandoned`
-- `ProgressEntryRecorded`, `ReflectionAdded`, `StreakAchieved`, `UpgradeOverdueDetected`
-
-## API Overview
-
-### Auth
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/api/auth/register` | Register new user |
-| POST | `/api/auth/login` | Login, receive JWT |
-| GET | `/api/auth/me` | Get current user info |
-
-### Health Areas
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/health-areas` | List all user's health areas |
-| POST | `/api/health-areas` | Create a health area |
-| PUT | `/api/health-areas/{id}` | Update a health area |
-| DELETE | `/api/health-areas/{id}` | Delete a health area |
-
-### Health Upgrades
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/upgrades` | List upgrades (filter: status, type, areaId, difficulty) |
-| POST | `/api/upgrades` | Create an upgrade |
-| GET | `/api/upgrades/{id}` | Get upgrade detail |
-| PUT | `/api/upgrades/{id}` | Update upgrade |
-| DELETE | `/api/upgrades/{id}` | Delete upgrade |
-| POST | `/api/upgrades/{id}/plan` | Plan an upgrade |
-| POST | `/api/upgrades/{id}/activate` | Activate an upgrade |
-| POST | `/api/upgrades/{id}/pause` | Pause an upgrade |
-| POST | `/api/upgrades/{id}/complete` | Complete an upgrade |
-| POST | `/api/upgrades/{id}/abandon` | Abandon an upgrade |
-| POST | `/api/upgrades/{id}/reschedule` | Reschedule an upgrade |
-
-### Progress & Reflections
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/api/upgrades/{id}/progress` | Log progress entry |
-| GET | `/api/upgrades/{id}/progress` | Get progress history |
-| GET | `/api/progress/today` | Today's progress entries |
-| GET | `/api/progress/week` | This week's progress |
-| POST | `/api/upgrades/{id}/reflections` | Add reflection |
-| GET | `/api/upgrades/{id}/reflections` | Get reflections |
-
-### Dashboard
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/api/dashboard` | Full dashboard summary |
-
-## Setup Instructions
-
-### Prerequisites
-- Java 21+
-- Maven 3.8+
-- Node.js 20+
-- PostgreSQL 15+ (or Docker)
-
-### Run Without Docker
-
-1. **Clone the repository**
-   ```bash
-   git clone <repo-url>
-   cd UpHealther
-   ```
-
-2. **Set up environment**
-   ```bash
-   cp .env.example .env
-   # Edit .env as needed
-   ```
-
-3. **Create PostgreSQL database**
-   ```sql
-   CREATE DATABASE healthupgrades;
-   CREATE USER healthupgrades WITH PASSWORD 'healthupgrades';
-   GRANT ALL PRIVILEGES ON DATABASE healthupgrades TO healthupgrades;
-   ```
-
-4. **Run the backend**
-   ```bash
-   cd backend
-   export DB_URL=jdbc:postgresql://localhost:5432/healthupgrades
-   export DB_USERNAME=healthupgrades
-   export DB_PASSWORD=healthupgrades
-   export JWT_SECRET=your-secret-key-at-least-256-bits
-   mvn spring-boot:run
-   ```
-
-5. **Run the frontend**
-   ```bash
-   cd frontend
-   npm install
-   npm run dev
-   ```
-
-6. Open http://localhost:3000
-
-### Run With Docker Compose
+**Prerequisites:** Docker 24+ with Compose v2. Nothing else — the toolchain runs in containers.
 
 ```bash
-cp .env.example .env
-# Edit .env if needed (especially JWT_SECRET for production)
-docker-compose up --build
+git clone https://github.com/NaimElijah/UpHealther.git && cd UpHealther
+docker compose up --build
 ```
 
-- Frontend: http://localhost:3000
-- Backend: http://localhost:8080
-- Health: http://localhost:8080/actuator/health
+Frontend at **http://localhost:3000**, API at **http://localhost:8080**. Compose waits for the
+backend to report *ready* before starting the frontend, so the first page load is never proxied to
+an API still migrating its schema — expect roughly a minute on a cold build.
 
-`docker-compose` waits for the backend to report **ready** before starting the frontend, so the first
-page load is never proxied to an API that is still migrating its schema.
+Sign in with the seeded demo account **`demo@healthupgrades.com` / `demo123`**. Every variable has
+a working default, so no `.env` is needed to start — copy `.env.example` to `.env` only to override.
 
-### Observability
+<details>
+<summary>If it does not come up</summary>
 
-Logs go to stdout and nowhere else — `docker logs healthupgrades-backend` is the whole of it. Under
-compose they are **one JSON object per line**; a local `mvn spring-boot:run` gets Spring Boot's readable
-console pattern instead. `SPRING_PROFILES_ACTIVE=json-logs` is what switches between them, and
-`LOG_LEVEL_APP=DEBUG` turns this application's own packages up for a run.
+- **`port is already allocated` on 5432** — a host PostgreSQL owns the port. Stop it, or drop the
+  `ports:` mapping on the `postgres` service; the backend reaches it over the compose network anyway.
+- **Backend restarts, logs mention Flyway** — a stale `postgres_data` volume. `docker compose down -v`.
+- **Frontend loads, every call fails** — `curl http://localhost:8080/actuator/health/readiness`.
 
-Every line carries a **trace id**, which is also returned as the `X-Trace-Id` response header and on the
-body of any error. It is the one thing worth quoting in a bug report:
+</details>
+
+## Configuration
+
+Mirrors [`.env.example`](.env.example). The defaults are for local development only; `JWT_SECRET` is
+a published value and gives no security.
+
+| Variable | Purpose | Default | Required |
+|---|---|---|---|
+| `POSTGRES_DB` | Database name created by the compose Postgres | `healthupgrades` | No |
+| `POSTGRES_USER` | Database user created by the compose Postgres | `healthupgrades` | No |
+| `POSTGRES_PASSWORD` | Password for that user | `healthupgrades` | In a deployment |
+| `JWT_SECRET` | Token signing key; at least 256 bits or the application refuses to start | published dev value | In a deployment |
+| `DB_URL` | JDBC URL the backend connects to | `jdbc:postgresql://localhost:5432/healthupgrades` | Outside compose |
+| `DB_USERNAME` | Database user the backend connects as | `healthupgrades` | Outside compose |
+| `DB_PASSWORD` | Password for that user | `healthupgrades` | Outside compose |
+| `CORS_ALLOWED_ORIGINS` | Origins allowed to call the API cross-origin; also the `/ws` handshake origins. Not needed behind the dev or nginx `/api` proxy | `http://localhost:3000` | No |
+| `SPRING_PROFILES_ACTIVE` | `json-logs` switches log output to one JSON object per line; compose sets it | empty locally | No |
+| `LOG_LEVEL_APP` | Level for `com.healthupgrades` only | `INFO` | No |
+| `VITE_API_URL` | Backend URL for the frontend. Leave empty to use the same-origin `/api` proxy | empty | No |
+
+<details>
+<summary>Scheduled job timings — set in <code>application.yml</code>, not wired through compose</summary>
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `UPGRADE_OVERDUE_CRON` | The overdue sweep (server timezone); `NOTIFY_OVERDUE_CRON` still honoured as its former name | `0 0 8 * * *` |
+| `NOTIFY_CHECKIN_CRON` | The daily check-in nudge | `0 0 18 * * *` |
+| `NOTIFY_REMINDERS_CRON` | How often reminders are dispatched | `0 * * * * *` |
+
+Absent from `.env.example`, and `docker-compose.yml` does not pass them to the backend — they take
+effect on a native run, or by adding them to the compose `environment:` block.
+
+</details>
+
+## Usage
+
+Authenticate, then send the token as a bearer on every `/api` call.
 
 ```bash
-docker logs healthupgrades-backend | grep <the id from the error>
+curl -sX POST http://localhost:8080/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"demo@healthupgrades.com","password":"demo123"}'
 ```
 
-Two streams are worth knowing about:
+Returns `200` with `{ "token": "eyJhbGciOiJIUzI1NiJ9…", "user": { "id", "name", "email",
+"createdAt" } }`. Export the token as `$TOKEN` for the calls below.
 
-| What | Where |
-|---|---|
-| Who did what, and whether it was allowed | the `AUDIT` logger — `action`, `outcome`, `actorId`, `resourceId` |
-| Latency, error rate, saturation, pool depth, audit and job counters | http://localhost:8080/actuator/prometheus |
+Create an upgrade — `201`, and it starts in `IDEA` because status moves only through the transition
+endpoints:
 
-`/actuator` serves **only** `health`, `info` and `prometheus`; anything else answers 404 by design.
-Liveness and readiness are separate: http://localhost:8080/actuator/health/liveness and
-`/actuator/health/readiness`.
+```bash
+curl -sX POST http://localhost:8080/api/upgrades \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"title":"Walk 8k steps","type":"HABIT","difficulty":"MEDIUM","targetEndDate":"2026-12-01"}'
+```
 
-### Demo Account
+The response carries all eighteen fields of the upgrade — nulls are serialised rather than omitted,
+so a client can rely on every key being present. It is reproduced in full in
+[docs/api.md](docs/api.md#a-created-upgrade-in-full).
 
-After startup, a demo account is available:
-- **Email:** `demo@healthupgrades.com`
-- **Password:** `demo123`
+A move the state machine forbids is refused by the domain, not the controller — `422`, with the
+`traceId` that finds the log line for it:
 
-## Running Tests
+```bash
+curl -sX POST "http://localhost:8080/api/upgrades/0f2c8f5a.../complete" \
+  -H "Authorization: Bearer $TOKEN"
+```
 
-### Backend Tests
+```json
+{
+  "status": 422,
+  "message": "Only ACTIVE upgrades can be completed",
+  "path": "/api/upgrades/0f2c8f5a.../complete",
+  "timestamp": "2026-01-14T09:13:40",
+  "traceId": "65b2c0f4a1d3e8b7"
+}
+```
+
+The rest of the surface — every endpoint, the full status contract, and the error body — is in
+[**docs/api.md**](docs/api.md).
+
+## Development
+
+Running natively needs **JDK 21**, **Maven 3.8+**, **Node 20+**, and a PostgreSQL 15 on `:5432`.
+
+```bash
+docker compose up -d postgres               # or bring your own PostgreSQL
+
+cd backend  && mvn spring-boot:run          # terminal 1 — :8080, Flyway migrates on start
+cd frontend && npm install && npm run dev   # terminal 2 — :3000, proxying /api to :8080
+```
+
+The backend falls back to the development defaults in `application.yml`, so a fresh clone runs
+with nothing set in the environment.
+
+**Migrations** are Flyway SQL in `backend/src/main/resources/db/migration`, named `V{n}__snake_case.sql`
+and append-only — Hibernate validates the entities against the schema and refuses to start on a
+mismatch, so an entity change needs a new migration rather than a `ddl-auto` change.
+
+**Conventions.** Conventional Commits (`type(scope): imperative subject`), branches
+`type/short-kebab-description`, one logical change per commit. Formatting is pinned by
+[`.editorconfig`](.editorconfig) and line endings by [`.gitattributes`](.gitattributes).
+
+**Adding a feature end to end**, in the order the files come: behaviour into `domain/model` (or
+`domain/service`) with a failing test; what it needs from outside into `domain/port/out`; a
+`@Transactional` service in `application` with its command and result records in
+`application/port/in`; the port implemented in `adapter/out/persistence`; the route in
+`adapter/in/web` with a request record, DTO and mapper; the Flyway migration; then
+`frontend/src/api` and the page. `HexagonalArchitectureTest` fails the build on any arrow that runs
+the wrong way.
+
+## Testing
+
+| Level | Covers | Command |
+|---|---|---|
+| Domain | The `HealthUpgrade` state machine and construction invariants, streaks, reminder scheduling, entry scoring | `mvn test` |
+| Application | Every use case in every context, including what a *rejected* operation must not leave behind | `mvn test` |
+| Web slice | Each controller against the real security chain: status codes, validation, another user's row as a 404 | `mvn test` |
+| Structural | Eleven ArchUnit rules, plus the frontend enum contract | `mvn test` |
+| Integration | The app booted against a real PostgreSQL — bean graph, migrations, database-enforced invariants | `mvn verify` |
+| Frontend | Session restore and 401 expiry, the notification socket, the route gate, theme, error boundary | `npm run test` |
+
 ```bash
 cd backend
-mvn test      # unit + architecture tests — no database needed
-mvn verify    # the above plus integration tests — needs Docker running
+mvn test        # 465 unit and structural tests — no database, no Docker
+mvn verify      # the above plus 39 integration tests in 8 *IT classes — needs Docker
+
+cd ../frontend
+npm run lint && npm run check:colours && npm run test
 ```
 
-`mvn test` covers four levels, described in
-[ADR-009](docs/ADRs/ADR-009-test-levels-boundaries-and-naming.md):
-- **Domain** — the HealthUpgrade state machine and its construction invariants, reminder scheduling,
-  streaks, and how an entry is scored against its tracking configuration
-- **Application** — every use case in every context, including what a rejected operation must *not*
-  leave behind
-- **Web slice** — each controller against the real security chain and exception handler: the status
-  codes, request validation, and that another user's row is a 404 rather than a 403
-- **Structural** — the hexagonal architecture rules (ArchUnit, eleven of them) and the frontend enum
-  contract
+The integration suite starts its own `postgres:15-alpine` through Testcontainers, so nothing needs
+provisioning first and CI runs the same `verify`
+([ADR-008](docs/ADRs/ADR-008-testcontainers-for-the-integration-test-database.md)).
 
-`mvn verify` adds the `*IT` suite, which boots the app against PostgreSQL and so catches a broken bean
-graph, a missing Flyway migration, or an invariant only the database enforces — none of which a unit test
-can see. There is nothing to start first: the tests bring up their own `postgres:15-alpine` container via
-Testcontainers, so they need a running Docker daemon and nothing else. See
-[ADR-008](docs/ADRs/ADR-008-testcontainers-for-the-integration-test-database.md) for why the database is
-described in the test source rather than handed to it.
+**What CI gates on** ([`ci.yml`](.github/workflows/ci.yml), every push and PR to `main` and `dev`):
+`mvn clean verify`; the generated diagrams still matching their source; frontend lint with
+`--max-warnings 0`; the colour-token check; `vitest run --coverage`; `npm audit --omit=dev
+--audit-level=high`; and the production build.
 
-### Frontend Tests
-```bash
-cd frontend
-npm run test           # Vitest + jsdom + Testing Library
-npm run test:coverage  # the same run, with a coverage summary
-npm run build          # type check and production build
-npm run lint           # ESLint, zero warnings tolerated
-npm run check:colours  # fails on any Tailwind palette colour used outside the theme tokens
-```
+**Coverage is reported and never gated.** Both suites publish a report every run — the backend's
+into the job summary, both as artefacts — but no threshold fails a build. The gate is
+[`requirements.md`](docs/requirements/requirements.md), where every requirement names the test that
+enforces it ([ADR-009](docs/ADRs/ADR-009-test-levels-boundaries-and-naming.md)).
 
-`npm run test` covers the session (a stored token restoring one, and a 401 ending it), the live
-notification socket, the route gate, the theme provider and the shared UI primitives. See
-[ADR-004](docs/ADRs/ADR-004-frontend-test-harness.md) for why the harness exists and what it cannot do.
+## Operations
 
-### Coverage
+**Nothing is deployed.** This runs locally under Compose and has never run in a hosted environment,
+so there is no pipeline and no published image. What follows are facts about the code.
 
-Both suites report coverage on every CI run and **neither gates on it**. The gate is
-[`docs/requirements/requirements.md`](docs/requirements/requirements.md): every requirement names the
-test that enforces it, or says why none can.
-
-```bash
-cd backend && mvn test    # writes target/site/jacoco/index.html
-cd frontend && npm run test:coverage
-```
-
-## Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `POSTGRES_DB` | `healthupgrades` | PostgreSQL database name |
-| `POSTGRES_USER` | `healthupgrades` | PostgreSQL username |
-| `POSTGRES_PASSWORD` | `healthupgrades` | PostgreSQL password |
-| `DB_URL` | `jdbc:postgresql://localhost:5432/healthupgrades` | Full JDBC URL |
-| `DB_USERNAME` | `healthupgrades` | Database user the backend connects as |
-| `DB_PASSWORD` | `healthupgrades` | Password for that user |
-| `JWT_SECRET` | (default dev key) | JWT signing secret (change in production!) |
-| `SPRING_PROFILES_ACTIVE` | (empty; `json-logs` under compose) | `json-logs` switches log output to one JSON object per line |
-| `LOG_LEVEL_APP` | `INFO` | Level for this application's own packages. `DEBUG` to read along |
-| `UPGRADE_OVERDUE_CRON` | `0 0 8 * * *` | When the overdue sweep runs (server timezone) |
-| `NOTIFY_CHECKIN_CRON` | `0 0 18 * * *` | When the daily check-in nudge runs |
-| `NOTIFY_REMINDERS_CRON` | `0 * * * * *` | How often reminders are dispatched |
-| `CORS_ALLOWED_ORIGINS` | `http://localhost:3000` | Comma-separated origins allowed to call the API cross-origin (only needed when not using the dev/nginx `/api` proxy) |
-| `VITE_API_URL` | (empty) | Backend API URL for frontend. Leave empty to use the same-origin `/api` proxy (Vite in dev, nginx in prod) — recommended. Set only if the API is on another origin. |
-
-## Future Improvements
-
-- [ ] Reminders / push notifications
-- [ ] AI-powered suggestions (lifestyle only, not medical advice)
-- [ ] Social features: share upgrades, accountability partners
-- [ ] Mobile app (React Native)
-- [ ] Export progress data (CSV/PDF)
-- [ ] Gamification: achievements, badges, levels
-- [ ] Integration with wearables (steps, sleep data)
-- [ ] Weekly/monthly progress email reports
-- [x] Dark mode
-- [ ] Internationalization (i18n)
-
-## Screenshots
-
-*(Coming soon — run the app to see it in action)*
-
-## Disclaimer
-
-> UpHealther is a lifestyle planning tool. It is **not** a medical application and does not provide medical advice, diagnosis, or treatment. Always consult a healthcare professional for medical decisions.
-
-## Project Summary
-
-**UpHealther** is a production-quality full-stack web application built with Java 21 / Spring Boot 3 backend and React / TypeScript frontend. It demonstrates:
-- Clean architecture: Domain-Driven Design (DDD) + Hexagonal (Ports & Adapters), enforced with ArchUnit
-- JWT authentication with Spring Security
-- PostgreSQL with Flyway migrations and optimistic locking
-- Domain events for clean separation of concerns
-- RESTful API design with proper HTTP semantics
-- React with TanStack Query for efficient data fetching
-- Tailwind CSS for responsive UI
-- Docker Compose for one-command deployment
-- GitHub Actions CI pipeline
-- Comprehensive unit tests for domain logic
-
-## License
-
-**Copyright © 2026 Naim Elijah. All rights reserved.**
-
-UpHealther is **source-available, not open source**. The code is published so it can be read,
-reviewed and evaluated — by prospective employers, collaborators and anyone technically curious. That
-is the whole of the permission granted.
-
-| You may | You may not |
+| Concern | Where |
 |---|---|
-| Read and review the source | Use it in any project, product or service |
-| Keep a local copy to evaluate it | Copy, modify or build on it |
-| Quote short excerpts, with credit | Deploy, host or run it |
-| | Redistribute or sell it |
-| | Present it as your own work |
-| | Use it to train a machine learning model |
+| Liveness | `GET /actuator/health/liveness` |
+| Readiness | `GET /actuator/health/readiness` — not ready until Flyway has finished; both images declare a `HEALTHCHECK` against it |
+| Metrics | `GET /actuator/prometheus` — HTTP latency, error rate, JVM, HikariCP saturation, audit and scheduled-job counters |
+| Traces | Micrometer Tracing over the OpenTelemetry bridge; sampled at 1.0, **no exporter configured**, so no span leaves the process |
+| Logs | `docker logs` only — one JSON object per line under compose, Boot's readable pattern locally |
+| Correlation | Every line carries a trace id, returned as the `X-Trace-Id` header and on the error body — with two exceptions, below |
+| Audit | The `AUDIT` logger — `action`, `outcome`, `actorId`, `resourceId`; enums and identifiers only, never personal data |
 
-Anything beyond reading requires **written permission** from the author. Requests go through
-[github.com/NaimElijah](https://github.com/NaimElijah) — an unanswered request is a refused one.
+Migrations run at application start, so a bad one leaves the container un-ready rather than
+corrupting the schema. To chase a reported failure:
+`docker logs healthupgrades-backend | grep <trace id>`.
 
-The full terms are in [`LICENSE`](LICENSE), and they are what govern; the table above is a summary.
+## Project structure
 
-Third-party dependencies (Spring Boot, React, PostgreSQL and the rest) are **not** covered by this
-licence and remain under the terms their own authors set. This licence applies only to the original
-work in this repository.
+```
+backend/            Spring Boot API — nine bounded contexts, hexagonal, ArchUnit-enforced
+  src/main/java/      com.healthupgrades.<context>/{domain,application,adapter} + common/
+  src/main/resources/ application.yml, logback-spring.xml, db/migration/V{n}__*.sql
+  src/test/java/      domain · application · web slice · architecture · *IT
+frontend/           React + TypeScript SPA served by nginx in production
+  src/api/            Typed client per resource, plus the shared axios instance and error mapping
+  src/pages/          One page per route; components/, contexts/, hooks/ alongside
+docs/               The documentation the repository baseline requires
+  requirements/       What the system must do, each requirement naming its enforcing test
+  architecture/       What the system is, plus seven diagrams (three generated from source)
+  ADRs/               Why — one file per decision, append-only
+.github/workflows/  CI: backend verify, diagram drift check, frontend lint/test/audit/build
+```
+
+## Design decisions
+
+**DDD + hexagonal, boundaries enforced by tests** ([ADR-001](docs/ADRs/ADR-001-ddd-hexagonal-architecture.md),
+corrected by [ADR-002](docs/ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md))
+— the lifecycle rules *are* the product, and conventional service/repository layering scatters them
+where nothing stops a controller reaching the database. **Cost:** many more types, so a small feature
+touches more files; entities stay JPA-annotated, so the domain is not persistence-ignorant.
+
+**A real PostgreSQL in the integration tests, started by the tests**
+([ADR-008](docs/ADRs/ADR-008-testcontainers-for-the-integration-test-database.md)) — an embedded H2 in
+compatibility mode was rejected outright: the schema is PostgreSQL-specific, Hibernate boots with
+`validate`, and the invariants that most need a real database (a partial unique constraint,
+optimistic locking under concurrent writes) are exactly where compatibility modes diverge. A CI
+service container was rejected for keeping the two environments different. **Cost:** `mvn verify`
+needs Docker, and the suite is slower.
+
+**Coverage is reported, never gated** ([ADR-009](docs/ADRs/ADR-009-test-levels-boundaries-and-naming.md))
+— a threshold is satisfied by tests written to move a number and says nothing about whether a rule is
+enforced. **Cost:** the gate is a document, so it holds only while that table is maintained.
+
+**The audit trail is a log stream, not a table** ([ADR-011](docs/ADRs/ADR-011-audit-as-a-log-stream.md))
+— an `audit_log` table rolls back with the very refusal it was recording unless it gets its own
+transaction, and Envers records versions of rows rather than attempts by people, so it cannot record
+refusals at all. **Cost:** the container log's retention *is* the audit trail's retention — adequate
+for diagnosis, explicitly not a compliance story.
+
+**Source-available, not open source** ([ADR-003](docs/ADRs/ADR-003-proprietary-source-available-licensing.md))
+— MIT and Apache-2.0 permit exactly what was not intended: anyone building on the work commercially,
+with attribution buried in a notices file. AGPL grants more than intended and is banned outright at
+many organisations. **Cost:** nobody may use or run the code without written permission, which rules
+out outside contribution.
+
+## Status and limitations
+
+**Feature-complete and unshipped.** Every capability above works and is covered — 465 unit and
+structural tests, 39 integration tests, 126 frontend tests, all green — but it has never run in a
+hosted environment, has no release tags, and is versioned `0.0.1-SNAPSHOT`.
+
+Known limitations, load-bearing rather than accidental:
+
+- **Single instance only.** The STOMP broker is in-memory, so a push reaches only clients connected
+  to the instance that raised it; others see the persisted notification on their next fetch. More
+  than one instance needs a broker relay first.
+- **No backend dependency audit.** OWASP dependency-check cannot populate its database without an
+  `NVD_API_KEY`, and a check that always fails — or cannot fail — was judged worse than none. The
+  frontend's shipped dependencies *are* audited on every run.
+- **Observability stops at the process.** `docker logs` is the only sink, so its retention is the
+  audit trail's retention; nothing scrapes `/actuator/prometheus`; no span leaves the process; and
+  the SPA has no telemetry, so `ErrorBoundary` can show an error and nothing else knows it happened.
+- **Two paths carry a trace id in the header but not the body** — an anonymous request to a protected
+  endpoint is rejected inside the security chain (as a `403`, since no `AuthenticationEntryPoint` is
+  configured), and a container error dispatch runs outside the observation scope.
+- **No screenshots yet.** The system-context diagram stands in until the UI is captured.
+
+Planned, and deliberately absent from every section above: push notifications, progress export,
+internationalisation, wearable integration. Sharing, accountability partners and a public API are
+**non-goals** rather than backlog ([§5](docs/requirements/requirements.md#5-non-goals)).
+
+## Contributing
+
+Outside contribution is not possible under the licence below — the code may be read, not modified.
+Corrections and questions are welcome as [issues](https://github.com/NaimElijah/UpHealther/issues).
+
+## Licence
+
+**Copyright © 2026 Naim Elijah. All rights reserved.** UpHealther is **source-available, not open
+source**: published so it can be read, reviewed and evaluated, which is the whole of the permission
+granted. Anything beyond reading — using, copying, modifying, running, deploying, redistributing, or
+training a model on it — needs written permission, via
+[github.com/NaimElijah](https://github.com/NaimElijah); an unanswered request is a refused one.
+
+[`LICENSE`](LICENSE) carries the terms that govern. Third-party dependencies remain under their own.
+
+## Acknowledgements
+
+The ADR format is Michael Nygard's; the ports-and-adapters shape is Alistair Cockburn's, and the
+context boundaries Eric Evans' *Domain-Driven Design*.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,102 @@
+# API reference
+
+Every endpoint below `/api` except `POST /api/auth/register` and `POST /api/auth/login` requires a
+bearer token: `Authorization: Bearer <token>`. Tokens last 24 hours and are not refreshable.
+
+Worked request and response bodies are in the [README's Usage section](../README.md#usage). This page
+is the surface; [`requirements.md`](requirements/requirements.md) says what each capability must do,
+and the `*ControllerTest` named against each area pins the status codes.
+
+## Endpoints
+
+| Area | Endpoints |
+|---|---|
+| Auth | `POST /api/auth/register` · `POST /api/auth/login` · `GET /api/auth/me` |
+| Health areas | `GET POST /api/health-areas` · `GET PUT DELETE /api/health-areas/{id}` |
+| Upgrades | `GET POST /api/upgrades` · `GET PUT DELETE /api/upgrades/{id}` |
+| Transitions | `POST /api/upgrades/{id}/…` — `plan` · `activate` · `pause` · `complete` · `abandon` · `reschedule` |
+| Tracking config | `GET PUT /api/upgrades/{id}/tracking-config` |
+| Progress | `GET POST /api/upgrades/{id}/progress` · `GET /api/upgrades/{id}/streak` · `GET /api/progress/today` · `GET /api/progress/week` |
+| Reflections | `GET POST /api/upgrades/{id}/reflections` |
+| Reminders | `GET POST /api/upgrades/{id}/reminders` · `PUT DELETE /api/reminders/{id}` |
+| Notifications | `GET /api/notifications` · `GET /api/notifications/unread-count` · `POST /api/notifications/{id}/read` · `POST /api/notifications/read-all` |
+| Dashboard | `GET /api/dashboard` |
+| Real-time | STOMP over `/ws`; the client subscribes to `/user/queue/notifications` |
+
+`GET /api/upgrades` filters on `status`, `type`, `areaId` and `difficulty`.
+
+## A created upgrade, in full
+
+`POST /api/upgrades` returns `201`. Nulls are serialised rather than omitted, so the body always
+carries all eighteen fields — a client can rely on the key being present.
+
+```bash
+curl -sX POST http://localhost:8080/api/upgrades \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"Walk 8k steps","type":"HABIT","difficulty":"MEDIUM","targetEndDate":"2026-12-01"}'
+```
+
+```json
+{
+  "id": "0f2c8f5a-2a4e-4a1d-8f0a-3c5b9d1e77a1",
+  "userId": "8c1f6d20-90ab-4c33-9f14-2b7a5e0c1d88",
+  "areaId": null,
+  "title": "Walk 8k steps",
+  "description": null,
+  "type": "HABIT",
+  "status": "IDEA",
+  "difficulty": "MEDIUM",
+  "plannedStartDate": null,
+  "actualStartDate": null,
+  "targetEndDate": "2026-12-01",
+  "motivation": null,
+  "successCriteria": null,
+  "overdue": false,
+  "version": 0,
+  "trackingConfig": null,
+  "createdAt": "2026-01-14T09:13:02",
+  "updatedAt": "2026-01-14T09:13:02"
+}
+```
+
+`status` is `IDEA` on creation and is absent from the request by design — it moves only through the
+transition endpoints. `actualStartDate` stays null until the upgrade is activated, `overdue` is
+derived at mapping time, and `version` is the optimistic-lock counter: echo a stale one back and the
+write is a `409`. Field order is part of the contract in practice and is pinned by
+`UpgradeDtoSerializationTest`.
+
+## Status contract
+
+Controllers never build a status by hand — they throw the domain exception that says what went wrong,
+and `GlobalExceptionHandler` decides how it surfaces
+([ADR-006](ADRs/ADR-006-framework-exceptions-through-responseentityexceptionhandler.md)).
+
+| Status | Raised when |
+|---|---|
+| `400` | Failed validation, an unbindable body, or a parameter that will not convert |
+| `401` | Credentials rejected — the response never says which half was wrong |
+| `403` | Access denied |
+| `404` | Not found, **including** a record belonging to another user: ownership is enforced by the query being user-scoped, so a foreign row is indistinguishable from a missing one |
+| `409` | A duplicate progress entry for the same upgrade and date, or a stale optimistic-lock `version` |
+| `422` | A business rule refused the operation — an illegal lifecycle transition, or a fourth concurrent `HARD` upgrade |
+| `405` `415` `406` | The status Spring defines for the framework exception |
+| `500` | A genuine server fault. Carries the status and a trace id, and nothing else |
+
+## Error body
+
+Every failed request returns the same shape. `fieldErrors` appears only on validation failures and
+`traceId` only when the request was traced; both are omitted otherwise.
+
+```json
+{
+  "status": 422,
+  "message": "Only ACTIVE upgrades can be completed",
+  "path": "/api/upgrades/0f2c8f5a.../complete",
+  "timestamp": "2026-01-14T09:13:40",
+  "traceId": "65b2c0f4a1d3e8b7"
+}
+```
+
+The `traceId` is also returned as the `X-Trace-Id` response header, and is the key that joins a
+failure a user reports to the log lines that produced it.

--- a/docs/api.md
+++ b/docs/api.md
@@ -85,8 +85,11 @@ and `GlobalExceptionHandler` decides how it surfaces
 
 ## Error body
 
-Every failed request returns the same shape. `fieldErrors` appears only on validation failures and
-`traceId` only when the request was traced; both are omitted otherwise.
+Every failure that reaches `GlobalExceptionHandler` returns the same shape. `fieldErrors` appears
+only on validation failures and `traceId` only when the request was traced; both are omitted
+otherwise. Two paths do not reach it and so return Boot's default body instead — an anonymous
+request to a protected endpoint, rejected inside the Spring Security chain, and a container error
+dispatch to `/error`. Both still carry the `X-Trace-Id` header.
 
 ```json
 {


### PR DESCRIPTION
Promotes the README restructure from `dev`. `dev` is ahead of `main` by exactly this work —
`README.md` and the new `docs/api.md`, no code — and it merged green in
[#67](https://github.com/NaimElijah/UpHealther/pull/67).

## Problem

The README was ordered for a reader who had already decided to install. Six endpoint tables sat
between the architecture and the setup instructions; the architecture section restated
`docs/architecture/` rather than pointing at it; planned work was mixed into a feature checklist as
unticked boxes, so a reader could not tell what shipped; the version column read `3.2.x`, `15` and
`-`; and there was no statement of maturity, no project structure, and no record of the trade-offs
the design makes.

## Approach

Reorder around **evaluation before installation** — most people opening this README are deciding
whether to care, not installing — and make it a router rather than an encyclopedia: anything deeper
than a screen moves into `docs/` behind a link. Every section is grounded in a file in the repo:
versions from `pom.xml`, `package-lock.json` and the packaged jar; commands from `ci.yml`;
configuration from `.env.example` and `application.yml`; limitations from `architecture.md`'s
"Known constraints"; design decisions from the ADRs they link to.

## What was done

- Reordered: header and badges → system-context diagram → what and why → features → architecture →
  tech stack → quick start → configuration → usage → development → testing → operations → project
  structure → design decisions → status and limitations → licence.
- Extracted `docs/api.md` — the endpoint list, the status contract and the error body, plus the full
  eighteen-field upgrade response the README had been abbreviating into something the API does not
  return.
- Added project structure, design decisions (each with alternatives and cost, linked to ADR-001,
  ADR-003, ADR-008, ADR-009 and ADR-011), and status and limitations.
- Pinned every version, each row carrying its rationale.
- Confined planned work to Status and limitations, marked as planned, and kept it distinct from the
  non-goals in [requirements §5](docs/requirements/requirements.md#5-non-goals).
- Stated plainly that nothing is deployed, that the metrics endpoint is unread and that no span
  leaves the process, rather than implying a pipeline.
- Added CI and licence badges; no coverage badge, because nothing uploads coverage, and no release
  badge, because there are no tags.

## Trade-offs accepted

- **409 lines, against a 200–400 target.** About sixty lines moved into `docs/api.md` and the space
  went to the missing sections; the rest is one 28-line Mermaid diagram and three worked API
  examples. Trimming further would cost content, not noise.
- **A container diagram stands in for a screenshot.** There is no UI capture in the repo; the old
  README promised one as "coming soon". The gap is now recorded under Status and limitations rather
  than left as a promise.
- **`docs/api.md` is hand-written and can drift**, exactly as the endpoint tables did inside the
  README. Moving them relocates that risk rather than removing it.

## How it was verified

Locally, before the first commit, and again by CI on #67 — all three jobs green:

| Check | Result |
|---|---|
| `mvn test` | 465 tests, 0 failures |
| `mvn verify` | + 39 integration tests in 8 `*IT` classes against Testcontainers PostgreSQL |
| `generate.py --check` | diagrams up to date |
| `npm run lint` | clean at `--max-warnings 0` |
| `npm run check:colours` | no palette colours across 83 compiled files |
| `npm run test` | 18 files, 126 tests |

Every relative link and heading anchor in both documents resolves against the repo.

**Not verified:** the full `docker compose up --build` stack was not booted; the Quick start path is
read from `docker-compose.yml`, the Dockerfiles and the seed migrations rather than executed.

## Follow-up

`UPGRADE_OVERDUE_CRON`, `NOTIFY_CHECKIN_CRON` and `NOTIFY_REMINDERS_CRON` are read by
`application.yml` but are absent from `.env.example` and are not passed through the backend's
`environment:` block in `docker-compose.yml`, so setting them in `.env` has no effect under compose.
Documented as-is; worth an issue rather than a silent fix in a docs PR.
