### PR TITLE
Enforce at the boundary what was only being assumed

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -37,8 +37,9 @@ enforced by `HexagonalArchitectureTest` (ArchUnit). Module-specific conventions 
 
 ### Full stack
 - `docker-compose up --build` — Postgres + backend + frontend. Frontend :3000, backend :8080.
-- Demo account after startup: `demo@healthupgrades.com` / `demo123` (seeded via Flyway `V2`; the demo
-  password hash is corrected in `V3`).
+- Demo account after startup: `demo@healthupgrades.com` / `demo1234` (seeded via Flyway `V2`; the
+  hash is corrected in `V3` and raised to the eight-character minimum of BR-17 in `V6`). Never edit an
+  applied migration to change it — Flyway checksums the comments too; add another `UPDATE`.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Frontend at **http://localhost:3000**, API at **http://localhost:8080**. Compose
 backend to report *ready* before starting the frontend, so the first page load is never proxied to
 an API still migrating its schema — expect roughly a minute on a cold build.
 
-Sign in with the seeded demo account **`demo@healthupgrades.com` / `demo123`**. Every variable has
+Sign in with the seeded demo account **`demo@healthupgrades.com` / `demo1234`**. Every variable has
 a working default, so no `.env` is needed to start — copy `.env.example` to `.env` only to override.
 
 <details>

--- a/backend/src/main/java/com/healthupgrades/auth/adapter/in/web/AuthController.java
+++ b/backend/src/main/java/com/healthupgrades/auth/adapter/in/web/AuthController.java
@@ -25,17 +25,17 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     /** Mirrors {@code users.name VARCHAR(255)}; see BR-16 for why the bound is here. */
-    static final int NAME_MAX = 255;
+    public static final int NAME_MAX = 255;
 
     /** Mirrors {@code users.email VARCHAR(255)}. */
-    static final int EMAIL_MAX = 255;
+    public static final int EMAIL_MAX = 255;
 
     /**
      * The shortest password the API accepts. Unlike the bounds above this mirrors no column - only the
      * hash is stored, and a BCrypt hash is always 60 characters - so it is policy, and it is enforced
      * here because a rule the browser alone applies is not enforced at all. BR-17.
      */
-    static final int PASSWORD_MIN = 8;
+    public static final int PASSWORD_MIN = 8;
 
     /**
      * Where BCrypt stops reading. {@code BCryptPasswordEncoder} guards only against null, so anything
@@ -44,7 +44,7 @@ public class AuthController {
      * {@code @Size} counts UTF-16 code units and BCrypt counts bytes, so a password of multi-byte
      * characters can pass this bound and still be truncated.
      */
-    static final int PASSWORD_MAX = 72;
+    public static final int PASSWORD_MAX = 72;
 
     private final AuthService authService; // application service
 

--- a/backend/src/main/java/com/healthupgrades/auth/adapter/in/web/AuthController.java
+++ b/backend/src/main/java/com/healthupgrades/auth/adapter/in/web/AuthController.java
@@ -30,6 +30,22 @@ public class AuthController {
     /** Mirrors {@code users.email VARCHAR(255)}. */
     static final int EMAIL_MAX = 255;
 
+    /**
+     * The shortest password the API accepts. Unlike the bounds above this mirrors no column - only the
+     * hash is stored, and a BCrypt hash is always 60 characters - so it is policy, and it is enforced
+     * here because a rule the browser alone applies is not enforced at all. BR-17.
+     */
+    static final int PASSWORD_MIN = 8;
+
+    /**
+     * Where BCrypt stops reading. {@code BCryptPasswordEncoder} guards only against null, so anything
+     * past this is silently dropped and a longer password becomes indistinguishable from its own
+     * prefix; refusing it is honest where truncating it is not. Note the mismatch this cannot close:
+     * {@code @Size} counts UTF-16 code units and BCrypt counts bytes, so a password of multi-byte
+     * characters can pass this bound and still be truncated.
+     */
+    static final int PASSWORD_MAX = 72;
+
     private final AuthService authService; // application service
 
     /**
@@ -85,7 +101,7 @@ public class AuthController {
     public record RegisterRequest(
             @NotBlank @Size(max = NAME_MAX) String name,
             @NotBlank @Email @Size(max = EMAIL_MAX) String email,
-            @NotBlank String password
+            @NotBlank @Size(min = PASSWORD_MIN, max = PASSWORD_MAX) String password
     ) {}
 
     /** Login request body. */

--- a/backend/src/main/java/com/healthupgrades/auth/adapter/in/web/AuthController.java
+++ b/backend/src/main/java/com/healthupgrades/auth/adapter/in/web/AuthController.java
@@ -8,6 +8,7 @@ import com.healthupgrades.user.domain.model.User;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
+
+    /** Mirrors {@code users.name VARCHAR(255)}; see BR-16 for why the bound is here. */
+    static final int NAME_MAX = 255;
+
+    /** Mirrors {@code users.email VARCHAR(255)}. */
+    static final int EMAIL_MAX = 255;
 
     private final AuthService authService; // application service
 
@@ -76,8 +83,8 @@ public class AuthController {
 
     /** Registration request body. */
     public record RegisterRequest(
-            @NotBlank String name,
-            @NotBlank @Email String email,
+            @NotBlank @Size(max = NAME_MAX) String name,
+            @NotBlank @Email @Size(max = EMAIL_MAX) String email,
             @NotBlank String password
     ) {}
 

--- a/backend/src/main/java/com/healthupgrades/common/adapter/in/web/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/healthupgrades/common/adapter/in/web/GlobalExceptionHandler.java
@@ -27,6 +27,7 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -168,14 +169,22 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     /**
      * Maps bean-validation failures on a request body to 400, with a field → message map so the client
      * can attach each message to the input that produced it.
+     *
+     * <p>One field can violate several constraints at once — an empty password fails both
+     * {@code @NotBlank} and {@code @Size(min = 8)} — and the map holds one message each. Hibernate
+     * Validator does not specify the order of {@code getFieldErrors()}, so picking whichever arrives
+     * last would let two identical requests answer differently. Sorting the messages and keeping the
+     * first makes the choice arbitrary but stable, which is what a wire contract needs: the client
+     * shows one message per input either way, and the same request always produces the same one.
      */
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers,
                                                                   HttpStatusCode status, WebRequest request) {
         Map<String, String> errors = new HashMap<>();
-        for (FieldError fe : ex.getBindingResult().getFieldErrors()) {
-            errors.put(fe.getField(), fe.getDefaultMessage());
-        }
+        ex.getBindingResult().getFieldErrors().stream()
+                .sorted(Comparator.comparing(FieldError::getField)
+                        .thenComparing(fe -> String.valueOf(fe.getDefaultMessage())))
+                .forEach(fe -> errors.putIfAbsent(fe.getField(), fe.getDefaultMessage()));
         ErrorResponse body = body(HttpStatus.BAD_REQUEST.value(), "Validation failed", pathOf(request));
         body.setFieldErrors(errors);
         return respond(ex, HttpStatus.BAD_REQUEST, body, headers, request);

--- a/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaRequest.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaRequest.java
@@ -1,6 +1,7 @@
 package com.healthupgrades.healtharea.adapter.in.web;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 /**
  * Request body for creating or replacing a health area.
@@ -8,7 +9,7 @@ import jakarta.validation.constraints.NotBlank;
  * <p>Used by both {@code POST} and {@code PUT}: an update is a full replacement, so every optional
  * field left out is stored as null rather than kept at its previous value.
  *
- * @param name        display name; required and non-blank
+ * @param name        display name; required, non-blank and no longer than its column
  * @param description free-text note, optional
  * @param priority    ordering hint, optional
  * @param icon        the glyph to draw for the area, usually an emoji; optional. Not an icon-font key
@@ -16,9 +17,18 @@ import jakarta.validation.constraints.NotBlank;
  * @param color       colour token, optional
  */
 public record HealthAreaRequest(
-        @NotBlank String name,
+        @NotBlank @Size(max = NAME_MAX) String name,
         String description,
         Integer priority,
-        String icon,
-        String color
-) {}
+        @Size(max = ICON_MAX) String icon,
+        @Size(max = COLOR_MAX) String color
+) {
+    /** Mirrors {@code health_areas.name VARCHAR(255)}; see BR-16 for why the bound is here. */
+    static final int NAME_MAX = 255;
+
+    /** Mirrors {@code health_areas.icon VARCHAR(100)}. */
+    static final int ICON_MAX = 100;
+
+    /** Mirrors {@code health_areas.color VARCHAR(50)}, the narrowest of the three. */
+    static final int COLOR_MAX = 50;
+}

--- a/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaRequest.java
+++ b/backend/src/main/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaRequest.java
@@ -24,11 +24,11 @@ public record HealthAreaRequest(
         @Size(max = COLOR_MAX) String color
 ) {
     /** Mirrors {@code health_areas.name VARCHAR(255)}; see BR-16 for why the bound is here. */
-    static final int NAME_MAX = 255;
+    public static final int NAME_MAX = 255;
 
     /** Mirrors {@code health_areas.icon VARCHAR(100)}. */
-    static final int ICON_MAX = 100;
+    public static final int ICON_MAX = 100;
 
     /** Mirrors {@code health_areas.color VARCHAR(50)}, the narrowest of the three. */
-    static final int COLOR_MAX = 50;
+    public static final int COLOR_MAX = 50;
 }

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/ProgressRequest.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/ProgressRequest.java
@@ -30,5 +30,5 @@ public record ProgressRequest(
         String note
 ) {
     /** Mirrors {@code progress_entries.unit VARCHAR(100)}; see BR-16 for why the bound is here. */
-    static final int UNIT_MAX = 100;
+    public static final int UNIT_MAX = 100;
 }

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/ProgressRequest.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/ProgressRequest.java
@@ -3,6 +3,7 @@ package com.healthupgrades.tracking.adapter.in.web;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 
@@ -24,7 +25,10 @@ public record ProgressRequest(
         LocalDate date,
         Boolean completed,
         @PositiveOrZero Double numericValue,
-        String unit,
+        @Size(max = UNIT_MAX) String unit,
         @Min(1) @Max(5) Integer rating,
         String note
-) {}
+) {
+    /** Mirrors {@code progress_entries.unit VARCHAR(100)}; see BR-16 for why the bound is here. */
+    static final int UNIT_MAX = 100;
+}

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigRequest.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigRequest.java
@@ -3,6 +3,7 @@ package com.healthupgrades.tracking.adapter.in.web;
 import com.healthupgrades.tracking.domain.model.Frequency;
 import com.healthupgrades.tracking.domain.model.TrackingType;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.UUID;
 
@@ -23,6 +24,9 @@ public record TrackingConfigRequest(
         @NotNull TrackingType trackingType,
         Frequency frequency,
         Double targetNumericValue,
-        String targetUnit,
+        @Size(max = TARGET_UNIT_MAX) String targetUnit,
         Boolean requiredDaily
-) {}
+) {
+    /** Mirrors {@code tracking_configs.target_unit VARCHAR(100)}; see BR-16 for why the bound is here. */
+    static final int TARGET_UNIT_MAX = 100;
+}

--- a/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigRequest.java
+++ b/backend/src/main/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigRequest.java
@@ -28,5 +28,5 @@ public record TrackingConfigRequest(
         Boolean requiredDaily
 ) {
     /** Mirrors {@code tracking_configs.target_unit VARCHAR(100)}; see BR-16 for why the bound is here. */
-    static final int TARGET_UNIT_MAX = 100;
+    public static final int TARGET_UNIT_MAX = 100;
 }

--- a/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeRequest.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeRequest.java
@@ -4,6 +4,7 @@ import com.healthupgrades.upgrade.domain.model.Difficulty;
 import com.healthupgrades.upgrade.domain.model.UpgradeType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 import java.util.UUID;
@@ -16,7 +17,7 @@ import java.util.UUID;
  * belongs to {@code /plan} and {@code /reschedule}.
  *
  * @param areaId           health area to file it under, optional
- * @param title            short name; required and non-blank
+ * @param title            short name; required, non-blank and no longer than its column
  * @param description      longer explanation, optional
  * @param type             what kind of change this is; required
  * @param difficulty       how demanding it is, optional
@@ -27,7 +28,7 @@ import java.util.UUID;
  */
 public record UpgradeRequest(
         UUID areaId,
-        @NotBlank String title,
+        @NotBlank @Size(max = TITLE_MAX) String title,
         String description,
         @NotNull UpgradeType type,
         Difficulty difficulty,
@@ -35,4 +36,7 @@ public record UpgradeRequest(
         LocalDate targetEndDate,
         String motivation,
         String successCriteria
-) {}
+) {
+    /** Mirrors {@code health_upgrades.title VARCHAR(255)}; see BR-16 for why the bound is here. */
+    static final int TITLE_MAX = 255;
+}

--- a/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeRequest.java
+++ b/backend/src/main/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeRequest.java
@@ -37,6 +37,11 @@ public record UpgradeRequest(
         String motivation,
         String successCriteria
 ) {
-    /** Mirrors {@code health_upgrades.title VARCHAR(255)}; see BR-16 for why the bound is here. */
-    static final int TITLE_MAX = 255;
+    /**
+     * Mirrors {@code health_upgrades.title VARCHAR(255)}; see BR-16 for why the bound is here.
+     *
+     * <p>Public because {@code ColumnBoundContractTest} reads it from another package to check it
+     * still agrees with the migration, which is the only thing keeping the two numbers in step.
+     */
+    public static final int TITLE_MAX = 255;
 }

--- a/backend/src/main/resources/db/migration/V6__raise_demo_password_to_the_minimum.sql
+++ b/backend/src/main/resources/db/migration/V6__raise_demo_password_to_the_minimum.sql
@@ -1,0 +1,11 @@
+-- V6: Raise the demo user's password to the minimum the API now enforces.
+-- BR-17 sets the minimum at eight characters, and "demo123" is seven. The account kept working
+-- because a seeded hash never passes through validation, but shipping a credential the system itself
+-- would refuse is the kind of contradiction nobody should have to discover by trying it.
+-- The password is now "demo1234". Applied as an UPDATE rather than by editing V2 or V3, whose Flyway
+-- checksums cover their comments as well as their SQL and must not change on an already-migrated
+-- database.
+UPDATE users
+SET password_hash = '$2a$10$Wcg8FBqRw0X/W6jcdfKFs.SnWasGS/u.lOQmXhHc7Es79fgbw/zWy',
+    updated_at = now()
+WHERE email = 'demo@healthupgrades.com';

--- a/backend/src/test/java/com/healthupgrades/auth/adapter/in/web/AuthControllerTest.java
+++ b/backend/src/test/java/com/healthupgrades/auth/adapter/in/web/AuthControllerTest.java
@@ -92,6 +92,24 @@ class AuthControllerTest {
     }
 
     @Test
+    void GivenAnEmptyPasswordViolatingTwoConstraints_WhenItIsSent_ThenTheSameMessageComesBackEveryTime()
+            throws Exception {
+        // "" fails both @NotBlank and @Size(min = 8), and the field map holds one message per field.
+        // Hibernate Validator does not specify the order of getFieldErrors(), so without the sort in
+        // GlobalExceptionHandler two identical requests could answer differently. Repeated because a
+        // single call cannot tell a stable choice from a lucky one.
+        for (int attempt = 0; attempt < 5; attempt++) {
+            mockMvc.perform(post("/api/auth/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"name\":\"Someone\",\"email\":\"someone@example.com\",\"password\":\"\"}"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.fieldErrors.password").value("must not be blank"));
+        }
+
+        verify(authService, never()).register(any(), any(), any());
+    }
+
+    @Test
     void GivenAPasswordBelowTheMinimum_WhenAVisitorRegisters_ThenItAnswers400AndNobodyIsRegistered()
             throws Exception {
         // The browser has always asked for a minimum and the API never did, so any caller that was not
@@ -113,7 +131,7 @@ class AuthControllerTest {
 
         mockMvc.perform(post("/api/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Someone\",\"email\":\"someone@example.com\",\"password\":\"12345678\"}"))
+                        .content("{\"name\":\"Someone\",\"email\":\"someone@example.com\",\"password\":\"" + "x".repeat(AuthController.PASSWORD_MIN) + "\"}"))
                 .andExpect(status().isCreated());
     }
 
@@ -126,7 +144,7 @@ class AuthControllerTest {
         mockMvc.perform(post("/api/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\":\"Someone\",\"email\":\"someone@example.com\",\"password\":\""
-                                + "p".repeat(73) + "\"}"))
+                                + "p".repeat(AuthController.PASSWORD_MAX + 1) + "\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.fieldErrors.password").exists());
 

--- a/backend/src/test/java/com/healthupgrades/auth/adapter/in/web/AuthControllerTest.java
+++ b/backend/src/test/java/com/healthupgrades/auth/adapter/in/web/AuthControllerTest.java
@@ -62,7 +62,7 @@ class AuthControllerTest {
 
         mockMvc.perform(post("/api/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Someone\",\"email\":\"someone@example.com\",\"password\":\"s3cret!\"}"))
+                        .content("{\"name\":\"Someone\",\"email\":\"someone@example.com\",\"password\":\"s3cret!42\"}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.token").value("issued.jwt.token"))
                 .andExpect(jsonPath("$.user.email").value(AUser.EMAIL))
@@ -75,7 +75,7 @@ class AuthControllerTest {
             throws Exception {
         mockMvc.perform(post("/api/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Someone\",\"email\":\"not-an-email\",\"password\":\"s3cret!\"}"))
+                        .content("{\"name\":\"Someone\",\"email\":\"not-an-email\",\"password\":\"s3cret!42\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.fieldErrors.email").exists());
 
@@ -92,6 +92,48 @@ class AuthControllerTest {
     }
 
     @Test
+    void GivenAPasswordBelowTheMinimum_WhenAVisitorRegisters_ThenItAnswers400AndNobodyIsRegistered()
+            throws Exception {
+        // The browser has always asked for a minimum and the API never did, so any caller that was not
+        // the frontend could register a one-character password. BR-17.
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Someone\",\"email\":\"someone@example.com\",\"password\":\"a\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.password").exists());
+
+        verify(authService, never()).register(any(), any(), any());
+    }
+
+    @Test
+    void GivenAPasswordAtTheMinimum_WhenAVisitorRegisters_ThenItIsAccepted() throws Exception {
+        // The bound is inclusive, so the shortest allowed password must not be refused.
+        when(authService.register(anyString(), anyString(), anyString()))
+                .thenReturn(new AuthResult("issued.jwt.token", aUser()));
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Someone\",\"email\":\"someone@example.com\",\"password\":\"12345678\"}"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void GivenAPasswordLongerThanBcryptHashes_WhenAVisitorRegisters_ThenItIsRefusedRatherThanTruncated()
+            throws Exception {
+        // BCryptPasswordEncoder in Spring Security 6.2 guards only against null: anything past 72 bytes
+        // is silently dropped, so a 100-character password and its first 72 characters would be the
+        // same password and the user would never be told. Refusing the input is the honest answer.
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Someone\",\"email\":\"someone@example.com\",\"password\":\""
+                                + "p".repeat(73) + "\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.password").exists());
+
+        verify(authService, never()).register(any(), any(), any());
+    }
+
+    @Test
     void GivenAnEmailAlreadyRegistered_WhenAVisitorRegisters_ThenItAnswers422() throws Exception {
         // FR-4 reaching the client. The request was well-formed and the rules refuse it, which is a 422
         // rather than a 400 — the form has nothing to correct.
@@ -100,7 +142,7 @@ class AuthControllerTest {
 
         mockMvc.perform(post("/api/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Someone\",\"email\":\"someone@example.com\",\"password\":\"s3cret!\"}"))
+                        .content("{\"name\":\"Someone\",\"email\":\"someone@example.com\",\"password\":\"s3cret!42\"}"))
                 .andExpect(status().isUnprocessableEntity());
     }
 

--- a/backend/src/test/java/com/healthupgrades/contract/ColumnBoundContractTest.java
+++ b/backend/src/test/java/com/healthupgrades/contract/ColumnBoundContractTest.java
@@ -1,0 +1,170 @@
+package com.healthupgrades.contract;
+
+import com.healthupgrades.auth.adapter.in.web.AuthController;
+import com.healthupgrades.healtharea.adapter.in.web.HealthAreaRequest;
+import com.healthupgrades.tracking.adapter.in.web.ProgressRequest;
+import com.healthupgrades.tracking.adapter.in.web.TrackingConfigRequest;
+import com.healthupgrades.upgrade.adapter.in.web.UpgradeRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins every {@code @Size(max = …)} bound on a request DTO against the column it mirrors.
+ *
+ * <p>BR-16 says a field stored in a bounded column is refused at the boundary rather than at the
+ * flush, and the numbers that make that true are copied out of the migrations by hand. Nothing else
+ * connects the two: the entities declare no {@code @Column(length)}, and Hibernate's {@code validate}
+ * checks that a column exists and has a compatible type, not that it has a particular width. So a
+ * migration that narrows a column leaves the DTO bound behind, and the exact 500 BR-16 exists to
+ * prevent comes back — while {@code requirements.md} still claims it cannot.
+ *
+ * <p>This is the same class of gap as {@link FrontendEnumContractTest}: two sides of a contract with
+ * no compiler between them. It is filled the same way, by reading the source of truth directly and
+ * failing the build on a divergence.
+ *
+ * <p>The bound may be <em>equal</em> to the column and nothing else. Wider re-opens the defect;
+ * narrower would silently refuse input the database would have accepted, which is a different defect
+ * and not one to introduce by accident — if a field should be shorter than its column, that is a
+ * product rule and belongs in the requirements with a test of its own.
+ */
+class ColumnBoundContractTest {
+
+    /** Flyway's migration directory, relative to the repository root. */
+    private static final Path MIGRATIONS =
+            Paths.get("src", "main", "resources", "db", "migration");
+
+    /**
+     * Matches a bounded character column in a {@code CREATE TABLE}, e.g. {@code title VARCHAR(255)}.
+     * Deliberately not matched: {@code TEXT}, which has no bound and which BR-16 leaves alone.
+     */
+    private static final Pattern COLUMN =
+            Pattern.compile("^\\s*([a-z_]+)\\s+VARCHAR\\((\\d+)\\)", Pattern.CASE_INSENSITIVE);
+
+    /** Matches the {@code CREATE TABLE users (} that opens a table body. */
+    private static final Pattern CREATE_TABLE =
+            Pattern.compile("CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?([a-z_]+)", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Every bound this codebase declares, against the column it claims to mirror.
+     *
+     * <p>Adding a {@code @Size(max = …)} to a request DTO without adding a row here is the one hole
+     * left, and {@link #GivenEveryBoundedColumn_WhenTheyAreListed_ThenEachOneIsClaimedByADto} is what
+     * closes it from the other direction.
+     */
+    private static Stream<Arguments> declaredBounds() {
+        return Stream.of(
+                Arguments.of("health_upgrades", "title", UpgradeRequest.TITLE_MAX),
+                Arguments.of("health_areas", "name", HealthAreaRequest.NAME_MAX),
+                Arguments.of("health_areas", "icon", HealthAreaRequest.ICON_MAX),
+                Arguments.of("health_areas", "color", HealthAreaRequest.COLOR_MAX),
+                Arguments.of("progress_entries", "unit", ProgressRequest.UNIT_MAX),
+                Arguments.of("tracking_configs", "target_unit", TrackingConfigRequest.TARGET_UNIT_MAX),
+                Arguments.of("users", "name", AuthController.NAME_MAX),
+                Arguments.of("users", "email", AuthController.EMAIL_MAX));
+    }
+
+    /**
+     * Columns a request body never writes to, and why.
+     *
+     * <p>Listed rather than filtered by a rule, so that a new bounded column has to be considered by
+     * somebody: the second test below fails until it appears in one list or the other.
+     */
+    private static final Map<String, String> UNBOUND_BY_DESIGN = Map.ofEntries(
+            Map.entry("users.password_hash", "a BCrypt hash the server writes; never taken from a request"),
+            Map.entry("health_upgrades.type", "an enum, bound by deserialization before validation runs"),
+            Map.entry("health_upgrades.status", "an enum, and moved only by the transition endpoints"),
+            Map.entry("health_upgrades.difficulty", "an enum, bound by deserialization"),
+            Map.entry("tracking_configs.tracking_type", "an enum, bound by deserialization"),
+            Map.entry("tracking_configs.frequency", "an enum, bound by deserialization"),
+            Map.entry("reminders.days_of_week",
+                    "written by ReminderDays, which rejects any token outside the seven valid ones, so the "
+                            + "joined string cannot exceed 27 characters"),
+            Map.entry("notifications.type", "an enum, bound by deserialization"),
+            Map.entry("notifications.category", "an enum, bound by deserialization"),
+            Map.entry("notifications.title", "written by the server from a template, never from a request"),
+            Map.entry("notifications.message", "written by the server from a template, never from a request"));
+
+    @ParameterizedTest(name = "{0}.{1}")
+    @MethodSource("declaredBounds")
+    void GivenABoundDeclaredOnADto_WhenItIsComparedToItsColumn_ThenTheyAgree(
+            String table, String column, int declared) {
+        Integer actual = boundedColumns().get(table + "." + column);
+
+        assertThat(actual)
+                .as("%s.%s is declared as a bound on a request DTO but no migration creates it as a "
+                        + "bounded column", table, column)
+                .isNotNull();
+        assertThat(declared)
+                .as("the DTO bounds %s.%s at %d but the column holds %d — a wider bound re-opens the "
+                        + "500 BR-16 prevents, a narrower one refuses input the database would accept",
+                        table, column, declared, actual)
+                .isEqualTo(actual);
+    }
+
+    @Test
+    void GivenEveryBoundedColumn_WhenTheyAreListed_ThenEachOneIsClaimedByADtoOrExcusedByName() {
+        List<String> claimed = declaredBounds()
+                .map(a -> a.get()[0] + "." + a.get()[1])
+                .toList();
+
+        assertThat(boundedColumns().keySet())
+                .as("a bounded column is either mirrored by a DTO bound (BR-16) or listed as one no "
+                        + "request body writes to — a new one must be considered, not defaulted")
+                .allSatisfy(qualified -> assertThat(claimed.contains(qualified)
+                        || UNBOUND_BY_DESIGN.containsKey(qualified))
+                        .as("%s is neither bounded by a DTO nor excused in UNBOUND_BY_DESIGN", qualified)
+                        .isTrue());
+    }
+
+    /**
+     * Every {@code table.column} created as a {@code VARCHAR(n)}, mapped to that {@code n}.
+     *
+     * <p>Reads the migrations in filename order so a later {@code ALTER} of a width would need to be
+     * handled here too; today none exists, and this test failing is how the next one gets noticed.
+     */
+    private static Map<String, Integer> boundedColumns() {
+        Map<String, Integer> columns = new LinkedHashMap<>();
+        try (Stream<Path> files = Files.list(MIGRATIONS)) {
+            List<Path> ordered = files.filter(p -> p.toString().endsWith(".sql")).sorted().toList();
+            for (Path file : ordered) {
+                String table = null;
+                for (String line : Files.readAllLines(file)) {
+                    Matcher create = CREATE_TABLE.matcher(line);
+                    if (create.find()) {
+                        table = create.group(1).toLowerCase();
+                        continue;
+                    }
+                    if (table == null) continue;
+                    Matcher column = COLUMN.matcher(line);
+                    if (column.find()) {
+                        columns.put(table + "." + column.group(1).toLowerCase(),
+                                Integer.parseInt(column.group(2)));
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("could not read the migrations at " + MIGRATIONS.toAbsolutePath(), e);
+        }
+        assertThat(columns)
+                .as("no bounded columns were parsed out of %s — the migrations moved, or their shape "
+                        + "changed and this test is now reading nothing", MIGRATIONS.toAbsolutePath())
+                .isNotEmpty();
+        return columns;
+    }
+}

--- a/backend/src/test/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaControllerTest.java
+++ b/backend/src/test/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaControllerTest.java
@@ -94,7 +94,7 @@ class HealthAreaControllerTest {
         // over-long name reached the flush in production and came back 500. This slice has no database
         // and cannot see that flush; what it pins is the boundary contract. BR-16.
         mockMvc.perform(bearer(post(BASE)).contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"" + "a".repeat(256) + "\"}"))
+                        .content("{\"name\":\"" + "a".repeat(HealthAreaRequest.NAME_MAX + 1) + "\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.fieldErrors.name").exists());
 
@@ -105,7 +105,7 @@ class HealthAreaControllerTest {
     void GivenAnIconLongerThanItsColumn_WhenAnAreaIsCreated_ThenItAnswers400NamingTheField() throws Exception {
         // health_areas.icon is VARCHAR(100) - a narrower column than the name, and a separate bound.
         mockMvc.perform(bearer(post(BASE)).contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Sleep\",\"icon\":\"" + "i".repeat(101) + "\"}"))
+                        .content("{\"name\":\"Sleep\",\"icon\":\"" + "i".repeat(HealthAreaRequest.ICON_MAX + 1) + "\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.fieldErrors.icon").exists());
 
@@ -116,7 +116,7 @@ class HealthAreaControllerTest {
     void GivenAColourLongerThanItsColumn_WhenAnAreaIsCreated_ThenItAnswers400NamingTheField() throws Exception {
         // health_areas.color is VARCHAR(50), the narrowest of the three.
         mockMvc.perform(bearer(post(BASE)).contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"Sleep\",\"color\":\"" + "c".repeat(51) + "\"}"))
+                        .content("{\"name\":\"Sleep\",\"color\":\"" + "c".repeat(HealthAreaRequest.COLOR_MAX + 1) + "\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.fieldErrors.color").exists());
 

--- a/backend/src/test/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaControllerTest.java
+++ b/backend/src/test/java/com/healthupgrades/healtharea/adapter/in/web/HealthAreaControllerTest.java
@@ -89,6 +89,41 @@ class HealthAreaControllerTest {
     }
 
     @Test
+    void GivenANameLongerThanItsColumn_WhenAnAreaIsCreated_ThenItAnswers400NamingTheField() throws Exception {
+        // health_areas.name is VARCHAR(255), which is where the 255 comes from. Unbounded here, an
+        // over-long name reached the flush in production and came back 500. This slice has no database
+        // and cannot see that flush; what it pins is the boundary contract. BR-16.
+        mockMvc.perform(bearer(post(BASE)).contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"" + "a".repeat(256) + "\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.name").exists());
+
+        verify(service, never()).create(any(), any());
+    }
+
+    @Test
+    void GivenAnIconLongerThanItsColumn_WhenAnAreaIsCreated_ThenItAnswers400NamingTheField() throws Exception {
+        // health_areas.icon is VARCHAR(100) - a narrower column than the name, and a separate bound.
+        mockMvc.perform(bearer(post(BASE)).contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Sleep\",\"icon\":\"" + "i".repeat(101) + "\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.icon").exists());
+
+        verify(service, never()).create(any(), any());
+    }
+
+    @Test
+    void GivenAColourLongerThanItsColumn_WhenAnAreaIsCreated_ThenItAnswers400NamingTheField() throws Exception {
+        // health_areas.color is VARCHAR(50), the narrowest of the three.
+        mockMvc.perform(bearer(post(BASE)).contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Sleep\",\"color\":\"" + "c".repeat(51) + "\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.color").exists());
+
+        verify(service, never()).create(any(), any());
+    }
+
+    @Test
     void GivenTheCallersAreas_WhenTheyAreListed_ThenTheyAnswer200ScopedToThePrincipal() throws Exception {
         when(service.listByUser(userId)).thenReturn(List.of(anArea()));
 

--- a/backend/src/test/java/com/healthupgrades/tracking/adapter/in/web/ProgressControllerTest.java
+++ b/backend/src/test/java/com/healthupgrades/tracking/adapter/in/web/ProgressControllerTest.java
@@ -100,6 +100,19 @@ class ProgressControllerTest {
     }
 
     @Test
+    void GivenAUnitLongerThanItsColumn_WhenProgressIsLogged_ThenItAnswers400NamingTheField() throws Exception {
+        // progress_entries.unit is VARCHAR(100), which is where the 100 comes from. Unbounded here, an
+        // over-long unit reached the flush in production and came back 500. This slice has no database
+        // and cannot see that flush; what it pins is the boundary contract. BR-16.
+        mockMvc.perform(bearer(post(progressPath)).contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"unit\":\"" + "u".repeat(101) + "\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.unit").exists());
+
+        verify(trackingService, never()).recordProgress(any(), any(), any());
+    }
+
+    @Test
     void GivenANegativeNumericValue_WhenProgressIsLogged_ThenItAnswers400() throws Exception {
         mockMvc.perform(bearer(post(progressPath)).contentType(MediaType.APPLICATION_JSON)
                         .content("{\"numericValue\":-1}"))

--- a/backend/src/test/java/com/healthupgrades/tracking/adapter/in/web/ProgressControllerTest.java
+++ b/backend/src/test/java/com/healthupgrades/tracking/adapter/in/web/ProgressControllerTest.java
@@ -105,7 +105,7 @@ class ProgressControllerTest {
         // over-long unit reached the flush in production and came back 500. This slice has no database
         // and cannot see that flush; what it pins is the boundary contract. BR-16.
         mockMvc.perform(bearer(post(progressPath)).contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"unit\":\"" + "u".repeat(101) + "\"}"))
+                        .content("{\"unit\":\"" + "u".repeat(ProgressRequest.UNIT_MAX + 1) + "\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.fieldErrors.unit").exists());
 

--- a/backend/src/test/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigControllerTest.java
+++ b/backend/src/test/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigControllerTest.java
@@ -93,7 +93,7 @@ class TrackingConfigControllerTest {
         // here, an over-long unit reached the flush in production and came back 500. This slice has no
         // database and cannot see that flush; what it pins is the boundary contract. BR-16.
         mockMvc.perform(bearer(put(path)).contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"trackingType\":\"NUMERIC\",\"targetUnit\":\"" + "u".repeat(101) + "\"}"))
+                        .content("{\"trackingType\":\"NUMERIC\",\"targetUnit\":\"" + "u".repeat(TrackingConfigRequest.TARGET_UNIT_MAX + 1) + "\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.fieldErrors.targetUnit").exists());
 

--- a/backend/src/test/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigControllerTest.java
+++ b/backend/src/test/java/com/healthupgrades/tracking/adapter/in/web/TrackingConfigControllerTest.java
@@ -87,6 +87,20 @@ class TrackingConfigControllerTest {
     }
 
     @Test
+    void GivenATargetUnitLongerThanItsColumn_WhenAConfigurationIsSaved_ThenItAnswers400NamingTheField()
+            throws Exception {
+        // tracking_configs.target_unit is VARCHAR(100), which is where the 100 comes from. Unbounded
+        // here, an over-long unit reached the flush in production and came back 500. This slice has no
+        // database and cannot see that flush; what it pins is the boundary contract. BR-16.
+        mockMvc.perform(bearer(put(path)).contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"trackingType\":\"NUMERIC\",\"targetUnit\":\"" + "u".repeat(101) + "\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.targetUnit").exists());
+
+        verify(trackingService, never()).saveConfig(any(), any(), any());
+    }
+
+    @Test
     void GivenATrackingTypeThatIsNotInTheEnum_WhenAConfigurationIsSaved_ThenItAnswers400RatherThan500()
             throws Exception {
         mockMvc.perform(bearer(put(path)).contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeControllerTest.java
+++ b/backend/src/test/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeControllerTest.java
@@ -108,6 +108,33 @@ class UpgradeControllerTest {
     }
 
     @Test
+    void GivenATitleLongerThanItsColumn_WhenAnUpgradeIsCreated_ThenItAnswers400NamingTheField() throws Exception {
+        // health_upgrades.title is VARCHAR(255), which is where the 255 comes from. Unbounded here, an
+        // over-long title reached the flush in production and came back 500 - a server fault reported
+        // for input the caller could have corrected. This slice has no database and cannot see that
+        // flush; what it pins is the boundary contract that makes it unreachable. BR-16.
+        mockMvc.perform(bearer(post(BASE))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"" + "a".repeat(256) + "\",\"type\":\"HABIT\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.title").exists());
+
+        verify(service, never()).create(any(), any());
+    }
+
+    @Test
+    void GivenATitleExactlyAsLongAsItsColumn_WhenAnUpgradeIsCreated_ThenItIsAccepted() throws Exception {
+        // The bound is inclusive: 255 is the longest the column holds, so refusing it would be a bug of
+        // the opposite sign.
+        when(service.create(eq(userId), any())).thenReturn(anUpgrade(UpgradeStatus.IDEA));
+
+        mockMvc.perform(bearer(post(BASE))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"" + "a".repeat(255) + "\",\"type\":\"HABIT\"}"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
     void GivenABodyThatIsNotJson_WhenAnUpgradeIsCreated_ThenItAnswers400RatherThan500() throws Exception {
         // The shape of issue #22: this used to be swallowed as a server fault.
         mockMvc.perform(bearer(post(BASE))

--- a/backend/src/test/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeControllerTest.java
+++ b/backend/src/test/java/com/healthupgrades/upgrade/adapter/in/web/UpgradeControllerTest.java
@@ -115,7 +115,7 @@ class UpgradeControllerTest {
         // flush; what it pins is the boundary contract that makes it unreachable. BR-16.
         mockMvc.perform(bearer(post(BASE))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\":\"" + "a".repeat(256) + "\",\"type\":\"HABIT\"}"))
+                        .content("{\"title\":\"" + "a".repeat(UpgradeRequest.TITLE_MAX + 1) + "\",\"type\":\"HABIT\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.fieldErrors.title").exists());
 
@@ -130,7 +130,7 @@ class UpgradeControllerTest {
 
         mockMvc.perform(bearer(post(BASE))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"title\":\"" + "a".repeat(255) + "\",\"type\":\"HABIT\"}"))
+                        .content("{\"title\":\"" + "a".repeat(UpgradeRequest.TITLE_MAX) + "\",\"type\":\"HABIT\"}"))
                 .andExpect(status().isCreated());
     }
 

--- a/docs/ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md
+++ b/docs/ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md
@@ -1,6 +1,6 @@
 # ADR-005: One page width, and a shell that cannot be pushed wider than the window
 
-- **Status:** Accepted
+- **Status:** Accepted — superseded in part by [ADR-013](ADR-013-trapping-focus-without-a-native-dialog.md)
 - **Date:** 2026-08-20
 - **Scope:** `frontend/` layout, plus one data-only backend migration. No new dependency, no runtime
   behaviour outside the browser.

--- a/docs/ADRs/ADR-013-trapping-focus-without-a-native-dialog.md
+++ b/docs/ADRs/ADR-013-trapping-focus-without-a-native-dialog.md
@@ -1,0 +1,104 @@
+# ADR-013: Trap focus with a portal and `inert`, not with a native `<dialog>`
+
+- **Status:** Accepted
+- **Date:** 2026-08-28
+- **Supersedes in part:** [ADR-005](ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md), whose
+  "the dialog announces itself but does not contain anything" section recorded the gap this closes
+- **Scope:** `frontend/src/components/ui/Modal.tsx` and its tests. No new dependency.
+
+## Context
+
+`Modal` had `role="dialog"` and an accessible name, and deliberately no `aria-modal`. Its own doc
+comment explained why: nothing trapped the keyboard, so Tab walked out behind the scrim, and focus was
+neither moved in on open nor restored on close. Claiming `aria-modal` would have told a screen reader
+that the page behind was inert while focus could still reach it — controls that are focusable but no
+longer announced, which is worse than the plain role. ADR-005 recorded that as an open question and
+named a native `<dialog>` with `showModal()` as the correct answer. §6 of the requirements carried the
+same entry.
+
+Two forces shaped the answer, and neither is about the trap itself.
+
+**The overlay is not a portal.** It is `fixed inset-0` inside the page tree, so "everything behind the
+dialog" is an ancestor's siblings at half a dozen different depths rather than one list of nodes.
+Anything that marks the page behind has either to walk the whole ancestor chain, writing attributes
+into DOM owned by components that know nothing about it, or to move the dialog somewhere the walk is
+one level deep.
+
+**`aria-hidden` and `inert` are not interchangeable in this repo.** `@testing-library/dom` treats an
+`aria-hidden` ancestor as non-existent for role queries, and knows nothing about `inert` — verified in
+its `role-helpers.js`. No test breaks today, because no page test currently opens a modal. The next one
+to do so would find it could not query the page it was standing on.
+
+## Decision
+
+Keep `<div role="dialog">` and build the trap by hand, in three parts.
+
+**Portal the overlay to `document.body`.** "The page behind" becomes exactly "the other children of
+`<body>`", which is a one-level walk. This is the codebase's first portal.
+
+**Mark those children `inert`, refcounted.** `inert` removes them from the accessibility tree and from
+the pointer, not only from the keyboard, and it is invisible to Testing Library's queries. The refcount
+is what makes two open dialogs safe — without it, closing the second releases the page while the first
+is still up. Overlays skip each other by a `data-modal-overlay` attribute set **in the JSX**, not by a
+registry populated from an effect: React inserts both portals during the mutation phase and runs
+neither effect until afterwards, so an effect-time registry loses that race and the first dialog marks
+the second one inert.
+
+**Confine Tab with an `onKeyDown` on the dialog**, not a listener on `document`, so two open dialogs
+cannot fight over the key. `preventDefault` fires at the two boundaries only; in the middle the
+browser's own order is better than a flat `querySelectorAll` list, which gets radio groups wrong.
+
+`aria-modal="true"` is then set, because all three make it true.
+
+## Consequences
+
+**What this makes easy.** The dialog is now honest about what it is, and FR-40 can state the whole
+contract. The portal also removes a latent fragility: `position: fixed` resolves against the viewport
+only while no ancestor has a `transform`, `filter` or `will-change`, which was true by luck rather than
+by design.
+
+**What this makes hard.** Focus restoration depends on the element that opened the dialog still being
+in the document; on the health-areas delete path it is not, and focus falls back to `<body>`. Fixing
+that properly means a `restoreFocusTo` prop, which one call site does not justify. `ToastContainer`
+lives inside `#root`, so a toast raised while a dialog is open goes inert with the rest of the page —
+still painted above it at `z-[60]`, no longer dismissable. That is what `aria-modal` means, and it is
+filed rather than folded in here.
+
+**What cannot be verified.** jsdom implements `inert` not at all, so the tests pin that the attribute
+is set and cleared on the right nodes and stop there. That a browser honours it belongs to the gap §6
+already records for contrast and layout: closing it needs a real browser in CI, which
+[ADR-004](ADR-004-frontend-test-harness.md) deferred. The same harness moves focus on Tab for nobody,
+so every Tab test asserts `defaultPrevented` alongside the resulting `activeElement` — the first
+because a browser would otherwise overwrite our move, the second because without it the test would pass
+against no handler at all.
+
+**Cost paid.** One existing test inverted (`…ThenItDoesNotClaimTheRestOfThePageIsInert`, which pinned
+the omission this record closes) and one query re-anchored, because the backdrop test reached its
+target through RTL's `container` and the portal empties it. Eight of the ten survived untouched.
+
+## Alternatives considered
+
+- **A native `<dialog>` with `showModal()`.** Still the platform's own answer, and still the one with
+  the least code: a real trap, real inertness, the top layer and native Escape. Not taken here for the
+  reason ADR-005 already records — the backdrop moves to `::backdrop` in `index.css`, which sits
+  outside what `check:colours` scans — and for a second: jsdom's `<dialog>` support is partial, so the
+  existing test file would be rewritten rather than extended. *Revisit when* `check:colours` is
+  extended to the stylesheet, at which point this record should be superseded rather than amended.
+- **`aria-hidden` instead of `inert`.** Rejected on the Testing Library consequence above. It is also
+  the weaker guarantee — it hides from assistive technology and leaves the pointer and the keyboard
+  alone. *Revisit:* never; `inert` is Baseline and has been since mid-2022.
+- **No portal; walk the ancestor chain marking siblings at every level.** What the `aria-hidden` npm
+  package does. Rejected: it writes attributes into DOM owned by half a dozen other components at
+  arbitrary depths, and a React re-render replacing any one of those siblings silently drops the mark.
+- **Focus the first control rather than the dialog container.** Rejected: it announces "Close modal,
+  button" instead of the dialog's role and name, which is what the `useId`/`aria-labelledby` work
+  exists to deliver. Focusing the container also makes the no-focusable-child case structurally
+  impossible rather than a branch to defend.
+- **Adding `@testing-library/user-event` for `userEvent.tab()`.** Rejected: it is not installed, and it
+  simulates tab order in JavaScript rather than reproducing a browser's, so it is no closer to the real
+  thing than firing the key. The `defaultPrevented` assertion covers the same contract without a new
+  dependency. *Revisit when* a richer keyboard workflow needs more than boundary assertions.
+- **Filtering the focusable list by visibility.** Rejected: jsdom reports every element as zero-sized,
+  so the filter would return an empty list in every test and leave the trap untestable. It costs
+  nothing today because the call sites conditionally render their optional fields rather than hiding
+  them in CSS.

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -384,11 +384,36 @@ the content, which is why every user-supplied string in the shell also carries `
 already has an automatic minimum size of zero. How wide a page may then grow is decided once, in
 `PageContainer`, and not by the pages. See [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md).
 
+**One dialog is portalled to `<body>`, and it mutates the rest of the document while it is open.**
+`components/ui/Modal` is the only `createPortal` in the SPA. Its overlay is a direct child of
+`<body>` rather than of the page that rendered it, so that "everything behind the dialog" is one list
+of nodes instead of an ancestor's siblings at several depths — and every one of those nodes is given
+`inert` for as long as a dialog is open, which is what makes its `aria-modal="true"` true rather than
+merely asserted. The marking is refcounted in module state inside `Modal.tsx`, so two dialogs open at
+once behave, and the set of nodes is snapshotted on the first open.
+
+Two constraints fall out of that and bind anything added later. **A new `createPortal(...,
+document.body)` has to declare itself**: it either carries `data-modal-overlay`, meaning it belongs
+above a dialog and must not be inerted, or it is mounted before a dialog opens so the walk can see it
+— a portal that appears while a dialog is already open is never marked and stays reachable behind one
+that says nothing behind it is. And **`inert` is the mechanism, never `aria-hidden`**: Testing
+Library's role queries treat an `aria-hidden` ancestor as non-existent, so using it would leave every
+future page test that opens a dialog unable to query the page it is standing on. See
+[ADR-013](../ADRs/ADR-013-trapping-focus-without-a-native-dialog.md).
+
 **The frontend's types are hand-written, not generated.** `src/types/index.ts` mirrors the backend's
 DTOs and enums by hand. The **enums** are checked: `FrontendEnumContractTest` reads that file and fails
 the build if any mirrored union stops matching its backend enum, which is what stops an unbindable
 value reaching the UI. The **DTO shapes** are not checked — a renamed or retyped field still drifts
 silently, and only a type generated from the API contract would close that gap.
+
+**Request DTO bounds are hand-copied from the migrations, and checked the same way.** Every
+`@Size(max = ...)` that mirrors a `VARCHAR(n)` exists because an unbounded field reaches the flush and
+returns 500 rather than 400 (BR-16). Nothing structural connects the two: the entities declare no
+`@Column(length)`, and Hibernate's `validate` checks a column's existence and type, not its width. So
+`ColumnBoundContractTest` reads the migrations directly and fails the build when a bound and its
+column disagree, or when a new bounded column is neither mirrored by a DTO nor listed as one no
+request body writes to.
 
 ### Known constraints
 
@@ -450,7 +475,8 @@ Stated because they are load-bearing, not because they are problems yet:
 | Why logs are JSON in a container but not locally; what each level means; why nothing personal may be logged | [ADR-010](../ADRs/ADR-010-structured-logging-and-a-level-policy.md) |
 | Why the audit trail is a log stream rather than a table or Envers; why refusals are recorded; what is not audited | [ADR-011](../ADRs/ADR-011-audit-as-a-log-stream.md) |
 | Why metrics are a scrape endpoint and not an exporter or a Grafana stack; why the actuator surface is closed by name | [ADR-012](../ADRs/ADR-012-metrics-through-a-prometheus-scrape-endpoint.md) |
-| Why every page shares one width; why the shell can be trusted not to overflow; why container queries and a native `<dialog>` were turned down | [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md) |
+| Why every page shares one width; why the shell can be trusted not to overflow; why container queries were turned down | [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md) |
+| Why the dialog traps focus by hand rather than through a native `<dialog>`; why `inert` and not `aria-hidden`; why the overlay is portalled | [ADR-013](../ADRs/ADR-013-trapping-focus-without-a-native-dialog.md) |
 | Day-to-day conventions when changing backend code | [`backend/CLAUDE.md`](../../backend/CLAUDE.md) |
 | Day-to-day conventions when changing frontend code | [`frontend/CLAUDE.md`](../../frontend/CLAUDE.md) |
 | How to run, test and deploy it | [`README.md`](../../README.md) |

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -2,7 +2,7 @@
 
 What UpHealther must do. This document records the requirements the project **currently meets** —
 each one is implemented, and the **test** that enforces it is named, so a claim here can be checked
-rather than trusted. Eighty of the eighty-seven entries below name a test — sixty-one distinct
+rather than trusted. Eighty-one of the eighty-eight entries below name a test — sixty-one distinct
 test classes and files between them. Four of the remaining seven name the command, workflow or script
 that *is* the check (NFR-11, NFR-12, NFR-13, NFR-18). The last three — FR-39, NFR-19 and NFR-20 — are
 verified by hand and say so, because each is about a rendered width, a colour or an overflow, and jsdom
@@ -133,6 +133,14 @@ nothing is shared between accounts.
 | BR-13 | Reflections are append-only — there is no edit or delete path | `ReflectionServiceTest` (asserted against the public surface), `ReflectionControllerTest` |
 | BR-14 | Concurrent edits to an upgrade are refused rather than silently merged | `UpgradePersistenceIT`, `GlobalExceptionHandlerTest` |
 | BR-15 | A record is visible only to its owner; another user's record is reported as absent, never as forbidden | `UpgradePersistenceIT`, `HealthAreaPersistenceIT`, `ProgressEntryPersistenceIT`, and every `*ControllerTest` |
+| BR-16 | A field stored in a bounded column is refused at the boundary when it exceeds that bound, and the response names the field | `UpgradeControllerTest`, `HealthAreaControllerTest`, `ProgressControllerTest`, `TrackingConfigControllerTest` |
+
+BR-16 exists because the alternative is a 500. Each bound is taken from the column the field lands in
+(`V1__init_schema.sql`), so the two cannot drift apart in the direction that matters: `@Size` counts
+UTF-16 code units where `VARCHAR(n)` counts characters, which makes the boundary *stricter* than the
+column for an astral-plane character such as an emoji, and never looser. Fields stored in `TEXT`
+columns are deliberately unbounded — nothing rejects them downstream, so a ceiling there is a product
+decision rather than a defect, and §6 records it as open.
 
 ---
 
@@ -222,6 +230,16 @@ Undecided, and owned by the repository owner.
   records why that was not done here.
 - **The backend has no dependency vulnerability audit.** OWASP dependency-check needs an `NVD_API_KEY`
   secret; ADR-002 records why a check that cannot fail was judged worse than none.
+- **No ceiling on the free-text fields.** `description`, `motivation`, `successCriteria`, `note`,
+  `whatWorked`, `whatDidNotWork` and `nextAdjustment` are `TEXT`, so BR-16 leaves them alone: nothing
+  downstream rejects them and there is no 500 to prevent. What is left is that a single request can
+  store as much prose as the servlet container will accept. How long a reflection may be is a product
+  decision, not a defect, and nobody has taken it.
+- **Whether `DataIntegrityViolationException` should be mapped at all.** BR-16 removes the known route
+  to it, but it stays unmapped, so any constraint a DTO annotation cannot express still surfaces as a
+  500. Mapping it centrally is not one decision but several — a unique violation, a foreign-key
+  violation and a not-null violation do not deserve the same status, and `DuplicateProgressException`
+  already shadows the first of them.
 - **`UpgradeType.PROTOCOL` is deprecated but retained** for rows that may already carry it. Removing it
   needs confirmation that no stored row uses it.
 - **No governing jurisdiction is named in the licence** — ADR-003 flags this as the first thing to add

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -109,7 +109,7 @@ nothing is shared between accounts.
 | FR-37 | The theme control is reachable before signing in | `LoginPage.test.tsx` |
 | FR-38 | A page's content grows with the browser window, up to one cap chosen for readability | `PageContainer`, `PageContainer.test.tsx` |
 | FR-39 | A dialog fits the window at any size: its heading stays put and only its body scrolls | `Modal` — checked by hand, see §6 |
-| FR-40 | A dialog announces itself as a dialog named by its title | `Modal`, `Modal.test.tsx` |
+| FR-40 | A dialog announces itself as a dialog named by its title, takes focus on open, confines Tab to its own controls, restores focus on close, and marks the page behind it inert | `Modal`, `Modal.test.tsx`, [ADR-013](../ADRs/ADR-013-trapping-focus-without-a-native-dialog.md) |
 | FR-41 | A health area whose stored icon cannot be drawn is shown with the default icon, and editing it does not write the undrawable value back | `areaIconGlyph`, `isIconGlyph`, `areaIcon.test.ts` |
 
 ---
@@ -231,11 +231,14 @@ Undecided, and owned by the repository owner.
   engine. Closing this needs a real browser in CI; [ADR-004](../ADRs/ADR-004-frontend-test-harness.md)
   records why that was deferred. FR-39 and NFR-20 land in exactly this gap: no test in the suite can
   observe a width, a wrap or an overflow, so both were verified by hand and neither is enforced.
-- **A dialog does not trap focus.** Tab walks out of the dialog into the page behind it, and focus is
-  neither moved into the dialog on open nor restored on close. `aria-modal` is deliberately left off
-  until that is true, because claiming it without a trap is worse than not claiming it. Closing this
-  properly means a native `<dialog>` with `showModal()`; [ADR-005](../ADRs/ADR-005-one-page-width-and-a-shell-that-cannot-overflow.md)
-  records why that was not done here.
+- **Nothing verifies that a browser honours the dialog's `inert`.** The focus trap and the inert page
+  behind it are built and tested ([ADR-013](../ADRs/ADR-013-trapping-focus-without-a-native-dialog.md)),
+  but jsdom implements `inert` not at all, so the tests pin that the attribute is set and cleared on
+  the right nodes and nothing further. This is the same gap as the entry above and closes with it.
+  Two smaller residuals go with it: focus falls back to `<body>` when the element that opened a dialog
+  unmounted along with it, which the health-areas delete path does; and a toast raised while a dialog
+  is open goes inert with the rest of the page, so it is painted above the dialog and cannot be
+  dismissed.
 - **The backend has no dependency vulnerability audit.** OWASP dependency-check needs an `NVD_API_KEY`
   secret; ADR-002 records why a check that cannot fail was judged worse than none.
 - **No ceiling on the free-text fields.** `description`, `motivation`, `successCriteria`, `note`,

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -133,7 +133,7 @@ nothing is shared between accounts.
 | BR-13 | Reflections are append-only — there is no edit or delete path | `ReflectionServiceTest` (asserted against the public surface), `ReflectionControllerTest` |
 | BR-14 | Concurrent edits to an upgrade are refused rather than silently merged | `UpgradePersistenceIT`, `GlobalExceptionHandlerTest` |
 | BR-15 | A record is visible only to its owner; another user's record is reported as absent, never as forbidden | `UpgradePersistenceIT`, `HealthAreaPersistenceIT`, `ProgressEntryPersistenceIT`, and every `*ControllerTest` |
-| BR-16 | A field stored in a bounded column is refused at the boundary when it exceeds that bound, and the response names the field | `UpgradeControllerTest`, `HealthAreaControllerTest`, `ProgressControllerTest`, `TrackingConfigControllerTest` |
+| BR-16 | A field stored in a bounded column is refused at the boundary when it exceeds that bound, and the response names the field | `ColumnBoundContractTest` (bound vs. column), `UpgradeControllerTest`, `HealthAreaControllerTest`, `ProgressControllerTest`, `TrackingConfigControllerTest` |
 | BR-17 | A password is at least 8 characters and at most 72, refused by the API rather than only by the browser | `AuthControllerTest` |
 
 BR-16 exists because the alternative is a 500. Each bound is taken from the column the field lands in

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -2,7 +2,7 @@
 
 What UpHealther must do. This document records the requirements the project **currently meets** —
 each one is implemented, and the **test** that enforces it is named, so a claim here can be checked
-rather than trusted. Eighty-one of the eighty-eight entries below name a test — sixty-one distinct
+rather than trusted. Eighty-two of the eighty-nine entries below name a test — sixty-one distinct
 test classes and files between them. Four of the remaining seven name the command, workflow or script
 that *is* the check (NFR-11, NFR-12, NFR-13, NFR-18). The last three — FR-39, NFR-19 and NFR-20 — are
 verified by hand and say so, because each is about a rendered width, a colour or an overflow, and jsdom
@@ -134,6 +134,7 @@ nothing is shared between accounts.
 | BR-14 | Concurrent edits to an upgrade are refused rather than silently merged | `UpgradePersistenceIT`, `GlobalExceptionHandlerTest` |
 | BR-15 | A record is visible only to its owner; another user's record is reported as absent, never as forbidden | `UpgradePersistenceIT`, `HealthAreaPersistenceIT`, `ProgressEntryPersistenceIT`, and every `*ControllerTest` |
 | BR-16 | A field stored in a bounded column is refused at the boundary when it exceeds that bound, and the response names the field | `UpgradeControllerTest`, `HealthAreaControllerTest`, `ProgressControllerTest`, `TrackingConfigControllerTest` |
+| BR-17 | A password is at least 8 characters and at most 72, refused by the API rather than only by the browser | `AuthControllerTest` |
 
 BR-16 exists because the alternative is a 500. Each bound is taken from the column the field lands in
 (`V1__init_schema.sql`), so the two cannot drift apart in the direction that matters: `@Size` counts
@@ -141,6 +142,13 @@ UTF-16 code units where `VARCHAR(n)` counts characters, which makes the boundary
 column for an astral-plane character such as an emoji, and never looser. Fields stored in `TEXT`
 columns are deliberately unbounded — nothing rejects them downstream, so a ceiling there is a product
 decision rather than a defect, and §6 records it as open.
+
+BR-17's upper bound is BCrypt's, not a policy: `BCryptPasswordEncoder` reads 72 bytes and silently
+drops the rest, so a longer password and its own prefix would be the same password and nobody would be
+told. The bound cannot close that gap completely — it counts UTF-16 code units where BCrypt counts
+bytes — but it removes the case anyone will actually hit. The minimum applies at registration, which is
+the only route by which a password reaches the system; the seeded demo account is inserted as a hash by
+Flyway and never passes through it.
 
 ---
 

--- a/frontend/src/api/apiError.test.ts
+++ b/frontend/src/api/apiError.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { AxiosError, AxiosHeaders } from 'axios';
 import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
-import { toApiError } from './apiError';
+import { toApiError, toFormMessage } from './apiError';
 
 /**
  * The one place the backend's error contract is decoded.
@@ -93,5 +93,68 @@ describe('toApiError', () => {
     const error = toApiError(responded(500, { message: 'Internal server error', traceId: '' }));
 
     expect(error.traceId).toBeUndefined();
+  });
+});
+
+/**
+ * What a form actually shows.
+ *
+ * A 400 puts "Validation failed" in `message` and the reason in `fieldErrors`, so a page that renders
+ * `message` tells somebody that something is wrong and nothing about what. That is what happened to
+ * the 400s BR-16 and BR-17 introduced: the API named the field and the interface dropped it.
+ */
+describe('toFormMessage', () => {
+  it('GivenAFailureOnTheFormsMainField_WhenItIsDescribed_ThenThatMessageIsShownAlone', () => {
+    const message = toFormMessage(
+      { status: 400, message: 'Validation failed', fieldErrors: { title: 'size must be between 0 and 255' } },
+      'title',
+    );
+
+    expect(message).toBe('Size must be between 0 and 255');
+  });
+
+  it('GivenFailuresOnFieldsTheFormDidNotName_WhenTheyAreDescribed_ThenEachIsNamedAndOrdered', () => {
+    // Sorted so the same failure always reads the same way, whatever order the map arrived in.
+    const message = toFormMessage({
+      status: 400,
+      message: 'Validation failed',
+      fieldErrors: { password: 'size must be between 8 and 72', name: 'must not be blank' },
+    });
+
+    expect(message).toBe('Name: must not be blank. Password: size must be between 8 and 72.');
+  });
+
+  it('GivenAFieldFailureElsewhere_WhenTheFormsOwnFieldIsUnaffected_ThenTheOtherFieldIsStillNamed', () => {
+    // The primary field is a preference, not a filter: dropping the rest would show an empty error.
+    const message = toFormMessage(
+      { status: 400, message: 'Validation failed', fieldErrors: { icon: 'size must be between 0 and 100' } },
+      'name',
+    );
+
+    expect(message).toBe('Icon: size must be between 0 and 100.');
+  });
+
+  it('GivenAFailureWithNoFieldDetail_WhenItIsDescribed_ThenTheTraceIdIsAppendedForAReport', () => {
+    const message = toFormMessage({ status: 500, message: 'Internal server error', traceId: 'abc123' });
+
+    expect(message).toBe('Internal server error (reference abc123)');
+  });
+
+  it('GivenAFieldFailure_WhenItIsDescribed_ThenNoTraceIdIsAppended', () => {
+    // A trace id helps a bug report and clutters a form: the user can fix this one themselves.
+    const message = toFormMessage({
+      status: 400,
+      message: 'Validation failed',
+      fieldErrors: { title: 'must not be blank' },
+      traceId: 'abc123',
+    }, 'title');
+
+    expect(message).toBe('Must not be blank');
+  });
+
+  it('GivenAFailureWithNeitherFieldsNorATraceId_WhenItIsDescribed_ThenTheMessageStandsAlone', () => {
+    const message = toFormMessage({ message: 'Could not reach the server. Check your connection and try again.' });
+
+    expect(message).toBe('Could not reach the server. Check your connection and try again.');
   });
 });

--- a/frontend/src/api/apiError.ts
+++ b/frontend/src/api/apiError.ts
@@ -20,6 +20,36 @@ export interface ApiError {
   traceId?: string;
 }
 
+/**
+ * The sentence to put in front of a user for a failed call, preferring the specific over the general.
+ *
+ * A validation failure carries its detail in `fieldErrors` and puts only "Validation failed" in
+ * `message`, so rendering `message` alone tells somebody that something is wrong and nothing about
+ * what — which is what every form here did with the 400s the API started returning for an over-long
+ * field or a short password. Field messages come first for that reason, and the trace id is appended
+ * only when there is no field detail, because "reference 7f3a..." helps a bug report and not a form.
+ *
+ * @param error   a decoded failure from {@link toApiError}
+ * @param primary the form's main field, whose message is shown alone when it is the one that failed
+ * @returns a string that is always safe to render
+ */
+export function toFormMessage(error: ApiError, primary?: string): string {
+  const fields = error.fieldErrors;
+  if (fields) {
+    if (primary && fields[primary]) return capitalise(fields[primary]);
+    return Object.entries(fields)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([field, message]) => `${capitalise(field)}: ${message}.`)
+      .join(' ');
+  }
+  return error.traceId ? `${error.message} (reference ${error.traceId})` : error.message;
+}
+
+/** Bean-validation messages arrive lowercase ("size must be between..."), mid-sentence in shape. */
+function capitalise(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
 /** Shown when the request never reached the API, or reached it and produced nothing to quote. */
 const UNREACHABLE = 'Could not reach the server. Check your connection and try again.';
 const UNEXPLAINED = 'Something went wrong.';

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -28,7 +28,15 @@ const renderModal = (onClose = vi.fn(), title = 'New Health Area') =>
     </Modal>,
   );
 
-/** Two modals mounted at once, which is what `HealthAreasPage` does with its create/edit/delete trio. */
+/**
+ * Two dialogs open at once.
+ *
+ * No page here can produce this: `HealthAreasPage` mounts a create/edit/delete trio, but their three
+ * open flags are set one at a time, and a closed `Modal` returns null before its portal so it is not
+ * open in the sense the refcount cares about. `Modal` is a shared primitive that does not control its
+ * call sites, so the state is defended against rather than assumed away — these fixtures exercise the
+ * defence, not a live path.
+ */
 const TwoModals: React.FC = () => (
   <>
     <Modal isOpen onClose={() => {}} title="New Health Area">
@@ -123,7 +131,7 @@ describe('Modal', () => {
       expect(container.getAttribute('inert')).toBe('');
     });
 
-    it('GivenAModalThatHasClosed_WhenItUnmounts_ThenTheContentBehindIsNoLongerInert', () => {
+    it('GivenAnOpenModal_WhenItCloses_ThenTheContentBehindIsNoLongerInert', () => {
       const { container } = render(<Openable />);
 
       fireEvent.keyDown(document, { key: 'Escape' });
@@ -252,6 +260,26 @@ describe('Modal', () => {
 
       expect(event.defaultPrevented).toBe(true);
       expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Save' }));
+    });
+
+    // FOCUSABLE cannot enumerate everything a browser will focus, so the handler has to tell "focus
+    // is on the dialog itself" apart from "focus is on something I do not know about". Both used to
+    // land on an index of -1 and take the Shift+Tab boundary, throwing the user to the last control.
+    it('GivenFocusOnAnElementTheFocusableListDoesNotKnow_WhenShiftTabIsPressed_ThenItIsLeftAlone', () => {
+      render(
+        <Modal isOpen onClose={() => {}} title="New Health Area">
+          <div data-testid="scratch" contentEditable suppressContentEditableWarning />
+        </Modal>,
+      );
+      const scratch = screen.getByTestId('scratch');
+      // Queried, not asserted on: the point is the handler's behaviour when indexOf misses, and this
+      // is simply a reliable way to produce that state in jsdom.
+      scratch.setAttribute('contenteditable', 'false');
+      scratch.focus();
+
+      const event = pressTab(scratch, true);
+
+      expect(event.defaultPrevented).toBe(false);
     });
 
     it('GivenADialogWhoseOnlyControlIsItsCloseButton_WhenTabIsPressed_ThenFocusStaysOnThatButton', () => {

--- a/frontend/src/components/ui/Modal.test.tsx
+++ b/frontend/src/components/ui/Modal.test.tsx
@@ -1,7 +1,25 @@
 import React, { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
 import Modal from './Modal';
+
+/**
+ * Two jsdom limits shape how the focus tests below are written, and both are worth knowing before
+ * changing one.
+ *
+ * jsdom moves focus on Tab for nobody — it implements no tab order at all. So every Tab test fires the
+ * key and asserts two things: that `defaultPrevented` is set, because in a real browser our `.focus()`
+ * would otherwise be overwritten by the browser's own move a moment later; and where focus actually
+ * ended up, because without that the test would pass against no handler whatsoever. Asserting merely
+ * that focus stayed *inside* the dialog would be vacuous for the same reason.
+ *
+ * jsdom also implements `inert` not at all — `'inert' in HTMLElement.prototype` is false. The
+ * inertness tests therefore pin that the attribute is set and cleared on the right nodes, and nothing
+ * more. That a browser honours it is not covered here and cannot be; see ADR-013.
+ *
+ * One smaller trap: `fireEvent.click` does not focus in jsdom, so a trigger has to be `.focus()`ed
+ * explicitly before it is clicked, or there is nothing for the dialog to restore focus to.
+ */
 
 const renderModal = (onClose = vi.fn(), title = 'New Health Area') =>
   render(
@@ -32,6 +50,55 @@ const Openable: React.FC = () => {
   );
 };
 
+/** A body with several controls, so the Tab cycle has a first, a middle and a last to move between. */
+const RichBody: React.FC<{ onClose?: () => void }> = ({ onClose = () => {} }) => (
+  <Modal isOpen onClose={onClose} title="New Health Area">
+    <input aria-label="Name" />
+    <input aria-label="Description" />
+    <button type="submit">Save</button>
+  </Modal>
+);
+
+/** A button that opens the dialog, so focus has somewhere real to be restored to. */
+const WithTrigger: React.FC<{ removeTriggerOnClose?: boolean }> = ({ removeTriggerOnClose = false }) => {
+  const [open, setOpen] = useState(false);
+  const [triggerGone, setTriggerGone] = useState(false);
+  return (
+    <>
+      {!triggerGone && (
+        <button
+          onClick={() => setOpen(true)}
+        >
+          Open
+        </button>
+      )}
+      <Modal
+        isOpen={open}
+        onClose={() => {
+          if (removeTriggerOnClose) setTriggerGone(true);
+          setOpen(false);
+        }}
+        title="New Health Area"
+      >
+        <p>body</p>
+      </Modal>
+    </>
+  );
+};
+
+/** Focuses and clicks, because a jsdom click alone leaves `document.activeElement` on `<body>`. */
+const openVia = (trigger: HTMLElement) => {
+  trigger.focus();
+  fireEvent.click(trigger);
+};
+
+/** Fires a Tab and hands back the event, so the caller can assert on `defaultPrevented`. */
+const pressTab = (on: HTMLElement, shiftKey = false) => {
+  const event = createEvent.keyDown(on, { key: 'Tab', shiftKey });
+  fireEvent(on, event);
+  return event;
+};
+
 describe('Modal', () => {
   describe('announcing itself', () => {
     it('GivenAnOpenModal_WhenItRenders_ThenItIsADialogNamedByItsTitle', () => {
@@ -40,12 +107,38 @@ describe('Modal', () => {
       expect(screen.getByRole('dialog', { name: 'New Health Area' })).toBeDefined();
     });
 
-    // Pins a deliberate omission, not an oversight: nothing here traps focus, so claiming the page
-    // behind is inert would strand a screen-reader user on controls it had removed from their buffer.
-    it('GivenAnOpenModal_WhenItRenders_ThenItDoesNotClaimTheRestOfThePageIsInert', () => {
+    // Replaces a test that pinned the opposite. `aria-modal` was withheld for as long as nothing made
+    // it true; the trap and the inert page behind it are what earned the claim.
+    it('GivenAnOpenModal_WhenItRenders_ThenItClaimsTheRestOfThePageIsInert', () => {
       renderModal();
 
-      expect(screen.getByRole('dialog').getAttribute('aria-modal')).toBeNull();
+      expect(screen.getByRole('dialog').getAttribute('aria-modal')).toBe('true');
+    });
+
+    // Pins the attribute, not the behaviour — jsdom enforces no inertness whatsoever. RTL's own
+    // container is a direct child of <body>, which is exactly what the walk marks.
+    it('GivenAnOpenModal_WhenItRenders_ThenTheContentBehindIsMarkedInert', () => {
+      const { container } = renderModal();
+
+      expect(container.getAttribute('inert')).toBe('');
+    });
+
+    it('GivenAModalThatHasClosed_WhenItUnmounts_ThenTheContentBehindIsNoLongerInert', () => {
+      const { container } = render(<Openable />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(container.getAttribute('inert')).toBeNull();
+    });
+
+    // The overlays skip each other by attribute rather than by a registry built in an effect, because
+    // React inserts both portals before it runs either effect.
+    it('GivenTwoOpenModals_WhenTheyRender_ThenNeitherMarksTheOtherInert', () => {
+      render(<TwoModals />);
+
+      const overlays = document.querySelectorAll('[data-modal-overlay]');
+      expect(overlays.length).toBe(2);
+      overlays.forEach((overlay) => expect(overlay.getAttribute('inert')).toBeNull());
     });
 
     it('GivenAnOpenModal_WhenItRenders_ThenTheCloseControlIsLabelled', () => {
@@ -61,6 +154,115 @@ describe('Modal', () => {
 
       expect(screen.getByRole('dialog', { name: 'New Health Area' })).toBeDefined();
       expect(screen.getByRole('dialog', { name: 'Delete Health Area' })).toBeDefined();
+    });
+  });
+
+  describe('managing focus', () => {
+    it('GivenAModalThatOpens_WhenItRenders_ThenFocusMovesIntoTheDialog', () => {
+      renderModal();
+
+      expect(document.activeElement).toBe(screen.getByRole('dialog'));
+    });
+
+    it('GivenAModalOpenedFromAButton_WhenTheCloseControlIsClicked_ThenFocusReturnsToThatButton', () => {
+      render(<WithTrigger />);
+      const trigger = screen.getByRole('button', { name: 'Open' });
+      openVia(trigger);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    it('GivenAModalOpenedFromAButton_WhenEscapeIsPressed_ThenFocusReturnsToThatButton', () => {
+      render(<WithTrigger />);
+      const trigger = screen.getByRole('button', { name: 'Open' });
+      openVia(trigger);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    it('GivenAModalOpenedFromAButton_WhenTheBackdropIsClicked_ThenFocusReturnsToThatButton', () => {
+      render(<WithTrigger />);
+      const trigger = screen.getByRole('button', { name: 'Open' });
+      openVia(trigger);
+
+      fireEvent.click(document.querySelector('[data-modal-overlay]')!.firstElementChild!);
+
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    // A spy, not a focus assertion: focusing a detached element is a silent no-op in jsdom, so
+    // `activeElement === body` would hold whether or not the isConnected guard were there at all.
+    it('GivenTheTriggerHasBeenRemoved_WhenTheModalCloses_ThenItIsNotAskedToTakeFocusBack', () => {
+      render(<WithTrigger removeTriggerOnClose />);
+      const trigger = screen.getByRole('button', { name: 'Open' });
+      openVia(trigger);
+      const takeFocus = vi.spyOn(trigger, 'focus');
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(takeFocus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('trapping the keyboard', () => {
+    it('GivenFocusOnTheLastControlInADialog_WhenTabIsPressed_ThenFocusWrapsToTheFirst', () => {
+      render(<RichBody />);
+      const submit = screen.getByRole('button', { name: 'Save' });
+      submit.focus();
+
+      const event = pressTab(submit);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Close modal' }));
+    });
+
+    it('GivenFocusOnTheFirstControlInADialog_WhenShiftTabIsPressed_ThenFocusWrapsToTheLast', () => {
+      render(<RichBody />);
+      const close = screen.getByRole('button', { name: 'Close modal' });
+      close.focus();
+
+      const event = pressTab(close, true);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Save' }));
+    });
+
+    // The one that catches a handler eager enough to hijack every Tab rather than only the two edges.
+    it('GivenFocusInTheMiddleOfADialog_WhenTabIsPressed_ThenTheBrowsersOwnOrderIsLeftAlone', () => {
+      render(<RichBody />);
+      const name = screen.getByLabelText('Name');
+      name.focus();
+
+      const event = pressTab(name);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(document.activeElement).toBe(name);
+    });
+
+    // Focus starts on the container, so Shift+Tab from there would otherwise escape backwards.
+    it('GivenFocusOnTheDialogItself_WhenShiftTabIsPressed_ThenFocusWrapsToTheLastControl', () => {
+      render(<RichBody />);
+      const dialog = screen.getByRole('dialog');
+
+      const event = pressTab(dialog, true);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Save' }));
+    });
+
+    it('GivenADialogWhoseOnlyControlIsItsCloseButton_WhenTabIsPressed_ThenFocusStaysOnThatButton', () => {
+      renderModal();
+      const close = screen.getByRole('button', { name: 'Close modal' });
+      close.focus();
+
+      const event = pressTab(close);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(close);
     });
   });
 
@@ -84,11 +286,13 @@ describe('Modal', () => {
     });
 
     // The backdrop is decorative and carries no role, so there is nothing accessible to query it by.
+    // Reached through the overlay's own data attribute rather than through RTL's container, because
+    // the dialog is portalled to <body> and no longer renders inside it.
     it('GivenAnOpenModal_WhenTheBackdropIsClicked_ThenItCloses', () => {
       const onClose = vi.fn();
-      const { container } = renderModal(onClose);
+      renderModal(onClose);
 
-      fireEvent.click(container.firstElementChild!.firstElementChild!);
+      fireEvent.click(document.querySelector('[data-modal-overlay]')!.firstElementChild!);
 
       expect(onClose).toHaveBeenCalledTimes(1);
     });
@@ -116,6 +320,33 @@ describe('Modal', () => {
       fireEvent.keyDown(document, { key: 'Escape' });
 
       expect(screen.queryByRole('dialog')).toBeNull();
+    });
+  });
+
+  describe('several modals', () => {
+    // The refcount test. A naive set-then-unset implementation passes every other test in this file
+    // and fails only this one, because the second modal's close would release the whole page.
+    it('GivenTwoOpenModals_WhenOneCloses_ThenTheContentBehindStaysInert', () => {
+      const Pair: React.FC = () => {
+        const [secondOpen, setSecondOpen] = useState(true);
+        return (
+          <>
+            <Modal isOpen onClose={() => {}} title="New Health Area">
+              <p>create</p>
+            </Modal>
+            <Modal isOpen={secondOpen} onClose={() => setSecondOpen(false)} title="Delete Health Area">
+              <p>confirm</p>
+            </Modal>
+          </>
+        );
+      };
+      const { container } = render(<Pair />);
+      expect(container.getAttribute('inert')).toBe('');
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(screen.queryByRole('dialog', { name: 'Delete Health Area' })).toBeNull();
+      expect(container.getAttribute('inert')).toBe('');
     });
   });
 

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -19,13 +19,23 @@ interface ModalProps {
  * every element a zero-sized box, so one would match nothing in any test and leave the trap untestable.
  * It costs nothing here because the call sites conditionally *render* their optional fields rather
  * than hiding them in CSS.
+ *
+ * This list cannot be complete — `contenteditable`, `summary`, embedded media and shadow roots all
+ * take focus under rules a selector does not capture — which is why `handleKeyDown` treats "focus is
+ * not in this list" as a reason to stand aside rather than as a boundary it has found.
  */
 const FOCUSABLE = [
   'a[href]',
+  'area[href]',
   'button:not([disabled])',
   'input:not([disabled]):not([type="hidden"])',
   'select:not([disabled])',
   'textarea:not([disabled])',
+  'iframe',
+  'audio[controls]',
+  'video[controls]',
+  'summary',
+  '[contenteditable]:not([contenteditable="false"])',
   '[tabindex]:not([tabindex="-1"])',
 ].join(',');
 
@@ -37,6 +47,14 @@ const FOCUSABLE = [
  * which has to be set in the JSX rather than registered from an effect — React inserts both portals
  * during the mutation phase and runs neither effect until afterwards, so an effect-time registry
  * loses that race and the first dialog marks the second one inert.
+ *
+ * **The set is snapshotted once, on the 0 -> 1 transition.** Anything appended to `<body>` while a
+ * dialog is already open is never marked, and stays reachable behind a dialog claiming nothing behind
+ * it is. Nothing does that today — this is the codebase's only portal — so the invariant is stated
+ * rather than enforced: a new `createPortal(..., document.body)` either carries `data-modal-overlay`
+ * because it belongs above a dialog, or it is mounted where this walk can see it. Watching for it
+ * would mean a MutationObserver alive for the lifetime of every dialog, which is a great deal of
+ * machinery for a case the codebase does not have.
  */
 let openModals = 0;
 let inerted: Element[] = [];
@@ -70,6 +88,12 @@ const releaseInert = () => {
  * Closes on Escape as well as on the button and the backdrop; the key listener is bound only while
  * open, so a closed modal costs nothing. Nothing is rendered when closed, which means the body is
  * unmounted and its form state resets between openings.
+ *
+ * Escape is bound to `document` rather than to the dialog, so it closes *every* open dialog rather
+ * than the topmost one. Tab is scoped to the dialog and does not have this problem. The difference
+ * cannot show up in this app, because no page can open two dialogs at once, and it is left that way
+ * on purpose: scoping Escape to the dialog would make it work only while focus was inside, which is
+ * reliably true only because the trap makes it true.
  *
  * **`aria-modal` is claimed here, and three things make the claim true.** The overlay is portalled to
  * `<body>`, so "the page behind" is exactly "the other children of `<body>`" — a one-level walk rather
@@ -119,6 +143,11 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
       // Order matters: a browser refuses to move focus into an inert subtree, so the page has to be
       // released before the trigger can take focus back. Keeping both in one effect makes that
       // explicit — split in two it would rest on declaration order, and jsdom would never show the bug.
+      //
+      // The guarantee is only as good as the release: with another dialog still open, releaseInert is
+      // a no-op and the trigger is still inside an inert subtree, so a browser ignores the focus call
+      // and focus falls to <body>. That needs two dialogs open at once, which no page here can
+      // produce; ADR-013 records it rather than defending against it.
       releaseInert();
       if (previouslyFocused?.isConnected) previouslyFocused.focus();
     };
@@ -129,10 +158,11 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
    * cannot fight over the key — only the one holding focus sees the event.
    *
    * `preventDefault` fires at the two boundaries and nowhere else: in the middle, the browser's own
-   * order beats a flat `querySelectorAll` list, which gets radio groups wrong. When focus is on the
-   * dialog container itself the index is -1, and both branches then do the right thing — Shift+Tab
-   * wraps to the last control instead of escaping backwards, and plain Tab is left alone because the
-   * container precedes its own contents in DOM order.
+   * order beats a flat `querySelectorAll` list, which gets radio groups wrong. Focus on the dialog
+   * container itself is a boundary — Shift+Tab from there would otherwise escape backwards, while
+   * plain Tab is safe to leave alone because the container precedes its own contents in DOM order.
+   * Focus on something the list does not know about is *not* a boundary, and the two are told apart
+   * by identity rather than by both happening to land on an index of -1.
    */
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key !== 'Tab') return;
@@ -148,8 +178,16 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
       return;
     }
 
-    const index = items.indexOf(document.activeElement as HTMLElement);
-    const wrapToLast = e.shiftKey && index <= 0;
+    const active = document.activeElement as HTMLElement | null;
+    const index = items.indexOf(active as HTMLElement);
+    const onDialogItself = active === dialog;
+
+    // Focus is on something FOCUSABLE does not list — see the note there. Standing aside is the safe
+    // reading: the browser moves focus one step, which is right, whereas guessing a boundary would
+    // throw the user to the far end of the dialog for no reason they could see.
+    if (index === -1 && !onDialogItself) return;
+
+    const wrapToLast = e.shiftKey && (onDialogItself || index === 0);
     const wrapToFirst = !e.shiftKey && index === items.length - 1;
     if (!wrapToLast && !wrapToFirst) return;
 

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useId } from 'react';
+import React, { useEffect, useId, useRef } from 'react';
+import { createPortal } from 'react-dom';
 
 /**
  * @param isOpen   whether the dialog is shown; when false the component renders nothing at all
@@ -14,6 +15,47 @@ interface ModalProps {
 }
 
 /**
+ * Everything the browser will move focus to with Tab. Deliberately no visibility filter: jsdom gives
+ * every element a zero-sized box, so one would match nothing in any test and leave the trap untestable.
+ * It costs nothing here because the call sites conditionally *render* their optional fields rather
+ * than hiding them in CSS.
+ */
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+/**
+ * Marks every other child of `<body>` inert while a dialog is open, refcounted across dialogs.
+ *
+ * The count is what makes two open dialogs safe: without it, closing the second would un-inert the
+ * page while the first is still up. Overlays are skipped by their `data-modal-overlay` attribute,
+ * which has to be set in the JSX rather than registered from an effect — React inserts both portals
+ * during the mutation phase and runs neither effect until afterwards, so an effect-time registry
+ * loses that race and the first dialog marks the second one inert.
+ */
+let openModals = 0;
+let inerted: Element[] = [];
+
+const acquireInert = () => {
+  if (++openModals > 1) return;
+  inerted = Array.from(document.body.children).filter(
+    (el) => !el.hasAttribute('data-modal-overlay') && !el.hasAttribute('inert'),
+  );
+  inerted.forEach((el) => el.setAttribute('inert', ''));
+};
+
+const releaseInert = () => {
+  if (--openModals > 0) return;
+  inerted.forEach((el) => el.removeAttribute('inert'));
+  inerted = [];
+};
+
+/**
  * Centred dialog over a dimmed backdrop, bounded by the viewport at any window size.
  *
  * The overlay's padding is what guarantees the gutter, and `max-h-full` resolves against that padded
@@ -26,20 +68,33 @@ interface ModalProps {
  * engage.
  *
  * Closes on Escape as well as on the button and the backdrop; the key listener is bound only while
- * open, so a closed modal costs nothing and several on one page cannot fight over the key. Nothing is
- * rendered when closed, which means the body is unmounted and its form state resets between openings.
+ * open, so a closed modal costs nothing. Nothing is rendered when closed, which means the body is
+ * unmounted and its form state resets between openings.
  *
- * Deliberately no `aria-modal`. It would tell assistive technology that everything outside the dialog
- * is inert, and nothing here makes that true: no focus trap, so Tab walks straight out into the page
- * behind, and focus is neither moved in on open nor restored on close. Claiming it would leave a
- * screen-reader user tabbing to controls the dialog has removed from their buffer — worse than the
- * plain `dialog` role, which at least announces this panel honestly. Closing the gap properly means a
- * native `<dialog>` with `showModal()`; see `docs/requirements/requirements.md` §6.
+ * **`aria-modal` is claimed here, and three things make the claim true.** The overlay is portalled to
+ * `<body>`, so "the page behind" is exactly "the other children of `<body>`" — a one-level walk rather
+ * than an ancestor's siblings at half a dozen different depths. Those children are marked `inert`,
+ * which takes them out of the accessibility tree and out of reach of the pointer, not only the
+ * keyboard. And Tab is confined: focus moves into the dialog on open, returns to whatever opened it on
+ * close, and wraps at both ends.
+ *
+ * `inert` rather than `aria-hidden` is deliberate. Testing Library's role queries treat an
+ * `aria-hidden` ancestor as non-existent and know nothing about `inert`, so `aria-hidden` would leave
+ * the next page test that opens a dialog unable to query the page it is standing on. `inert` is also
+ * the stronger of the two in a browser. See ADR-013.
+ *
+ * **What this does not cover.** jsdom implements `inert` not at all, so the tests can pin that the
+ * attribute is set and cleared on the right nodes and nothing more; that a browser then honours it
+ * falls in the same gap §6 of the requirements records for contrast and layout. Focus falls back to
+ * `<body>` when the element that opened the dialog unmounted along with it, which the health-areas
+ * delete path does. And `ToastContainer` lives inside `#root`, so a toast raised while a dialog is
+ * open goes inert with the rest of the page — still painted, no longer dismissable.
  */
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
   // Three modals can share one page, so the title's id has to be unique per instance — a hard-coded
   // one would make every dialog resolve the same accessible name.
   const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -49,15 +104,75 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
     return () => document.removeEventListener('keydown', handler);
   }, [isOpen, onClose]);
 
+  // Keyed on `isOpen` alone, deliberately. Adding `onClose` or `children` would re-run this on every
+  // parent render and drag focus back to the dialog out from under whatever the user had tabbed to.
+  // The trigger is captured inside the effect body rather than in a ref so that under StrictMode's
+  // double-invoke the cleanup has already restored it before the second pass captures again.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    acquireInert();
+    dialogRef.current?.focus();
+
+    return () => {
+      // Order matters: a browser refuses to move focus into an inert subtree, so the page has to be
+      // released before the trigger can take focus back. Keeping both in one effect makes that
+      // explicit — split in two it would rest on declaration order, and jsdom would never show the bug.
+      releaseInert();
+      if (previouslyFocused?.isConnected) previouslyFocused.focus();
+    };
+  }, [isOpen]);
+
+  /**
+   * Confines Tab to the dialog. Bound to the dialog rather than to `document` so two open dialogs
+   * cannot fight over the key — only the one holding focus sees the event.
+   *
+   * `preventDefault` fires at the two boundaries and nowhere else: in the middle, the browser's own
+   * order beats a flat `querySelectorAll` list, which gets radio groups wrong. When focus is on the
+   * dialog container itself the index is -1, and both branches then do the right thing — Shift+Tab
+   * wraps to the last control instead of escaping backwards, and plain Tab is left alone because the
+   * container precedes its own contents in DOM order.
+   */
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'Tab') return;
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const items = Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE));
+    if (items.length === 0) {
+      // Unreachable through this component's own markup — the close button is always rendered and
+      // never disabled — but focus still has to land somewhere if a future body removes it.
+      e.preventDefault();
+      dialog.focus();
+      return;
+    }
+
+    const index = items.indexOf(document.activeElement as HTMLElement);
+    const wrapToLast = e.shiftKey && index <= 0;
+    const wrapToFirst = !e.shiftKey && index === items.length - 1;
+    if (!wrapToLast && !wrapToFirst) return;
+
+    e.preventDefault();
+    (wrapToLast ? items[items.length - 1] : items[0]).focus();
+  };
+
   if (!isOpen) return null;
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
+  return createPortal(
+    <div
+      data-modal-overlay=""
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6"
+    >
       <div className="absolute inset-0 bg-overlay/50" onClick={onClose} />
       <div
+        ref={dialogRef}
         role="dialog"
+        aria-modal="true"
         aria-labelledby={titleId}
-        className="relative z-10 flex max-h-full w-full min-w-0 max-w-lg flex-col overflow-hidden rounded-xl bg-surface border border-line-strong shadow-xl"
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        className="relative z-10 flex max-h-full w-full min-w-0 max-w-lg flex-col overflow-hidden rounded-xl bg-surface border border-line-strong shadow-xl focus:outline-none"
       >
         <div className="flex shrink-0 items-center justify-between gap-4 px-6 py-4 border-b border-line">
           <h2 id={titleId} className="min-w-0 truncate text-lg font-semibold text-fg-muted">
@@ -73,7 +188,8 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
         </div>
         <div className="min-h-0 overflow-y-auto overscroll-contain px-6 py-4">{children}</div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 };
 

--- a/frontend/src/pages/HealthAreasPage.tsx
+++ b/frontend/src/pages/HealthAreasPage.tsx
@@ -12,7 +12,7 @@ import type { CreateHealthAreaRequest, HealthArea } from '../types';
 import PageContainer from '../components/ui/PageContainer';
 import { areaIconGlyph, DEFAULT_AREA_ICON, isIconGlyph } from '../components/ui/areaIcon';
 import ErrorState from '../components/ui/ErrorState';
-import { toApiError } from '../api/apiError';
+import { toApiError, toFormMessage } from '../api/apiError';
 
 /**
  * Manages health areas — the folders upgrades are filed under.
@@ -53,13 +53,24 @@ const HealthAreasPage: React.FC = () => {
     e.preventDefault();
     setFormError('');
     if (!form.name.trim()) { setFormError('Name is required.'); return; }
-    await createMutation.mutateAsync(form);
+    try {
+      await createMutation.mutateAsync(form);
+    } catch (thrown) {
+      // The name, icon and colour are each bounded by their column (BR-16), and the API names whichever
+      // failed. Before this the rejection was unhandled and the dialog gave no sign of it.
+      setFormError(toFormMessage(toApiError(thrown), 'name'));
+    }
   };
 
   const handleUpdate = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!editArea) return;
-    await updateMutation.mutateAsync({ id: editArea.id, req: form });
+    setFormError('');
+    try {
+      await updateMutation.mutateAsync({ id: editArea.id, req: form });
+    } catch (thrown) {
+      setFormError(toFormMessage(toApiError(thrown), 'name'));
+    }
   };
 
   /**

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../hooks/useAuth';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import ThemeToggle from '../components/theme/ThemeToggle';
-import { toApiError } from '../api/apiError';
+import { toApiError, toFormMessage } from '../api/apiError';
 
 /**
  * Must match `AuthController.PASSWORD_MIN`. Nothing keeps the two in step automatically — a contract
@@ -55,8 +55,10 @@ const RegisterPage: React.FC = () => {
       // network outage - which sent people looking for an account they had never created. The API
       // says what went wrong; the trace id is appended so a report about the ones it cannot explain
       // is worth acting on.
-      const failure = toApiError(thrown);
-      setError(failure.traceId ? `${failure.message} (reference ${failure.traceId})` : failure.message);
+      // toFormMessage prefers the field detail: a 400 puts only "Validation failed" in `message` and
+      // the reason in `fieldErrors`, so rendering `message` left somebody who pasted a passphrase past
+      // BCrypt's 72-byte limit with nothing to act on.
+      setError(toFormMessage(toApiError(thrown)));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -7,11 +7,19 @@ import ThemeToggle from '../components/theme/ThemeToggle';
 import { toApiError } from '../api/apiError';
 
 /**
+ * Must match `AuthController.PASSWORD_MIN`. Nothing keeps the two in step automatically — a contract
+ * test in the shape of `FrontendEnumContractTest` would, and is more machinery than one integer earns.
+ * The server is the enforcer; this only decides when the message appears without a round trip.
+ */
+const PASSWORD_MIN_LENGTH = 8;
+
+/**
  * Account creation page, and the other route reachable without a session.
  *
  * The password rules checked here — matching confirmation, minimum length — are for immediate feedback
- * only; the API is the authority on whether a registration is accepted. A duplicate email is reported
- * as a possibility rather than a fact, so this page does not become a way to test which emails exist.
+ * only; the API is the authority on whether a registration is accepted, and since #54 it genuinely
+ * enforces the minimum rather than trusting this page to. A duplicate email is reported as a
+ * possibility rather than a fact, so this page does not become a way to test which emails exist.
  *
  * Signs the new account straight in, since registration returns a token.
  */
@@ -34,7 +42,10 @@ const RegisterPage: React.FC = () => {
     setError('');
     if (!name || !email || !password) { setError('Please fill in all fields.'); return; }
     if (password !== confirm) { setError('Passwords do not match.'); return; }
-    if (password.length < 6) { setError('Password must be at least 6 characters.'); return; }
+    if (password.length < PASSWORD_MIN_LENGTH) {
+      setError(`Password must be at least ${PASSWORD_MIN_LENGTH} characters.`);
+      return;
+    }
     setLoading(true);
     try {
       await register(name, email, password);

--- a/frontend/src/pages/UpgradeBacklogPage.tsx
+++ b/frontend/src/pages/UpgradeBacklogPage.tsx
@@ -13,7 +13,7 @@ import UpgradeCard from '../components/upgrade/UpgradeCard';
 import type { CreateUpgradeRequest, UpgradeType, Difficulty, UpgradeStatus } from '../types';
 import PageContainer from '../components/ui/PageContainer';
 import ErrorState from '../components/ui/ErrorState';
-import { toApiError } from '../api/apiError';
+import { toApiError, toFormMessage } from '../api/apiError';
 
 /**
  * The upgrade types offered when creating one: the eight kinds the product defines.
@@ -69,7 +69,13 @@ const UpgradeBacklogPage: React.FC = () => {
     e.preventDefault();
     setFormError('');
     if (!form.title.trim()) { setFormError('Title is required.'); return; }
-    await createMutation.mutateAsync(form);
+    try {
+      await createMutation.mutateAsync(form);
+    } catch (thrown) {
+      // Without this the rejection was unhandled and the modal simply sat there: the API refuses an
+      // over-long title with a 400 naming the field (BR-16), and none of it reached the form.
+      setFormError(toFormMessage(toApiError(thrown), 'title'));
+    }
   };
 
   const handleStatusChange = (id: string, status: UpgradeStatus) => {


### PR DESCRIPTION
Promotes the five commits merged into `dev` today (#72). Closes #53, #54 and #60.

## The problem

Three defects sharing a shape — a rule the system appeared to have and did not — plus what the review
of the fix turned up.

- **#53** an over-long title passed validation and failed at the flush, answering **500** for input the
  caller could have corrected. That contradicts NFR-7.
- **#54** `POST /api/auth/register` with `"password": "a"` created the account. Only the browser asked
  for a minimum, and the browser runs on the caller's machine.
- **#60** `Modal` declined `aria-modal` because nothing made it true — no focus trap, focus neither
  moved in on open nor restored on close.

## The approach

Bounds are taken from the columns in `V1__init_schema.sql`, not chosen. The password's upper bound is
BCrypt's own 72 bytes, verified in the resolved `spring-security-crypto-6.2.4` bytecode: the encoder
guards only against null, so anything longer is silently truncated and a password becomes
indistinguishable from its own prefix. `aria-modal` needed a portal and `inert` on the page behind,
not only a Tab handler — and `inert` rather than `aria-hidden` because Testing Library's role queries
treat an `aria-hidden` ancestor as non-existent, which would blind the next page test that opens a
dialog. Recorded in **ADR-013**.

The review then found that the API's new 400s were being discarded by every modal form, which made the
first commit's justification false; and that nine hand-copied column bounds had nothing enforcing
agreement, which made BR-16 a promise rather than a guard. Both are now fixed, the second with
`ColumnBoundContractTest`.

## The trade-offs accepted

- `TEXT`-backed fields stay unbounded, and `DataIntegrityViolationException` stays unmapped — both are
  decisions rather than defects, and §6 records them.
- Login is deliberately unbounded: a wrong-length password there is already a 401, and bounding it
  would leak the rule to an unauthenticated caller.
- The dialog's inertness cannot be verified here — jsdom implements `inert` not at all — so the tests
  pin the attribute, not the browser's honouring of it. §6 keeps a narrower entry for that, plus focus
  falling back to `<body>` when the trigger unmounts with the dialog, and toasts going inert with the
  page (#74).
- The demo password moves to `demo1234`; seven characters would no longer meet the rule the API
  enforces. `V6` does it as an `UPDATE`, because Flyway checksums a migration whole and editing even
  the comments in `V2`/`V3` would break validation on a migrated database.
- `UpgradeDetailsPage`'s four forms still have no error state at all — a wider change, filed as #76.

## What was done

Requirements gain **BR-16** and **BR-17**; **FR-40** grows to what the dialog can now honestly claim;
architecture.md gains the portal and the body-level `inert` invariant. Five commits, one per concern.

## How it was verified

`mvn verify` 485 unit + 39 integration green; `npm run test` 147 green; lint, `check:colours`, build
and the diagram drift check clean; CI green on #72. Every new test was seen to fail first, and the
five subtle branches — the inert refcount, the overlay skip, `preventDefault`, the `isConnected`
guard and the column-bound contract — were each mutation-checked and fail exactly their own test.
End to end against `docker-compose`: `demo1234` logs in and `demo123` no longer does; a 256-character
title and a one-character password each answer 400 naming the field.

Also filed while verifying: #73 (Spring Boot 3.2 is past extended EOL, blocking #59), #74, #75, #76.
