### PR TITLE
docs(readme): add an emoji heading system and repoint moved anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,16 @@ flowchart LR
     core -->|"JDBC"| db
 ```
 
-**Contents** · [What and why](#what-and-why) · [Features](#features) ·
-[Architecture](#architecture) · [Tech stack](#tech-stack) · [Quick start](#quick-start) ·
-[Configuration](#configuration) · [Usage](#usage) · [Development](#development) ·
-[Testing](#testing) · [Operations](#operations) · [Project structure](#project-structure) ·
-[Design decisions](#design-decisions) · [Status and limitations](#status-and-limitations) ·
-[Licence](#licence)
+**Contents** · [🎯 What and why](#-what-and-why) · [✨ Features](#-features) ·
+[🧱 Architecture](#-architecture) · [🧰 Tech stack](#-tech-stack) · [🚀 Quick start](#-quick-start) ·
+[🔩 Configuration](#-configuration) · [📖 Usage](#-usage) · [💻 Development](#-development) ·
+[🧪 Testing](#-testing) · [📡 Operations](#-operations) ·
+[📁 Project structure](#-project-structure) · [🧭 Design decisions](#-design-decisions) ·
+[🚦 Status and limitations](#-status-and-limitations) · [📜 Licence](#-licence)
 
 ---
 
-## What and why
+## 🎯 What and why
 
 People who decide to change a health habit rarely fail at the decision — they fail at knowing
 whether the change survived contact with a normal week. UpHealther models each intended change as
@@ -68,7 +68,7 @@ and every one of those moves is a guarded transition rather than an editable sta
 > treatment, and no feature may imply otherwise
 > ([non-goal 5.1](docs/requirements/requirements.md#5-non-goals)).
 
-## Features
+## ✨ Features
 
 - Create an upgrade — habit, one-off action, experiment, goal, routine or product replacement — and
   file it under a health area you define
@@ -84,7 +84,7 @@ and every one of those moves is a guarded transition rather than an editable sta
   client still sees them
 - Switch between light and dark themes, applied before the first paint — no wrong-theme flash
 
-## Architecture
+## 🧱 Architecture
 
 Three processes and a browser, shown above. No message broker, no cache, no third-party service:
 every piece of state is in the one database, and every side effect is either a write to it or a
@@ -118,7 +118,7 @@ Spring Data is confined to the persistence adapters.
 Seven diagrams, outside in: [arch-diagrams](docs/architecture/arch-diagrams/README.md). The prose:
 [architecture.md](docs/architecture/architecture.md). The why: [ADRs](docs/ADRs/).
 
-## Tech stack
+## 🧰 Tech stack
 
 | Layer | Technology | Version | Why |
 |:---|:---|---:|:---|
@@ -135,7 +135,7 @@ Seven diagrams, outside in: [arch-diagrams](docs/architecture/arch-diagrams/READ
 | Real-time | STOMP over WebSocket | 7.3.0 | Push reuses the JWT via a channel interceptor rather than a second auth scheme |
 | Tests | JUnit 5, ArchUnit, Testcontainers / Vitest | 1.3.0 / 1.21.4 / 3.2.7 | Real PostgreSQL in the integration suite; architecture rules as ordinary tests |
 
-## Quick start
+## 🚀 Quick start
 
 **Prerequisites:** Docker 24+ with Compose v2. Nothing else — the toolchain runs in containers.
 
@@ -161,7 +161,7 @@ a working default, so no `.env` is needed to start — copy `.env.example` to `.
 
 </details>
 
-## Configuration
+## 🔩 Configuration
 
 Mirrors [`.env.example`](.env.example). The defaults are for local development only; `JWT_SECRET` is
 a published value and gives no security.
@@ -185,7 +185,7 @@ Three more live only in `application.yml` — `UPGRADE_OVERDUE_CRON` (`0 0 8 * *
 absent from `.env.example`, and `docker-compose.yml` does not pass them through, so they take
 effect on a native run only.
 
-## Usage
+## 📖 Usage
 
 `POST /api/auth/login` with the demo credentials returns `200` and
 `{ "token": …, "user": { "id", "name", "email", "createdAt" } }`. Export that token as `$TOKEN`;
@@ -225,7 +225,7 @@ curl -sX POST "http://localhost:8080/api/upgrades/0f2c8f5a.../complete" \
 The rest of the surface — every endpoint, the full status contract, and the error body — is in
 [**docs/api.md**](docs/api.md).
 
-## Development
+## 💻 Development
 
 Running natively needs **JDK 21**, **Maven 3.8+**, **Node 20+**, and a PostgreSQL 15 on `:5432`.
 
@@ -255,7 +255,7 @@ mismatch, so an entity change needs a new migration rather than a `ddl-auto` cha
 `frontend/src/api` and the page. `HexagonalArchitectureTest` fails the build on any arrow that runs
 the wrong way.
 
-## Testing
+## 🧪 Testing
 
 | Level | Covers | Command |
 |---|---|---|
@@ -288,7 +288,7 @@ provisioning first and CI runs the same `verify`
 build. The gate is [`requirements.md`](docs/requirements/requirements.md), where every requirement
 names the test enforcing it ([ADR-009](docs/ADRs/ADR-009-test-levels-boundaries-and-naming.md)).
 
-## Operations
+## 📡 Operations
 
 > [!NOTE]
 > **Nothing is deployed.** This runs locally under Compose and has never run in a hosted
@@ -309,7 +309,7 @@ Migrations run at application start, so a bad one leaves the container un-ready 
 corrupting the schema. To chase a reported failure:
 `docker logs healthupgrades-backend | grep <trace id>`.
 
-## Project structure
+## 📁 Project structure
 
 ```
 backend/           Spring Boot API — nine bounded contexts, hexagonal, ArchUnit-enforced
@@ -326,7 +326,7 @@ docs/              The documentation the repository baseline requires
 .github/workflows/ CI: backend verify, diagram drift, frontend lint/test/audit/build
 ```
 
-## Design decisions
+## 🧭 Design decisions
 
 **DDD + hexagonal, boundaries enforced by tests** ([ADR-001](docs/ADRs/ADR-001-ddd-hexagonal-architecture.md),
 corrected by [ADR-002](docs/ADRs/ADR-002-close-the-gap-between-the-described-and-enforced-architecture.md))
@@ -357,7 +357,7 @@ with attribution buried in a notices file. AGPL grants more than intended and is
 many organisations. **Cost:** nobody may use or run the code without written permission, which rules
 out outside contribution.
 
-## Status and limitations
+## 🚦 Status and limitations
 
 **Feature-complete and unshipped.** Every capability above works and is covered — 465 unit and
 structural tests, 39 integration tests, 126 frontend tests, all green — but it has never run in a
@@ -383,14 +383,14 @@ Planned, and deliberately absent from every section above: push notifications, p
 internationalisation, wearable integration. Sharing, accountability partners and a public API are
 **non-goals** rather than backlog ([§5](docs/requirements/requirements.md#5-non-goals)).
 
-## Contributing
+## 🤝 Contributing
 
 Outside contribution is not possible under the licence below — the code may be read, not modified.
 Corrections and questions are welcome as [issues](https://github.com/NaimElijah/UpHealther/issues).
 
 ---
 
-## Licence
+## 📜 Licence
 
 > [!IMPORTANT]
 > UpHealther is **source-available, not open source**. Reading, reviewing and evaluating it is the
@@ -403,7 +403,7 @@ training a model on it — needs written permission, via
 
 [`LICENSE`](LICENSE) carries the terms that govern. Third-party dependencies remain under their own.
 
-## Acknowledgements
+## 🙏 Acknowledgements
 
 The ADR format is Michael Nygard's; the ports-and-adapters shape is Alistair Cockburn's, and the
 context boundaries Eric Evans' *Domain-Driven Design*.

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,7 +3,7 @@
 Every endpoint below `/api` except `POST /api/auth/register` and `POST /api/auth/login` requires a
 bearer token: `Authorization: Bearer <token>`. Tokens last 24 hours and are not refreshable.
 
-Worked request and response bodies are in the [README's Usage section](../README.md#usage). This page
+Worked request and response bodies are in the [README's Usage section](../README.md#-usage). This page
 is the surface; [`requirements.md`](requirements/requirements.md) says what each capability must do,
 and the `*ControllerTest` named against each area pins the status codes.
 


### PR DESCRIPTION
## Problem

The README's sixteen level-2 headings scanned as an undifferentiated grey column. Nothing gave the eye a rail to run down during the five-second scan that decides whether there is a five-minute read.

## Approach

An emoji on every level-2 heading, and only there. All sixteen or none — a partial set reads as unfinished rather than as emphasis, and the ones that have an emoji are not more important, they are just the ones written on a different day. The same emoji are mirrored into the **Contents** row so the table of contents and the heading rail read as one system instead of two.

No new visual device was added. The page already runs badges, a Mermaid diagram, tables, GitHub alerts, `<details>` and rules — six device types against a practical ceiling of about four. Piling on a seventh would have made it read as busier, not more designed.

## The anchor problem this creates

An emoji in a heading changes the generated anchor: `## Usage` → `#usage` becomes `#-usage`. Left alone that silently breaks the whole Contents row plus `docs/api.md`, which links to `../README.md#usage`. Both are repointed in this commit — the `docs/api.md` edit belongs here rather than in its own commit, because it is not an independent change, it is the link the rename would otherwise break.

Emoji carrying a variation selector (U+FE0F) are worse: that codepoint is **not** stripped by the slugger, so `## 🏗️ Architecture` yields an anchor with an invisible character wedged in front of it — one nobody could type correctly. The first pass used five such emoji (🏗️ ⚙️ 🛠️ 🗂️ ⚖️); every one was swapped for a single-codepoint emoji.

## Trade-off accepted

Emoji headings pull the page a step toward friendly and a step away from severe, and this README's register is deliberately restrained and evidence-heavy. For a lifestyle-tracker project that is a fair trade; for an infrastructure or enterprise-facing audience it would not be, and the decision would be worth revisiting if the audience changes.

Anchors are also now one character less obvious to hand-write. Nothing outside this repository links to them.

## What was done

- An emoji on each of the sixteen `##` headings
- The Contents row: emoji mirrored, every anchor repointed, block rewrapped to the file's ~95–100 character source wrap
- `docs/api.md`: `../README.md#usage` → `../README.md#-usage`

23 insertions, 23 deletions. No prose changed; no claim in the README was added, removed or altered.

## How it was verified

- Ran all sixteen headings through `github-slugger`, the library GitHub uses to generate anchors. Every resulting anchor is plain ASCII, checked codepoint by codepoint.
- Cross-checked every internal `](#…)` link in the README against the set of heading anchors: zero dangling links.
- Confirmed zero U+FE0F remain anywhere in the file.
- CI has no markdown or link-checking step, so there was nothing further to run locally.
